### PR TITLE
Add Parity trait for optimized is_odd/is_even

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -14,11 +14,12 @@ keywords = ["numerics", "bignum"]
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
+num-integer = { version = "0.1", default-features = false, optional = true }
 c0nst = { version = "0.2", optional = true }
-fixed-bigint = { version = "0.2.0", optional = true, default-features = false, features = ["nightly"] }
+fixed-bigint = { version = "0.2.1", optional = true, default-features = false, features = ["nightly"] }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.2.0" }
+fixed-bigint = { version = "0.2.1" }
 num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint" , path = "../bn/num-bigint" }
 num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
@@ -41,4 +42,5 @@ std = []
 constrained = []
 basic = []
 strict = []
+num-integer = ["dep:num-integer"]
 nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint"]

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -54,7 +54,6 @@ where
         + num_traits::One
         + num_traits::Zero
         + crate::parity::Parity
-        + core::ops::BitAnd<Output = T>
         + core::ops::Rem<Output = T>
         + core::ops::Shr<usize, Output = T>
         + num_traits::ops::wrapping::WrappingAdd
@@ -96,7 +95,7 @@ where
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::DivAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     base.rem_assign(modulus);
     let mut result = T::one() % modulus;
@@ -131,7 +130,7 @@ where
         + core::ops::DivAssign<&'a T>
         + core::ops::ShrAssign<usize>
         + core::ops::Rem<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     let mut result = T::one() % modulus;
     base.rem_assign(modulus);

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -53,6 +53,7 @@ where
     T: PartialOrd
         + num_traits::One
         + num_traits::Zero
