### PR TITLE
Add missing entry points

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = """
 Modular math implemented with traits.

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -32,15 +32,34 @@ mod montgomery;
 pub use add::{basic_mod_add, constrained_mod_add, strict_mod_add};
 pub use exp::{basic_mod_exp, constrained_mod_exp, strict_mod_exp};
 pub use inv::{basic_mod_inv, constrained_mod_inv, strict_mod_inv};
+#[rustfmt::skip]
 pub use montgomery::{
-    NPrimeMethod, basic_compute_montgomery_params, basic_compute_montgomery_params_with_method,
-    basic_from_montgomery, basic_montgomery_mod_exp, basic_montgomery_mod_mul,
-    basic_montgomery_mul, basic_to_montgomery, constrained_compute_montgomery_params,
-    constrained_compute_montgomery_params_with_method, constrained_from_montgomery,
-    constrained_montgomery_mod_exp, constrained_montgomery_mod_mul, constrained_montgomery_mul,
-    constrained_to_montgomery, strict_compute_montgomery_params,
-    strict_compute_montgomery_params_with_method, strict_from_montgomery,
-    strict_montgomery_mod_exp, strict_montgomery_mod_exp_with_method, strict_montgomery_mod_mul,
+    NPrimeMethod,
+    basic_compute_montgomery_params,
+    basic_compute_montgomery_params_with_method,
+    basic_from_montgomery,
+    basic_montgomery_mod_exp,
+    basic_montgomery_mod_exp_with_method,
+    basic_montgomery_mod_mul,
+    basic_montgomery_mod_mul_with_method,
+    basic_montgomery_mul,
+    basic_to_montgomery,
+    constrained_compute_montgomery_params,
+    constrained_compute_montgomery_params_with_method,
+    constrained_from_montgomery,
+    constrained_montgomery_mod_exp,
+    constrained_montgomery_mod_exp_with_method,
+    constrained_montgomery_mod_mul,
+    constrained_montgomery_mod_mul_with_method,
+    constrained_montgomery_mul,
+    constrained_to_montgomery,
+    strict_compute_montgomery_params,
+    strict_compute_montgomery_params_with_method,
+    strict_from_montgomery,
+    strict_montgomery_mod_exp,
+    strict_montgomery_mod_exp_with_method,
+    strict_montgomery_mod_mul,
+    strict_montgomery_mod_mul_with_method,
     strict_to_montgomery,
 };
 pub use mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -40,7 +40,8 @@ pub use montgomery::{
     constrained_montgomery_mod_exp, constrained_montgomery_mod_mul, constrained_montgomery_mul,
     constrained_to_montgomery, strict_compute_montgomery_params,
     strict_compute_montgomery_params_with_method, strict_from_montgomery,
-    strict_montgomery_mod_exp, strict_montgomery_mod_mul, strict_to_montgomery,
+    strict_montgomery_mod_exp, strict_montgomery_mod_exp_with_method, strict_montgomery_mod_mul,
+    strict_to_montgomery,
 };
 pub use mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};
 pub use sub::{basic_mod_sub, constrained_mod_sub, strict_mod_sub};

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -10,22 +10,25 @@ pub mod strict_mont;
 // Re-export basic functions for backwards compatibility
 pub use basic_mont::{
     NPrimeMethod, basic_compute_montgomery_params, basic_compute_montgomery_params_with_method,
-    basic_from_montgomery, basic_montgomery_mod_exp, basic_montgomery_mod_mul,
-    basic_montgomery_mul, basic_to_montgomery,
+    basic_from_montgomery, basic_montgomery_mod_exp, basic_montgomery_mod_exp_with_method,
+    basic_montgomery_mod_mul, basic_montgomery_mod_mul_with_method, basic_montgomery_mul,
+    basic_to_montgomery,
 };
 
 // Re-export constrained functions
 pub use constrained_mont::{
     constrained_compute_montgomery_params, constrained_compute_montgomery_params_with_method,
-    constrained_from_montgomery, constrained_montgomery_mod_exp, constrained_montgomery_mod_mul,
-    constrained_montgomery_mul, constrained_to_montgomery,
+    constrained_from_montgomery, constrained_montgomery_mod_exp,
+    constrained_montgomery_mod_exp_with_method, constrained_montgomery_mod_mul,
+    constrained_montgomery_mod_mul_with_method, constrained_montgomery_mul,
+    constrained_to_montgomery,
 };
 
 // Re-export strict functions
 pub use strict_mont::{
     strict_compute_montgomery_params, strict_compute_montgomery_params_with_method,
-    strict_from_montgomery, strict_montgomery_mod_exp, strict_montgomery_mod_mul,
-    strict_to_montgomery,
+    strict_from_montgomery, strict_montgomery_mod_exp, strict_montgomery_mod_exp_with_method,
+    strict_montgomery_mod_mul, strict_montgomery_mod_mul_with_method, strict_to_montgomery,
 };
 
 #[cfg(test)]

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -8,27 +8,45 @@ pub mod constrained_mont;
 pub mod strict_mont;
 
 // Re-export basic functions for backwards compatibility
+#[rustfmt::skip]
 pub use basic_mont::{
-    NPrimeMethod, basic_compute_montgomery_params, basic_compute_montgomery_params_with_method,
-    basic_from_montgomery, basic_montgomery_mod_exp, basic_montgomery_mod_exp_with_method,
-    basic_montgomery_mod_mul, basic_montgomery_mod_mul_with_method, basic_montgomery_mul,
+    NPrimeMethod,
+    basic_compute_montgomery_params,
+    basic_compute_montgomery_params_with_method,
+    basic_from_montgomery,
+    basic_montgomery_mod_exp,
+    basic_montgomery_mod_exp_with_method,
+    basic_montgomery_mod_mul,
+    basic_montgomery_mod_mul_with_method,
+    basic_montgomery_mul,
     basic_to_montgomery,
 };
 
 // Re-export constrained functions
+#[rustfmt::skip]
 pub use constrained_mont::{
-    constrained_compute_montgomery_params, constrained_compute_montgomery_params_with_method,
-    constrained_from_montgomery, constrained_montgomery_mod_exp,
-    constrained_montgomery_mod_exp_with_method, constrained_montgomery_mod_mul,
-    constrained_montgomery_mod_mul_with_method, constrained_montgomery_mul,
+    constrained_compute_montgomery_params,
+    constrained_compute_montgomery_params_with_method,
+    constrained_from_montgomery,
+    constrained_montgomery_mod_exp,
+    constrained_montgomery_mod_exp_with_method,
+    constrained_montgomery_mod_mul,
+    constrained_montgomery_mod_mul_with_method,
+    constrained_montgomery_mul,
     constrained_to_montgomery,
 };
 
 // Re-export strict functions
+#[rustfmt::skip]
 pub use strict_mont::{
-    strict_compute_montgomery_params, strict_compute_montgomery_params_with_method,
-    strict_from_montgomery, strict_montgomery_mod_exp, strict_montgomery_mod_exp_with_method,
-    strict_montgomery_mod_mul, strict_montgomery_mod_mul_with_method, strict_to_montgomery,
+    strict_compute_montgomery_params,
+    strict_compute_montgomery_params_with_method,
+    strict_from_montgomery,
+    strict_montgomery_mod_exp,
+    strict_montgomery_mod_exp_with_method,
+    strict_montgomery_mod_mul,
+    strict_montgomery_mod_mul_with_method,
+    strict_to_montgomery,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary by Sourcery

Add missing entry points for Montgomery multiplication and exponentiation across basic, constrained, and strict modules by introducing method-selection variants and default wrappers using the default NPrimeMethod.

New Features:
- Introduce `*_with_method` variants for Montgomery multiplication and exponentiation in strict, constrained, and basic modules.
- Provide default entry-point wrappers for Montgomery multiplication and exponentiation that invoke the method-selection variants with `NPrimeMethod::default()`.

Enhancements:
- Refactor `strict_compute_montgomery_params` to delegate to its method-based counterpart for unified parameter computation.
- Extend trait bounds and update doc comments to reflect method-selection support in Montgomery functions.
- Update module re-exports in `mod.rs` and `lib.rs` to include the new entry points.

Documentation:
- Revise documentation comments to mention method selection for Montgomery operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable strategies for Montgomery modular multiplication and exponentiation across all variants, while preserving existing defaults.
  * Expanded public API to expose the method-parameterized options at the top level.

* **Documentation**
  * Updated guides and comments to explain method selection and default behavior.

* **Tests**
  * Added tests covering multiple strategies, defaults, and failure scenarios.

* **Chores**
  * Package version bumped to 0.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->