### PR TITLE
Optimize mul and exp across all variants

### DIFF
--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -59,26 +59,20 @@ where
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::ShrAssign<usize>
-        + core::ops::RemAssign<T>
         + Copy,
 {
-    let two = T::one() + T::one();
-    let mut result = T::one();
+    let mut result = T::one() % modulus;
     let mut exp = exponent;
 
-    base %= modulus; // reduce base initially
+    base = base % modulus;
 
     while exp > T::zero() {
-        // If the exponent is odd, multiply the result by base
-        if exp % two == T::one() {
+        if exp & T::one() == T::one() {
             result = basic_mod_mul(result, base, modulus);
         }
-        // Right shift the exponent (divide by 2)
         exp >>= 1;
 
-        // Only square base if exp > 0 (avoid unnecessary squaring in final step)
         if exp > T::zero() {
-            // Square the base using modular multiplication
             base = basic_mod_mul(base, base, modulus);
         }
     }
@@ -103,11 +97,11 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
 {
     base.rem_assign(modulus);
-    let mut result = T::one();
+    let mut result = T::one() % modulus;
     let mut exp = T::zero().wrapping_add(exponent);
-    let two = T::one().wrapping_add(&T::one());
+    let one = T::one();
     while exp > T::zero() {
-        if &exp % &two == T::one() {
+        if &exp & &one == one {
             result = constrained_mod_mul(result, &base, modulus);
         }
         exp >>= 1;
@@ -137,13 +131,13 @@ where
         + core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
 {
-    let two = T::one().overflowing_add(&T::one()).0;
-    let mut result = T::one();
+    let mut result = T::one() % modulus;
     base.rem_assign(modulus);
     let mut exp = T::zero().overflowing_add(exponent).0;
+    let one = T::one();
 
     while exp > T::zero() {
-        if &exp % &two == T::one() {
+        if &exp & &one == one {
             result = strict_mod_mul(result, &base, modulus);
         }
         exp >>= 1;
@@ -195,6 +189,12 @@ macro_rules! generate_mod_exp_tests_block_64 {
         #[test]
         fn test_identity_exponent_of_0() {
             assert_eq!(mod_exp(5_u64, &0_u64, &9_u64), 1_u64); // 5^0 % 9 = 1
+        }
+
+        #[test]
+        fn test_identity_exponent_of_0_modulus_of_1() {
+            assert_eq!(mod_exp(5_u64, &0_u64, &1_u64), 0_u64); // 5^0 % 1 = 0
+            assert_eq!(mod_exp(0_u64, &0_u64, &1_u64), 0_u64); // 0^0 % 1 = 0
         }
 
         #[test]

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -82,15 +82,16 @@ where
             };
         }
 
-        // Doubling logic
-        let sum = a.wrapping_add(&a);
-        a = if sum >= m1 || sum < a {
-            sum.wrapping_sub(&m1)
-        } else {
-            sum
-        };
-
         b = b >> 1;
+
+        if b > T::zero() {
+            let sum = a.wrapping_add(&a);
+            a = if sum >= m1 || sum < a {
+                sum.wrapping_sub(&m1)
+            } else {
+                sum
+            };
+        }
     }
 
     result
@@ -127,15 +128,16 @@ where
             };
         }
 
-        // Doubling logic
-        let sum = a.wrapping_add(&a);
-        a = if &sum >= m || sum < a {
-            sum.wrapping_sub(m)
-        } else {
-            sum
-        };
-
         b = b >> 1;
+
+        if b > T::zero() {
+            let sum = a.wrapping_add(&a);
+            a = if &sum >= m || sum < a {
+                sum.wrapping_sub(m)
+            } else {
+                sum
+            };
+        }
     }
 
     result
@@ -162,10 +164,7 @@ where
     let one = T::one();
 
     while b > T::zero() {
-        // TODO: Can we just do a first bit check here rather than
-        // a full bit and and equality check
         if &b & &one == one {
-            // Inline strict_mod_add but skip the redundant modulo on 'a' since we know it's reduced
             let (sum, overflow) = result.overflowing_add(&a);
             result = if &sum >= m || overflow {
                 sum.overflowing_sub(m).0
@@ -174,15 +173,16 @@ where
             };
         }
 
-        // Doubling logic
-        let (doubled, overflow) = a.overflowing_add(&a);
-        a = if &doubled >= m || overflow {
-            doubled.overflowing_sub(m).0
-        } else {
-            doubled
-        };
-
         b = b >> 1;
+
+        if b > T::zero() {
+            let (doubled, overflow) = a.overflowing_add(&a);
+            a = if &doubled >= m || overflow {
+                doubled.overflowing_sub(m).0
+            } else {
+                doubled
+            };
+        }
     }
 
     result


### PR DESCRIPTION
Apply const_mod optimizations to basic/constrained/strict:
- exp: use bitwise & for parity, fix modulus=1 edge case
- mul: skip final doubling when b becomes zero

## Summary by Sourcery

Optimize modular multiplication and exponentiation across basic, constrained, and strict variants.

Bug Fixes:
- Fix modular exponentiation identity behavior when modulus is 1 by reducing the initial result value.

Enhancements:
- Skip redundant doubling steps in modular multiplication loops once the multiplier becomes zero.
- Use bitwise parity checks instead of modulo operations in modular exponentiation to reduce overhead.
- Ensure base and initial result are reduced modulo the modulus in all exponentiation variants for consistency and edge-case safety.

Tests:
- Add regression tests covering exponent 0 with modulus 1 for modular exponentiation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized core algorithms for modular arithmetic operations, improving computational efficiency and execution speed in exponentiation and multiplication routines.

* **Bug Fixes**
  * Improved robustness of edge case handling in modular arithmetic calculations.

* **Tests**
  * Expanded unit test coverage to validate mathematical edge cases and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->