+        + crate::parity::Parity
         + core::ops::BitAnd<Output = T>
         + core::ops::Rem<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -67,7 +68,7 @@ where
     base = base % modulus;
 
     while exp > T::zero() {
-        if exp & T::one() == T::one() {
+        if exp.is_odd() {
             result = basic_mod_mul(result, base, modulus);
         }
         exp >>= 1;
@@ -87,6 +88,7 @@ where
     T: PartialOrd
         + num_traits::One
         + num_traits::Zero
+        + crate::parity::Parity
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::ShrAssign<usize>
@@ -99,9 +101,8 @@ where
     base.rem_assign(modulus);
     let mut result = T::one() % modulus;
     let mut exp = T::zero().wrapping_add(exponent);
-    let one = T::one();
     while exp > T::zero() {
-        if &exp & &one == one {
+        if exp.is_odd() {
             result = constrained_mod_mul(result, &base, modulus);
         }
         exp >>= 1;
@@ -122,6 +123,7 @@ where
     T: PartialOrd
         + num_traits::One
         + num_traits::Zero
+        + crate::parity::Parity
         + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::ops::overflowing::OverflowingSub
         + core::ops::Shr<usize, Output = T>,
@@ -134,10 +136,9 @@ where
     let mut result = T::one() % modulus;
     base.rem_assign(modulus);
     let mut exp = T::zero().overflowing_add(exponent).0;
-    let one = T::one();
 
     while exp > T::zero() {
-        if &exp & &one == one {
+        if exp.is_odd() {
             result = strict_mod_mul(result, &base, modulus);
         }
         exp >>= 1;

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -26,10 +26,13 @@
 mod add;
 mod exp;
 mod mul;
+mod parity;
 mod sub;
 
 mod inv;
 mod montgomery;
+
+pub use parity::Parity;
 
 #[cfg(feature = "nightly")]
 pub use add::const_mod_add;

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -221,7 +221,6 @@ where
         + Copy
         + num_traits::Zero
         + num_traits::One
-        + core::ops::BitAnd<Output = T>
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Shr<usize, Output = T>

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -225,7 +225,8 @@ where
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Shr<usize, Output = T>
-        + core::ops::Rem<Output = T>,
+        + core::ops::Rem<Output = T>
+        + crate::parity::Parity,
 {
     crate::mul::basic_mod_mul(a, r, modulus)
 }
@@ -290,7 +291,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + num_traits::ops::wrapping::WrappingAdd
-        + num_traits::ops::wrapping::WrappingSub,
+        + num_traits::ops::wrapping::WrappingSub
+        + crate::parity::Parity,
 {
     // Montgomery multiplication algorithm:
     // Input: a_mont, b_mont (both in Montgomery form), modulus N, N', r_bits
@@ -327,7 +329,8 @@ where
         + core::ops::BitAnd<Output = T>
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::parity::Parity,
 {
     let (r, _r_inv, n_prime, r_bits) =
         basic_compute_montgomery_params_with_method(modulus, method)?;
@@ -354,7 +357,8 @@ where
         + core::ops::BitAnd<Output = T>
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::parity::Parity,
 {
     basic_montgomery_mod_mul_with_method(a, b, modulus, NPrimeMethod::default())
 }
@@ -372,6 +376,7 @@ where
     T: Copy
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -401,7 +406,7 @@ where
     // Binary exponentiation using Montgomery multiplication
     while exp > T::zero() {
         // If exponent is odd, multiply result by current base power
-        if exp & T::one() == T::one() {
+        if exp.is_odd() {
             result = basic_montgomery_mul(result, base, modulus, n_prime, r_bits);
         }
 
@@ -424,6 +429,7 @@ where
     T: Copy
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -77,7 +77,6 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
-        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -85,14 +84,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
-    // Hensel's lifting requires modulus to be odd (prerequisite for Montgomery arithmetic)
-    debug_assert!(
-        modulus.is_odd(),
-        "Hensel's lifting requires an odd modulus for Montgomery arithmetic"
-    );
-
     // Hensel's lifting for N' computation when R = 2^k
     let mut n_prime = T::one();
 
@@ -134,7 +127,6 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
-        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -148,8 +140,7 @@ where
         + core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T>
         + core::ops::Div<&'a T, Output = T>
-        + core::ops::Rem<&'a T, Output = T>
-        + core::ops::BitAnd<&'a T, Output = T>,
+        + core::ops::Rem<&'a T, Output = T>,
 {
     // Step 1: Find R = 2^k where R > modulus
     let mut r = T::one();
@@ -185,7 +176,6 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
-        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -199,8 +189,7 @@ where
         + core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T>
         + core::ops::Div<&'a T, Output = T>
-        + core::ops::Rem<&'a T, Output = T>
-        + core::ops::BitAnd<&'a T, Output = T>,
+        + core::ops::Rem<&'a T, Output = T>,
 {
     constrained_compute_montgomery_params_with_method(modulus, NPrimeMethod::default())
 }
@@ -216,7 +205,7 @@ where
         + core::ops::Shr<usize, Output = T>
         + crate::parity::Parity,
     for<'a> T: core::ops::RemAssign<&'a T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     crate::mul::constrained_mod_mul(a, r, modulus)
 }

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -77,6 +77,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -88,7 +89,7 @@ where
 {
     // Hensel's lifting requires modulus to be odd (prerequisite for Montgomery arithmetic)
     debug_assert!(
-        modulus & &T::one() == T::one(),
+        modulus.is_odd(),
         "Hensel's lifting requires an odd modulus for Montgomery arithmetic"
     );
 
@@ -133,6 +134,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -183,6 +185,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -210,7 +213,8 @@ where
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::parity::Parity,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
 {
@@ -286,6 +290,7 @@ where
         + core::ops::Shr<usize, Output = T>
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
+        + crate::parity::Parity
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
@@ -310,6 +315,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -347,6 +353,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -380,6 +387,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
@@ -415,7 +423,7 @@ where
     // Binary exponentiation using Montgomery multiplication
     while exp > T::zero() {
         // If exponent is odd, multiply result by current base power
-        if &exp & &T::one() == T::one() {
+        if exp.is_odd() {
             result = constrained_montgomery_mul(&result, &base, modulus, &n_prime, r_bits);
         }
 
@@ -440,6 +448,7 @@ where
     T: Clone
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -346,7 +346,7 @@ where
         + num_traits::ops::overflowing::OverflowingSub
         + core::ops::Shr<usize, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     crate::mul::strict_mod_mul(a, r, modulus)
 }

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -258,6 +258,7 @@ pub fn strict_montgomery_mul<T>(a_mont: T, b_mont: &T, modulus: &T, n_prime: &T,
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialOrd
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -340,6 +341,7 @@ where
     T: PartialOrd
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::ops::overflowing::OverflowingSub
         + core::ops::Shr<usize, Output = T>,
@@ -361,6 +363,7 @@ pub fn strict_montgomery_mod_mul_with_method<T>(
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -420,6 +423,7 @@ pub fn strict_montgomery_mod_mul<T>(a: T, b: &T, modulus: &T) -> Option<T>
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -458,6 +462,7 @@ pub fn strict_montgomery_mod_exp_with_method<T>(
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -499,7 +504,7 @@ where
     // Use Montgomery multiplication to stay in Montgomery domain throughout
     while exp > T::zero() {
         // If exponent is odd, multiply result by current base power
-        if &exp & &T::one() == T::one() {
+        if exp.is_odd() {
             result = strict_montgomery_mul(result, &base, modulus, &n_prime, r_bits);
         }
 
@@ -531,6 +536,7 @@ pub fn strict_montgomery_mod_exp<T>(base: T, exponent: &T, modulus: &T) -> Optio
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -61,7 +61,6 @@ where
         + num_traits::Zero
         + num_traits::One
         + crate::parity::Parity
-        + core::ops::BitAnd<Output = T>
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Shr<usize, Output = T>
@@ -111,7 +110,7 @@ where
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Shr<usize, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     a.rem_assign(m);
     let mut b = b % m;
@@ -157,7 +156,7 @@ where
         + num_traits::ops::overflowing::OverflowingSub
         + core::ops::Shr<usize, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     a.rem_assign(m);
     let mut b = b % m;

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -60,6 +60,7 @@ where
         + Copy
         + num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + core::ops::BitAnd<Output = T>
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
@@ -72,7 +73,7 @@ where
     let mut result = T::zero();
 
     while b > T::zero() {
-        if b & T::one() == T::one() {
+        if b.is_odd() {
             // Inline basic_mod_add but skip the redundant modulo on 'a' since we know it's reduced
             let sum = result.wrapping_add(&a);
             result = if sum >= m1 || sum < result {
@@ -104,6 +105,7 @@ pub fn constrained_mod_mul<T>(mut a: T, b: &T, m: &T) -> T
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialOrd
         + num_traits::ops::wrapping::WrappingAdd
         + num_traits::ops::wrapping::WrappingSub
@@ -115,10 +117,9 @@ where
     let mut b = b % m;
 
     let mut result = T::zero();
-    let one = T::one();
 
     while b > T::zero() {
-        if &b & &one == one {
+        if b.is_odd() {
             // Inline constrained_mod_add but skip the redundant modulo on 'a' since we know it's reduced
             let sum = result.wrapping_add(&a);
             result = if &sum >= m || sum < result {
@@ -150,6 +151,7 @@ pub fn strict_mod_mul<T>(mut a: T, b: &T, m: &T) -> T
 where
     T: num_traits::Zero
         + num_traits::One
+        + crate::parity::Parity
         + PartialOrd
         + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::ops::overflowing::OverflowingSub
@@ -161,10 +163,9 @@ where
     let mut b = b % m;
 
     let mut result = T::zero();
-    let one = T::one();
 
     while b > T::zero() {
-        if &b & &one == one {
+        if b.is_odd() {
             let (sum, overflow) = result.overflowing_add(&a);
             result = if &sum >= m || overflow {
                 sum.overflowing_sub(m).0

--- a/modmath/src/parity.rs
+++ b/modmath/src/parity.rs
@@ -1,0 +1,34 @@
+/// Trait for checking parity (odd/even) of integer types.
+///
+/// When the `num-integer` feature is enabled, this delegates to
+/// `num_integer::Integer::is_odd` which can be optimized per-type
+/// (e.g. fixed-bigint checks a single byte instead of all limbs).
+///
+/// Without the feature, falls back to `self & one == one` which
+/// touches all limbs via BitAnd.
+pub trait Parity {
+    fn is_odd(&self) -> bool;
+    fn is_even(&self) -> bool {
+        !self.is_odd()
+    }
+}
+
+#[cfg(not(feature = "num-integer"))]
+impl<T> Parity for T
+where
+    T: core::ops::BitAnd<Output = T> + num_traits::One + PartialEq + Clone,
+{
+    fn is_odd(&self) -> bool {
+        self.clone() & T::one() == T::one()
+    }
+}
+
+#[cfg(feature = "num-integer")]
+impl<T> Parity for T
+where
+    T: num_integer::Integer,
+{
+    fn is_odd(&self) -> bool {
+        num_integer::Integer::is_odd(self)
+    }
+}


### PR DESCRIPTION
Feature-gated trait with two blanket impls:
- Default: BitAnd fallback (all types work)
- num-integer feature: delegates to Integer::is_odd()

## Summary by Sourcery

Introduce a generic Parity trait and integrate it across modular arithmetic and Montgomery exponentiation to enable optimized odd/even checks, with optional delegation to num-integer.

New Features:
- Add a Parity trait with is_odd/is_even helpers and export it from the crate.
- Provide feature-gated Parity implementations: a BitAnd-based fallback and an optimized num-integer-backed version when enabled.

Enhancements:
- Replace manual bitwise odd checks in modular multiplication, exponentiation, and Montgomery routines with Parity-based calls for cleaner and potentially faster parity testing.
- Extend numeric trait bounds across modular arithmetic and Montgomery functions to require Parity where odd/even checks are needed.

Build:
- Add optional num-integer dependency and corresponding cargo feature, and bump fixed-bigint to version 0.2.1 in dependencies and dev-dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Parity trait with is_odd()/is_even() for integer types.
  * Added an optional num-integer feature to enable optimized parity checks.

* **Refactor**
  * Modular multiplication and exponentiation now use Parity-based checks instead of raw bit tests.

* **Chores**
  * Adjusted dependency configuration (added num-integer mapping; bumped a dev-dependency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->