### PR TITLE
Add const-eval modular math

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -17,8 +17,10 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust: ["1.85", stable, nightly]
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,20 +16,32 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: ["1.85", stable, nightly]
 
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           targets: thumbv6m-none-eabi
           components: rustfmt, clippy
     - name: Check formatting
+      if: matrix.rust == 'stable'
       working-directory: modmath
       run: cargo fmt -- --check
     - name: Run clippy
+      if: matrix.rust == 'stable'
       working-directory: modmath
       run: cargo clippy -- -D warnings
     - name: Build
       working-directory: modmath
       run: cargo build
+    - name: Run tests
+      working-directory: modmath
+      run: cargo test --verbose
+    - name: Run tests with nightly feature
+      if: matrix.rust == 'nightly'
+      working-directory: modmath
+      run: cargo test --verbose --features nightly

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -14,9 +14,11 @@ keywords = ["numerics", "bignum"]
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
+c0nst = { version = "0.2", optional = true }
+fixed-bigint = { version = "0.2.0", optional = true, default-features = false, features = ["nightly"] }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.1.13" }
+fixed-bigint = { version = "0.2.0" }
 num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint" , path = "../bn/num-bigint" }
 num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
@@ -39,3 +41,4 @@ std = []
 constrained = []
 basic = []
 strict = []
+nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint"]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -1,3 +1,29 @@
+#[cfg(feature = "nightly")]
+use fixed_bigint::const_numtraits::{ConstOverflowingAdd, ConstOverflowingSub};
+
+#[cfg(feature = "nightly")]
+c0nst::c0nst! {
+    /// # Const Modular Addition
+    /// Const-evaluable version of modular addition. Uses const traits from
+    /// `fixed_bigint::const_numtraits` instead of `num_traits`.
+    pub c0nst fn const_mod_add<T>(a: T, b: T, m: T) -> T
+    where
+        T: [c0nst] core::cmp::PartialOrd
+            + Copy
+            + [c0nst] ConstOverflowingAdd
+            + [c0nst] ConstOverflowingSub
+            + [c0nst] core::ops::Rem<Output = T>,
+    {
+        let a = a % m;
+        let (sum, overflow) = a.overflowing_add(&(b % m));
+        if sum >= m || overflow {
+            sum.overflowing_sub(&m).0
+        } else {
+            sum
+        }
+    }
+}
+
 /// # Modular Addition (Basic)
 /// Simple version that operates on values and copies them. Requires
 /// `WrappingAdd` and `WrappingSub` traits to be implemented.
@@ -184,6 +210,20 @@ mod constrained_mod_add_tests {
 mod basic_mod_add_tests {
     use super::basic_mod_add;
     generate_mod_add_tests!(basic_mod_add, u8, by_val);
+}
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+const _: () = {
+    let result = const_mod_add(5u8, 10u8, 20u8);
+    assert!(result == 15u8);
+};
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+mod const_mod_add_tests {
+    use super::const_mod_add;
+    generate_mod_add_tests!(const_mod_add, u8, by_val);
 }
 
 #[cfg(test)]

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -1,4 +1,51 @@
+#[cfg(feature = "nightly")]
+use super::mul::const_mod_mul;
 use super::mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};
+
+#[cfg(feature = "nightly")]
+use fixed_bigint::const_numtraits::{
+    ConstOne, ConstOverflowingAdd, ConstOverflowingSub, ConstZero,
+};
+
+#[cfg(feature = "nightly")]
+c0nst::c0nst! {
+    /// # Const Modular Exponentiation
+    /// Const-evaluable version of modular exponentiation. Uses const traits from
+    /// `fixed_bigint::const_numtraits` instead of `num_traits`.
+    pub c0nst fn const_mod_exp<T>(mut base: T, exponent: T, modulus: T) -> T
+    where
+        T: [c0nst] core::cmp::PartialOrd
+            + [c0nst] core::cmp::PartialEq
+            + Copy
+            + [c0nst] ConstZero
+            + [c0nst] ConstOne
+            + [c0nst] core::ops::BitAnd<Output = T>
+            + [c0nst] ConstOverflowingAdd
+            + [c0nst] ConstOverflowingSub
+            + [c0nst] core::ops::Shr<usize, Output = T>
+            + [c0nst] core::ops::ShrAssign<usize>
+            + [c0nst] core::ops::Rem<Output = T>
+            + [c0nst] core::ops::RemAssign<T>,
+    {
+        let two = T::one().overflowing_add(&T::one()).0;
+        let mut result = T::one();
+        let mut exp = exponent;
+
+        base %= modulus;
+
+        while exp > T::zero() {
+            if exp % two == T::one() {
+                result = const_mod_mul(result, base, modulus);
+            }
+            exp >>= 1;
+
+            if exp > T::zero() {
+                base = const_mod_mul(base, base, modulus);
+            }
+        }
+        result
+    }
+}
 
 /// # Modular Exponentiation (Basic)
 /// Simple version that operates on values and copies them. Requires
@@ -310,6 +357,32 @@ mod basic_mod_exp_tests {
     }
     mod u32_tests {
         generate_mod_exp_tests_block_32!(super::basic_mod_exp, u32, by_val);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+const _: () = {
+    let result = const_mod_exp(2u64, 3u64, 5u64);
+    assert!(result == 3u64);
+};
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+mod const_mod_exp_tests {
+    use super::const_mod_exp;
+
+    mod u64_tests {
+        generate_mod_exp_tests_block_64!(super::const_mod_exp, u64, by_val);
+    }
+    mod u8_tests {
+        generate_mod_exp_tests_block_8!(super::const_mod_exp, u8, by_val);
+    }
+    mod u16_tests {
+        generate_mod_exp_tests_block_16!(super::const_mod_exp, u16, by_val);
+    }
+    mod u32_tests {
+        generate_mod_exp_tests_block_32!(super::const_mod_exp, u32, by_val);
     }
 }
 

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -24,17 +24,15 @@ c0nst::c0nst! {
             + [c0nst] ConstOverflowingSub
             + [c0nst] core::ops::Shr<usize, Output = T>
             + [c0nst] core::ops::ShrAssign<usize>
-            + [c0nst] core::ops::Rem<Output = T>
-            + [c0nst] core::ops::RemAssign<T>,
+            + [c0nst] core::ops::Rem<Output = T>,
     {
-        let two = T::one().overflowing_add(&T::one()).0;
-        let mut result = T::one();
+        let mut result = T::one() % modulus;
         let mut exp = exponent;
 
-        base %= modulus;
+        base = base % modulus;
 
         while exp > T::zero() {
-            if exp % two == T::one() {
+            if exp & T::one() == T::one() {
                 result = const_mod_mul(result, base, modulus);
             }
             exp >>= 1;

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(const_trait_impl, const_ops, const_cmp))]
+#![cfg_attr(feature = "nightly", allow(incomplete_features))]
 
 //! Modular math implemented with traits.
 //!
@@ -29,7 +31,11 @@ mod sub;
 mod inv;
 mod montgomery;
 
+#[cfg(feature = "nightly")]
+pub use add::const_mod_add;
 pub use add::{basic_mod_add, constrained_mod_add, strict_mod_add};
+#[cfg(feature = "nightly")]
+pub use exp::const_mod_exp;
 pub use exp::{basic_mod_exp, constrained_mod_exp, strict_mod_exp};
 pub use inv::{basic_mod_inv, constrained_mod_inv, strict_mod_inv};
 #[rustfmt::skip]
@@ -62,7 +68,11 @@ pub use montgomery::{
     strict_montgomery_mod_mul_with_method,
     strict_to_montgomery,
 };
+#[cfg(feature = "nightly")]
+pub use mul::const_mod_mul;
 pub use mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};
+#[cfg(feature = "nightly")]
+pub use sub::const_mod_sub;
 pub use sub::{basic_mod_sub, constrained_mod_sub, strict_mod_sub};
 
 #[cfg(test)]

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -35,14 +35,16 @@ c0nst::c0nst! {
                 };
             }
 
-            let (doubled, overflow) = a.overflowing_add(&a);
-            a = if doubled >= m || overflow {
-                doubled.overflowing_sub(&m).0
-            } else {
-                doubled
-            };
-
             b = b >> 1;
+
+            if b > T::zero() {
+                let (doubled, overflow) = a.overflowing_add(&a);
+                a = if doubled >= m || overflow {
+                    doubled.overflowing_sub(&m).0
+                } else {
+                    doubled
+                };
+            }
         }
 
         result

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -1,3 +1,54 @@
+#[cfg(feature = "nightly")]
+use fixed_bigint::const_numtraits::{
+    ConstOne, ConstOverflowingAdd, ConstOverflowingSub, ConstZero,
+};
+
+#[cfg(feature = "nightly")]
+c0nst::c0nst! {
+    /// # Const Modular Multiplication
+    /// Const-evaluable version of modular multiplication. Uses const traits from
+    /// `fixed_bigint::const_numtraits` instead of `num_traits`.
+    pub c0nst fn const_mod_mul<T>(a: T, b: T, m: T) -> T
+    where
+        T: [c0nst] core::cmp::PartialOrd
+            + [c0nst] core::cmp::PartialEq
+            + Copy
+            + [c0nst] ConstZero
+            + [c0nst] ConstOne
+            + [c0nst] core::ops::BitAnd<Output = T>
+            + [c0nst] ConstOverflowingAdd
+            + [c0nst] ConstOverflowingSub
+            + [c0nst] core::ops::Shr<usize, Output = T>
+            + [c0nst] core::ops::Rem<Output = T>,
+    {
+        let mut a = a % m;
+        let mut b = b % m;
+        let mut result = T::zero();
+
+        while b > T::zero() {
+            if b & T::one() == T::one() {
+                let (sum, overflow) = result.overflowing_add(&a);
+                result = if sum >= m || overflow {
+                    sum.overflowing_sub(&m).0
+                } else {
+                    sum
+                };
+            }
+
+            let (doubled, overflow) = a.overflowing_add(&a);
+            a = if doubled >= m || overflow {
+                doubled.overflowing_sub(&m).0
+            } else {
+                doubled
+            };
+
+            b = b >> 1;
+        }
+
+        result
+    }
+}
+
 /// # Modular Multiplication (Basic)
 /// Simple version that operates on values and copies them. Requires
 /// `WrappingAdd` and `WrappingSub` traits to be implemented.
@@ -363,6 +414,27 @@ mod basic_mod_mul_tests {
     mod u64_tests {
         use super::basic_mod_mul;
         generate_mod_mul_tests_block_2!(basic_mod_mul, u64, by_val);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+const _: () = {
+    let result = const_mod_mul(7u8, 13u8, 19u8);
+    assert!(result == 15u8);
+};
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+mod const_mod_mul_tests {
+    use super::const_mod_mul;
+    mod u8_tests {
+        use super::const_mod_mul;
+        generate_mod_mul_tests_block_1!(const_mod_mul, u8, by_val);
+    }
+    mod u64_tests {
+        use super::const_mod_mul;
+        generate_mod_mul_tests_block_2!(const_mod_mul, u64, by_val);
     }
 }
 

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -1,3 +1,29 @@
+#[cfg(feature = "nightly")]
+use fixed_bigint::const_numtraits::{ConstOverflowingAdd, ConstOverflowingSub};
+
+#[cfg(feature = "nightly")]
+c0nst::c0nst! {
+    /// # Const Modular Subtraction
+    /// Const-evaluable version of modular subtraction. Uses const traits from
+    /// `fixed_bigint::const_numtraits` instead of `num_traits`.
+    pub c0nst fn const_mod_sub<T>(a: T, b: T, m: T) -> T
+    where
+        T: [c0nst] core::cmp::PartialOrd
+            + Copy
+            + [c0nst] ConstOverflowingAdd
+            + [c0nst] ConstOverflowingSub
+            + [c0nst] core::ops::Rem<Output = T>,
+    {
+        let a = a % m;
+        let (diff, overflow) = a.overflowing_sub(&(b % m));
+        if overflow {
+            m.overflowing_add(&diff).0
+        } else {
+            diff
+        }
+    }
+}
+
 /// # Modular Subtraction (Basic)
 /// Simple version that operates on values and copies them. Requires
 /// `WrappingAdd` and `WrappingSub` traits to be implemented.
@@ -168,6 +194,19 @@ mod constrained_mod_sub_tests {
 #[cfg(test)]
 mod basic_mod_sub_tests {
     generate_mod_sub_tests!(super::basic_mod_sub, u8, by_val);
+}
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+const _: () = {
+    let result = const_mod_sub(5u8, 10u8, 20u8);
+    assert!(result == 15u8);
+};
+
+#[cfg(test)]
+#[cfg(feature = "nightly")]
+mod const_mod_sub_tests {
+    generate_mod_sub_tests!(super::const_mod_sub, u8, by_val);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add msrv and nightly

## Summary by Sourcery

Add const-evaluable modular arithmetic operations behind a nightly feature and ensure they are exercised in CI across stable, MSRV, and nightly toolchains.

New Features:
- Expose const-evaluable modular add, sub, mul, and exp APIs behind a nightly Cargo feature flag.

Enhancements:
- Enable nightly-only compiler features to support const-evaluable modular arithmetic implementations.

Build:
- Introduce a nightly feature with additional optional dependencies and update fixed-bigint to 0.2.0 for both regular and nightly builds.

CI:
- Run the Rust workflow against a matrix of 1.85 MSRV, stable, and nightly compilers with conditional formatting, linting, and feature-gated test runs.

Tests:
- Add compile-time and runtime tests for const-evaluable modular arithmetic functions gated behind the nightly feature.
- Extend CI to run tests on MSRV, stable, and nightly toolchains, including nightly-feature tests on nightly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose compile-time (const) modular arithmetic operations when the nightly feature is enabled.

* **Chores**
  * CI updated to test multiple Rust channels (including nightly) with conditional checks per channel.
  * Dependencies and feature flags updated to enable nightly-only const evaluation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->