### PR TITLE
Consolidate wide-REDC into basic Montgomery path

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,10 +16,10 @@ keywords = ["numerics", "bignum"]
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false, optional = true }
 c0nst = { version = "0.2", optional = true }
-fixed-bigint = { version = "0.2.1", optional = true, default-features = false, features = ["nightly"] }
+fixed-bigint = { version = "0.2.2", optional = true, default-features = false }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.2.1" }
+fixed-bigint = { version = "0.2.2" }
 num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint" , path = "../bn/num-bigint" }
 num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
@@ -43,4 +43,5 @@ constrained = []
 basic = []
 strict = []
 num-integer = ["dep:num-integer"]
-nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint"]
+wide-mul = ["dep:fixed-bigint"]
+nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint", "fixed-bigint/nightly"]

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -55,6 +55,7 @@ pub use montgomery::{
     basic_montgomery_mod_mul_with_method,
     basic_montgomery_mul,
     basic_to_montgomery,
+    wide_from_montgomery,
     constrained_compute_montgomery_params,
     constrained_compute_montgomery_params_with_method,
     constrained_from_montgomery,

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -28,11 +28,13 @@ mod exp;
 mod mul;
 mod parity;
 mod sub;
+mod wide_mul;
 
 mod inv;
 mod montgomery;
 
 pub use parity::Parity;
+pub use wide_mul::WideMul;
 
 #[cfg(feature = "nightly")]
 pub use add::const_mod_add;

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -248,7 +248,11 @@ where
 }
 
 /// Convert from Montgomery form (Basic): (a * R) -> a mod N
-/// Uses Montgomery reduction algorithm
+/// Uses Montgomery reduction algorithm with legacy R > N semantics.
+///
+/// **Warning**: This function can overflow for large moduli where m * N exceeds
+/// the type width. For overflow-free reduction, use [`wide_from_montgomery`]
+/// which uses wide-REDC with R = 2^W.
 pub fn basic_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
 where
     T: Copy
@@ -284,12 +288,31 @@ where
     let m = ((a_mont & mask) * n_prime) & mask;
 
     // Step 2: t = (a_mont + m * N) >> r_bits
-    // TODO(Phase 1): m * N can overflow for large moduli (m < R, N < R, so
-    // m*N can reach R^2). Needs WideningMul for correctness at key sizes.
+    // WARNING: m * N can overflow for large moduli (m < R, N < R, so
+    // m*N can reach R^2). Use wide_from_montgomery for overflow-free reduction.
     let t = (a_mont + m * modulus) >> r_bits;
 
     // Step 3: Final reduction
     if t >= modulus { t - modulus } else { t }
+}
+
+/// Convert from Montgomery form using wide-REDC: (a * R) -> a mod N
+///
+/// Uses R = 2^W (full type width) semantics with overflow-free reduction.
+/// The N' parameter must be computed for R = 2^W (e.g., via Newton's method).
+#[allow(dead_code)] // Public API for external use
+pub fn wide_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T) -> T
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub,
+{
+    wide_redc(a_mont, T::zero(), modulus, n_prime)
 }
 
 /// Montgomery multiplication (Basic): (a * R) * (b * R) -> (a * b * R) mod N
@@ -428,7 +451,6 @@ where
 /// Invariants maintained:
 /// - `result` is in range [0, modulus + 1] on entry (sum of two values < modulus plus carry)
 /// - Returns (result + carry1, extra_bit) where extra_bit indicates overflow
-#[inline]
 fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
 where
     T: Copy + num_traits::One + num_traits::ops::overflowing::OverflowingAdd,
@@ -534,9 +556,23 @@ where
     basic_montgomery_mod_mul(a, b, modulus)
 }
 
+/// Reduce value modulo modulus using repeated subtraction.
+/// For values close to modulus this is efficient; for very large values
+/// callers should pre-reduce before calling Montgomery functions.
+fn reduce_mod<T>(mut val: T, modulus: T) -> T
+where
+    T: Copy + PartialOrd + num_traits::WrappingSub,
+{
+    while val >= modulus {
+        val = val.wrapping_sub(&modulus);
+    }
+    val
+}
+
 /// Complete Montgomery modular multiplication (Basic): A * B mod N
 ///
 /// Uses wide REDC (R = 2^W) with Newton's method for N'.
+/// Inputs are reduced modulo N before conversion to Montgomery form.
 /// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_mul<T>(a: T, b: T, modulus: T) -> Option<T>
 where
@@ -560,10 +596,14 @@ where
     let r_mod_n = compute_r_mod_n(modulus, w);
     let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
 
+    // Reduce inputs to [0, modulus) before Montgomery conversion
+    let a_red = reduce_mod(a, modulus);
+    let b_red = reduce_mod(b, modulus);
+
     // Convert to Montgomery form via REDC(a * R^2)
-    let (lo, hi) = a.wide_mul(&r2_mod_n);
+    let (lo, hi) = a_red.wide_mul(&r2_mod_n);
     let a_m = wide_redc(lo, hi, modulus, n_prime);
-    let (lo, hi) = b.wide_mul(&r2_mod_n);
+    let (lo, hi) = b_red.wide_mul(&r2_mod_n);
     let b_m = wide_redc(lo, hi, modulus, n_prime);
 
     // Multiply in Montgomery domain
@@ -607,6 +647,7 @@ where
 /// Montgomery-based modular exponentiation (Basic): base^exponent mod modulus
 ///
 /// Uses wide REDC (R = 2^W) with Newton's method for N'.
+/// The base is reduced modulo N before conversion to Montgomery form.
 /// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_exp<T>(base: T, exponent: T, modulus: T) -> Option<T>
 where
@@ -632,11 +673,12 @@ where
     let r_mod_n = compute_r_mod_n(modulus, w);
     let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
 
-    // 1 in Montgomery form = REDC(1 * R^2)
-    let (lo, hi) = T::one().wide_mul(&r2_mod_n);
-    let one_mont = wide_redc(lo, hi, modulus, n_prime);
+    // 1 in Montgomery form = R mod N (since REDC(1 * R²) = 1 * R² * R⁻¹ = R mod N)
+    let one_mont = r_mod_n;
 
-    let (lo, hi) = base.wide_mul(&r2_mod_n);
+    // Reduce base to [0, modulus) before Montgomery conversion
+    let base_red = reduce_mod(base, modulus);
+    let (lo, hi) = base_red.wide_mul(&r2_mod_n);
     let mut base_mont = wide_redc(lo, hi, modulus, n_prime);
     let mut result = one_mont;
     let mut exp = exponent;
@@ -1141,5 +1183,68 @@ mod tests {
         let expected = crate::exp::basic_mod_exp(base, exp, modulus);
         let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
         assert_eq!(got, expected);
+    }
+
+    // -- Input reduction tests -----------------------------------------------
+
+    #[test]
+    fn test_input_reduction_mod_mul() {
+        // Test that inputs >= modulus are handled correctly via reduction
+        let modulus = 13u32;
+
+        // Inputs larger than modulus should be reduced before Montgomery conversion
+        let a = 27u32; // 27 mod 13 = 1
+        let b = 39u32; // 39 mod 13 = 0
+        let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+        assert_eq!(got, 0, "27 * 39 mod 13 should be 0");
+
+        // Another case: both inputs need reduction
+        let a = 100u32; // 100 mod 13 = 9
+        let b = 200u32; // 200 mod 13 = 5
+        let expected = (9 * 5) % 13; // 45 mod 13 = 6
+        let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+        assert_eq!(got, expected);
+
+        // Edge case: input equals modulus (should reduce to 0)
+        let got = basic_montgomery_mod_mul(13u32, 5u32, modulus).unwrap();
+        assert_eq!(got, 0, "modulus * 5 mod modulus should be 0");
+    }
+
+    #[test]
+    fn test_input_reduction_mod_exp() {
+        // Test that base >= modulus is handled correctly
+        let modulus = 13u32;
+
+        // Base larger than modulus
+        let base = 27u32; // 27 mod 13 = 1
+        let exp = 100u32;
+        let expected = 1u32; // 1^100 = 1
+        let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+        assert_eq!(got, expected);
+
+        // Another case
+        let base = 100u32; // 100 mod 13 = 9
+        let exp = 3u32;
+        let expected = crate::exp::basic_mod_exp(9u32, 3, modulus); // 729 mod 13 = 1
+        let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_wide_from_montgomery() {
+        // Test the wide-REDC based from_montgomery function
+        let modulus = 13u8;
+        let w = type_bit_width::<u8>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+        // Convert to Montgomery form and back for various values
+        for a in 0u8..13 {
+            let (lo, hi) = a.wide_mul(&r2_mod_n);
+            let a_m = wide_redc(lo, hi, modulus, n_prime);
+            let back = wide_from_montgomery(a_m, modulus, n_prime);
+            assert_eq!(back, a, "wide_from_montgomery roundtrip failed for {a}");
+        }
     }
 }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -2,17 +2,26 @@
 // These require Copy trait but have minimal constraints
 
 use crate::inv::basic_mod_inv;
+use crate::parity::Parity;
+use crate::wide_mul::WideMul;
 
 /// Methods for computing N' in Montgomery parameter computation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum NPrimeMethod {
-    /// Trial search - O(R) complexity, simple but slow for large R
+    /// Trial search - O(R) complexity, simple but slow for large R.
+    /// Only works when R fits in the type (R > N, smallest power of 2).
     TrialSearch,
-    /// Extended Euclidean Algorithm - O(log R) complexity
-    #[default]
+    /// Extended Euclidean Algorithm - O(log R) complexity.
+    /// Only works when R fits in the type (R > N, smallest power of 2).
     ExtendedEuclidean,
-    /// Hensel's lifting - O(log R) complexity, optimized for R = 2^k
+    /// Hensel's lifting - O(log R) complexity, optimized for R = 2^k.
+    /// Only works when R fits in the type (R > N, smallest power of 2).
     HenselsLifting,
+    /// Newton's method - O(log W) complexity, works with R = 2^W (full type width).
+    /// Uses wrapping arithmetic so R never needs to be represented explicitly.
+    /// This is the only method compatible with the wide-REDC path.
+    #[default]
+    Newton,
 }
 
 /// Compute N' using trial search method - O(R) complexity
@@ -188,6 +197,12 @@ where
         NPrimeMethod::TrialSearch => compute_n_prime_trial_search(modulus, r)?,
         NPrimeMethod::ExtendedEuclidean => compute_n_prime_extended_euclidean(modulus, r)?,
         NPrimeMethod::HenselsLifting => compute_n_prime_hensels_lifting(modulus, r, r_bits)?,
+        NPrimeMethod::Newton => {
+            // In this legacy param path (R > N, smallest power of 2),
+            // delegate to ExtendedEuclidean which computes -N^{-1} mod R
+            // using the same mathematical identity.
+            compute_n_prime_extended_euclidean(modulus, r)?
+        }
     };
 
     Some((r, r_inv, n_prime, r_bits))
@@ -268,7 +283,7 @@ where
 
     // Step 2: t = (a_mont + m * N) >> r_bits
     // TODO(Phase 1): m * N can overflow for large moduli (m < R, N < R, so
-    // m*N can reach R²). Needs WideningMul for correctness at key sizes.
+    // m*N can reach R^2). Needs WideningMul for correctness at key sizes.
     let t = (a_mont + m * modulus) >> r_bits;
 
     // Step 3: Final reduction
@@ -306,8 +321,198 @@ where
     basic_from_montgomery(product, modulus, n_prime, r_bits)
 }
 
+// ---------------------------------------------------------------------------
+// Wide-REDC private helpers (R = 2^W, full type width)
+// ---------------------------------------------------------------------------
+
+/// Bit width of type T (e.g. 32 for u32, 128 for FixedUInt<u32,4>).
+const fn type_bit_width<T>() -> usize {
+    core::mem::size_of::<T>() * 8
+}
+
+/// Modular doubling: (val + val) mod modulus, handling overflow.
+fn mod_double<T>(val: T, modulus: T) -> T
+where
+    T: Copy + PartialOrd + num_traits::ops::overflowing::OverflowingAdd + num_traits::WrappingSub,
+{
+    let (doubled, overflow) = val.overflowing_add(&val);
+    if overflow || doubled >= modulus {
+        doubled.wrapping_sub(&modulus)
+    } else {
+        doubled
+    }
+}
+
+/// Newton's method for N' = -N^{-1} mod 2^W.
+///
+/// Invariant: after each iteration, `modulus * x ≡ 1 (mod 2^precision)`.
+/// We return `0 - x` so that `modulus * N' ≡ -1 (mod 2^W)`.
+fn compute_n_prime_newton<T>(modulus: T, w: usize) -> T
+where
+    T: Copy
+        + num_traits::One
+        + num_traits::Zero
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub
+        + num_traits::WrappingAdd,
+{
+    let two = T::one().wrapping_add(&T::one());
+    let mut x = T::one(); // modulus * 1 ≡ 1 (mod 2) for odd modulus
+    let mut precision = 1usize;
+    while precision < w {
+        // x = x * (2 - modulus * x)   mod 2^(2*precision)
+        x = x.wrapping_mul(&two.wrapping_sub(&modulus.wrapping_mul(&x)));
+        precision *= 2;
+    }
+    // N' = -x mod 2^W  (wrapping_sub from 0 gives two's complement negation)
+    T::zero().wrapping_sub(&x)
+}
+
+/// Compute R mod N = 2^W mod N via W modular doublings starting from 1.
+fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
+where
+    T: Copy
+        + num_traits::One
+        + PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingSub,
+{
+    let mut val = T::one();
+    for _ in 0..w {
+        val = mod_double(val, modulus);
+    }
+    val
+}
+
+/// Compute R^2 mod N via W more modular doublings from (R mod N).
+fn compute_r2_mod_n<T>(r_mod_n: T, modulus: T, w: usize) -> T
+where
+    T: Copy + PartialOrd + num_traits::ops::overflowing::OverflowingAdd + num_traits::WrappingSub,
+{
+    let mut val = r_mod_n;
+    for _ in 0..w {
+        val = mod_double(val, modulus);
+    }
+    val
+}
+
+/// REDC on a double-width input (t_lo, t_hi).
+///
+/// Computes  (t_lo + t_hi * 2^W) * R^{-1}  mod N.
+fn wide_redc<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub,
+{
+    // m = t_lo * N'  (mod 2^W -- wrapping mul gives that for free)
+    let m = t_lo.wrapping_mul(&n_prime);
+
+    // (m_lo, m_hi) = m * modulus  (full double-width product)
+    let (m_lo, m_hi) = m.wide_mul(&modulus);
+
+    // low half:  t_lo + m_lo  -- the low W bits cancel by construction,
+    // we only need the carry.
+    let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
+
+    // high half:  t_hi + m_hi + carry1
+    let (mut result, carry2) = t_hi.overflowing_add(&m_hi);
+
+    let mut carry3 = false;
+    if carry1 {
+        let (r2, c3) = result.overflowing_add(&T::one());
+        result = r2;
+        carry3 = c3;
+    }
+
+    let extra_bit = carry2 || carry3;
+
+    if extra_bit || result >= modulus {
+        result.wrapping_sub(&modulus)
+    } else {
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wide-REDC Montgomery multiply helper
+// ---------------------------------------------------------------------------
+
+/// Montgomery multiplication using wide REDC: REDC(a_mont * b_mont).
+fn wide_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T) -> T
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub,
+{
+    let (lo, hi) = a_mont.wide_mul(&b_mont);
+    wide_redc(lo, hi, modulus, n_prime)
+}
+
+// ---------------------------------------------------------------------------
+// Public API: mod_mul / mod_exp using wide REDC
+// ---------------------------------------------------------------------------
+
+/// Compute N' for the wide-REDC path (R = 2^W) using the specified method.
+///
+/// `Newton` uses wrapping arithmetic and works directly with R = 2^W.
+/// The other methods (`TrialSearch`, `ExtendedEuclidean`, `HenselsLifting`) use
+/// `basic_compute_montgomery_params_with_method` (where R is the smallest power
+/// of 2 exceeding the modulus), then re-derive N' for full-width R via Newton.
+fn wide_n_prime<T>(modulus: T, method: NPrimeMethod) -> Option<T>
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq
+        + PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        // Legacy methods need these for basic_compute_montgomery_params_with_method
+        + core::ops::Shl<usize, Output = T>
+        + core::ops::Div<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Mul<Output = T>
+        + core::ops::Rem<Output = T>
+        + core::ops::Add<Output = T>
+        + core::ops::BitAnd<Output = T>,
+{
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
+    let w = type_bit_width::<T>();
+    match method {
+        NPrimeMethod::Newton => Some(compute_n_prime_newton(modulus, w)),
+        // The legacy methods validate the modulus through the old param path,
+        // then we compute N' for R = 2^W via Newton anyway (the old R doesn't
+        // apply to wide REDC).  This preserves the "returns None on bad input"
+        // behaviour of each legacy method.
+        other => {
+            // Will return None for even modulus, zero, etc.
+            basic_compute_montgomery_params_with_method(modulus, other)?;
+            Some(compute_n_prime_newton(modulus, w))
+        }
+    }
+}
+
 /// Complete Montgomery modular multiplication with method selection (Basic): A * B mod N
-/// Returns None if Montgomery parameter computation fails
+///
+/// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
+/// `method` selects how N' is validated/computed — see [`NPrimeMethod`].
+/// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_mul_with_method<T>(
     a: T,
     b: T,
@@ -320,27 +525,43 @@ where
         + num_traits::One
         + PartialEq
         + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        // Legacy methods need these for basic_compute_montgomery_params_with_method
         + core::ops::Shl<usize, Output = T>
         + core::ops::Div<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::BitAnd<Output = T>
-        + num_traits::ops::wrapping::WrappingAdd
-        + num_traits::ops::wrapping::WrappingSub
-        + core::ops::Shr<usize, Output = T>
-        + crate::parity::Parity,
+        + core::ops::Add<Output = T>
+        + core::ops::BitAnd<Output = T>,
 {
-    let (r, _r_inv, n_prime, r_bits) =
-        basic_compute_montgomery_params_with_method(modulus, method)?;
-    let a_mont = basic_to_montgomery(a, modulus, r);
-    let b_mont = basic_to_montgomery(b, modulus, r);
-    let result_mont = basic_montgomery_mul(a_mont, b_mont, modulus, n_prime, r_bits);
-    Some(basic_from_montgomery(result_mont, modulus, n_prime, r_bits))
+    let n_prime = wide_n_prime(modulus, method)?;
+    let w = type_bit_width::<T>();
+    let r_mod_n = compute_r_mod_n(modulus, w);
+    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+    // Convert to Montgomery form via REDC(a * R^2)
+    let (lo, hi) = a.wide_mul(&r2_mod_n);
+    let a_m = wide_redc(lo, hi, modulus, n_prime);
+    let (lo, hi) = b.wide_mul(&r2_mod_n);
+    let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+    // Multiply in Montgomery domain
+    let r_m = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
+
+    // Convert back: REDC(r_m, 0)
+    Some(wide_redc(r_m, T::zero(), modulus, n_prime))
 }
 
 /// Complete Montgomery modular multiplication (Basic): A * B mod N
-/// Returns None if Montgomery parameter computation fails
+///
+/// Uses wide REDC (R = 2^W) with Newton's method for N'.
+/// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_mul<T>(a: T, b: T, modulus: T) -> Option<T>
 where
     T: Copy
@@ -348,25 +569,41 @@ where
         + num_traits::One
         + PartialEq
         + PartialOrd
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::Div<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::BitAnd<Output = T>
-        + num_traits::ops::wrapping::WrappingAdd
-        + num_traits::ops::wrapping::WrappingSub
-        + core::ops::Shr<usize, Output = T>
-        + crate::parity::Parity,
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity,
 {
-    basic_montgomery_mod_mul_with_method(a, b, modulus, NPrimeMethod::default())
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
+    let w = type_bit_width::<T>();
+    let n_prime = compute_n_prime_newton(modulus, w);
+    let r_mod_n = compute_r_mod_n(modulus, w);
+    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+    // Convert to Montgomery form via REDC(a * R^2)
+    let (lo, hi) = a.wide_mul(&r2_mod_n);
+    let a_m = wide_redc(lo, hi, modulus, n_prime);
+    let (lo, hi) = b.wide_mul(&r2_mod_n);
+    let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+    // Multiply in Montgomery domain
+    let r_m = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
+
+    // Convert back: REDC(r_m, 0)
+    Some(wide_redc(r_m, T::zero(), modulus, n_prime))
 }
 
 /// Montgomery-based modular exponentiation with method selection (Basic): base^exponent mod modulus
-/// Uses Montgomery arithmetic for efficient repeated multiplication
-/// Returns None if Montgomery parameter computation fails
+///
+/// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
+/// `method` selects how N' is validated/computed — see [`NPrimeMethod`].
+/// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_exp_with_method<T>(
-    mut base: T,
+    base: T,
     exponent: T,
     modulus: T,
     method: NPrimeMethod,
@@ -375,79 +612,107 @@ where
     T: Copy
         + num_traits::Zero
         + num_traits::One
-        + crate::parity::Parity
         + PartialEq
         + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::ShrAssign<usize>
+        // Legacy methods need these for basic_compute_montgomery_params_with_method
         + core::ops::Shl<usize, Output = T>
         + core::ops::Div<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::BitAnd<Output = T>
-        + num_traits::ops::wrapping::WrappingAdd
-        + num_traits::ops::wrapping::WrappingSub
-        + core::ops::Shr<usize, Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::Add<Output = T>
+        + core::ops::BitAnd<Output = T>,
 {
-    // Compute Montgomery parameters using specified method
-    let (r, _r_inv, n_prime, r_bits) =
-        basic_compute_montgomery_params_with_method(modulus, method)?;
+    let n_prime = wide_n_prime(modulus, method)?;
+    let w = type_bit_width::<T>();
+    let r_mod_n = compute_r_mod_n(modulus, w);
+    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
 
-    // Convert base to Montgomery form
-    base = basic_to_montgomery(base % modulus, modulus, r); // Reduce base first
+    // 1 in Montgomery form = REDC(1 * R^2)
+    let (lo, hi) = T::one().wide_mul(&r2_mod_n);
+    let one_mont = wide_redc(lo, hi, modulus, n_prime);
 
-    // Montgomery form of 1 (the initial result)
-    let mut result = basic_to_montgomery(T::one(), modulus, r);
-
-    // Copy exponent for manipulation
+    let (lo, hi) = base.wide_mul(&r2_mod_n);
+    let mut base_mont = wide_redc(lo, hi, modulus, n_prime);
+    let mut result = one_mont;
     let mut exp = exponent;
 
-    // Binary exponentiation using Montgomery multiplication
     while exp > T::zero() {
-        // If exponent is odd, multiply result by current base power
         if exp.is_odd() {
-            result = basic_montgomery_mul(result, base, modulus, n_prime, r_bits);
+            result = wide_montgomery_mul(result, base_mont, modulus, n_prime);
         }
-
-        // Square the base for next iteration
         exp >>= 1;
         if exp > T::zero() {
-            base = basic_montgomery_mul(base, base, modulus, n_prime, r_bits);
+            base_mont = wide_montgomery_mul(base_mont, base_mont, modulus, n_prime);
         }
     }
 
-    // Convert result back from Montgomery form
-    Some(basic_from_montgomery(result, modulus, n_prime, r_bits))
+    Some(wide_redc(result, T::zero(), modulus, n_prime))
 }
 
 /// Montgomery-based modular exponentiation (Basic): base^exponent mod modulus
-/// Uses Montgomery arithmetic for efficient repeated multiplication
-/// Returns None if Montgomery parameter computation fails
+///
+/// Uses wide REDC (R = 2^W) with Newton's method for N'.
+/// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_exp<T>(base: T, exponent: T, modulus: T) -> Option<T>
 where
     T: Copy
         + num_traits::Zero
         + num_traits::One
-        + crate::parity::Parity
         + PartialEq
         + PartialOrd
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::Div<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::BitAnd<Output = T>
-        + num_traits::ops::wrapping::WrappingAdd
-        + num_traits::ops::wrapping::WrappingSub
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>,
 {
-    basic_montgomery_mod_exp_with_method(base, exponent, modulus, NPrimeMethod::default())
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
+    let w = type_bit_width::<T>();
+    let n_prime = compute_n_prime_newton(modulus, w);
+    let r_mod_n = compute_r_mod_n(modulus, w);
+    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+    // 1 in Montgomery form = REDC(1 * R^2)
+    let (lo, hi) = T::one().wide_mul(&r2_mod_n);
+    let one_mont = wide_redc(lo, hi, modulus, n_prime);
+
+    let (lo, hi) = base.wide_mul(&r2_mod_n);
+    let mut base_mont = wide_redc(lo, hi, modulus, n_prime);
+    let mut result = one_mont;
+    let mut exp = exponent;
+
+    while exp > T::zero() {
+        if exp.is_odd() {
+            result = wide_montgomery_mul(result, base_mont, modulus, n_prime);
+        }
+        exp >>= 1;
+        if exp > T::zero() {
+            base_mont = wide_montgomery_mul(base_mont, base_mont, modulus, n_prime);
+        }
+    }
+
+    Some(wide_redc(result, T::zero(), modulus, n_prime))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- Old basic_mont tests (param computation, N' methods, etc.) ----------
 
     #[test]
     fn test_basic_compute_n_prime_trial_search_failure() {
@@ -693,5 +958,242 @@ mod tests {
                 r
             );
         }
+    }
+
+    // -- Wide REDC helper tests (moved from wide_mont.rs) --------------------
+
+    #[test]
+    fn test_type_bit_width() {
+        assert_eq!(type_bit_width::<u8>(), 8);
+        assert_eq!(type_bit_width::<u16>(), 16);
+        assert_eq!(type_bit_width::<u32>(), 32);
+        assert_eq!(type_bit_width::<u64>(), 64);
+    }
+
+    #[test]
+    fn test_mod_double() {
+        // Normal case: 5+5=10, 10 < 13 -> 10
+        assert_eq!(mod_double(5u8, 13), 10);
+        // Needs reduction: 8+8=16 >= 13 -> 3
+        assert_eq!(mod_double(8u8, 13), 3);
+        // Overflow case: 200+200 wraps in u8, result should still be correct
+        // 400 mod 201 = 400 - 201 = 199
+        // In u8: 200+200 = 144 (wrap), overflow=true -> 144 - 201 wraps to 199
+        assert_eq!(mod_double(200u8, 201), 199);
+        // Edge: 0 doubled is 0
+        assert_eq!(mod_double(0u8, 13), 0);
+    }
+
+    #[test]
+    fn test_compute_n_prime_newton() {
+        // For several small odd moduli, verify N * N' == -1 (mod 2^W)
+        let test_moduli: &[u8] = &[3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 255];
+        for &n in test_moduli {
+            let np = compute_n_prime_newton(n, 8);
+            // N * N' should wrap to 0xFF (which is -1 mod 256)
+            let product = n.wrapping_mul(np);
+            assert_eq!(
+                product, 0xFF,
+                "n={n}: n*n_prime={product:#04x}, expected 0xFF"
+            );
+        }
+
+        // Also check u32
+        let np32 = compute_n_prime_newton(13u32, 32);
+        assert_eq!(13u32.wrapping_mul(np32), u32::MAX);
+    }
+
+    #[test]
+    fn test_compute_r_mod_n() {
+        // R = 2^8 = 256 for u8
+        // 256 mod 13 = 256 - 19*13 = 256-247 = 9
+        assert_eq!(compute_r_mod_n(13u8, 8), 9);
+        // 256 mod 255 = 1
+        assert_eq!(compute_r_mod_n(255u8, 8), 1);
+        // 256 mod 3 = 1
+        assert_eq!(compute_r_mod_n(3u8, 8), 1);
+
+        // R = 2^32 for u32: 2^32 mod 13 = 4294967296 mod 13 = 9
+        assert_eq!(compute_r_mod_n(13u32, 32), 9);
+    }
+
+    #[test]
+    fn test_wide_redc() {
+        // With u8, R=256, N=13
+        // REDC(35, 0) should give 35 * R^{-1} mod 13
+        // R^{-1} mod 13: R=256, 256 mod 13 = 9, inv(9,13)=3 (9*3=27==1 mod 13)
+        // So REDC(35,0) = 35*3 mod 13 = 105 mod 13 = 1
+        let n: u8 = 13;
+        let n_prime = compute_n_prime_newton(n, 8);
+        let result = wide_redc(35u8, 0u8, n, n_prime);
+        assert_eq!(result, 1);
+    }
+
+    // -- Round-trip tests ----------------------------------------------------
+
+    #[test]
+    fn test_wide_montgomery_roundtrip() {
+        let modulus = 13u8;
+        let w = type_bit_width::<u8>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+        for a in 0u8..13 {
+            let (lo, hi) = a.wide_mul(&r2_mod_n);
+            let a_m = wide_redc(lo, hi, modulus, n_prime);
+            let back = wide_redc(a_m, 0u8, modulus, n_prime);
+            assert_eq!(back, a, "roundtrip failed for a={a}");
+        }
+    }
+
+    #[test]
+    fn test_wide_montgomery_roundtrip_u32() {
+        let modulus = 0xFFFF_FFF1u32; // large odd u32
+        let w = type_bit_width::<u32>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+        let test_vals = [0u32, 1, 2, 100, modulus - 1, modulus - 2, 0x7FFF_FFFF];
+        for &a in &test_vals {
+            let (lo, hi) = a.wide_mul(&r2_mod_n);
+            let a_m = wide_redc(lo, hi, modulus, n_prime);
+            let back = wide_redc(a_m, 0u32, modulus, n_prime);
+            assert_eq!(back, a, "roundtrip failed for a={a:#x}");
+        }
+    }
+
+    // -- Mod mul tests -------------------------------------------------------
+
+    #[test]
+    fn test_wide_mod_mul_u8_exhaustive() {
+        let modulus = 13u8;
+        for a in 0u8..13 {
+            for b in 0u8..13 {
+                let expected = ((a as u16 * b as u16) % 13) as u8;
+                let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+                assert_eq!(
+                    got, expected,
+                    "{a}*{b} mod 13: got {got}, expected {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_wide_mod_mul_u32() {
+        // Compare against basic_mod_mul for a range of values with a large modulus
+        let modulus = 0xFFFF_FFF1u32;
+        let vals = [0u32, 1, 2, 7, 1000, 0x7FFF_FFFF, modulus - 1, modulus - 2];
+        for &a in &vals {
+            for &b in &vals {
+                let expected = crate::mul::basic_mod_mul(a, b, modulus);
+                let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+                assert_eq!(
+                    got, expected,
+                    "{a:#x}*{b:#x} mod {modulus:#x}: got {got:#x}, expected {expected:#x}"
+                );
+            }
+        }
+    }
+
+    // -- Mod exp tests -------------------------------------------------------
+
+    #[test]
+    fn test_wide_mod_exp_small() {
+        let modulus = 13u8;
+        for base in 0u8..13 {
+            for exp in 0u8..20 {
+                let expected = crate::exp::basic_mod_exp(base, exp, modulus);
+                let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+                assert_eq!(
+                    got, expected,
+                    "{base}^{exp} mod 13: got {got}, expected {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_wide_mod_exp_u32() {
+        let modulus = 0xFFFF_FFF1u32;
+        // 2^100 mod modulus
+        let expected = crate::exp::basic_mod_exp(2u32, 100, modulus);
+        let got = basic_montgomery_mod_exp(2, 100, modulus).unwrap();
+        assert_eq!(got, expected);
+
+        // 3^1000 mod modulus
+        let expected = crate::exp::basic_mod_exp(3u32, 1000, modulus);
+        let got = basic_montgomery_mod_exp(3, 1000, modulus).unwrap();
+        assert_eq!(got, expected);
+
+        // (modulus-1)^(modulus-2) mod modulus  (Fermat inverse if prime-ish)
+        let expected = crate::exp::basic_mod_exp(modulus - 1, modulus - 2, modulus);
+        let got = basic_montgomery_mod_exp(modulus - 1, modulus - 2, modulus).unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_wide_mod_exp_large_u64() {
+        // Values that would overflow with the old mod_mul-based approach
+        let modulus = 0xFFFF_FFFF_FFFF_FFC5u64; // large odd u64
+        let base = 0xDEAD_BEEF_CAFE_BABEu64;
+        let exp = 0x1234_5678u64;
+        let expected = crate::exp::basic_mod_exp(base, exp, modulus);
+        let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+        assert_eq!(got, expected);
+    }
+
+    // -- Error paths ---------------------------------------------------------
+
+    #[test]
+    fn test_wide_params_even_modulus() {
+        assert!(basic_montgomery_mod_mul(2u32, 3u32, 4u32).is_none());
+        assert!(basic_montgomery_mod_mul(2u32, 3u32, 0u32).is_none());
+    }
+
+    #[test]
+    fn test_wide_mod_mul_even_modulus() {
+        assert!(basic_montgomery_mod_mul(2u32, 3u32, 4u32).is_none());
+    }
+
+    #[test]
+    fn test_wide_mod_exp_even_modulus() {
+        assert!(basic_montgomery_mod_exp(2u32, 3u32, 4u32).is_none());
+    }
+
+    // -- FixedUInt test ------------------------------------------------------
+
+    #[test]
+    fn test_wide_fixed_bigint() {
+        use fixed_bigint::FixedUInt;
+        type U128 = FixedUInt<u32, 4>;
+
+        // Pick a 128-bit-ish odd modulus close to type max
+        let modulus = !U128::from(0u64) - U128::from(58u64); // 2^128 - 59 (odd)
+
+        // Round-trip test via wide helpers directly
+        let w = type_bit_width::<U128>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+        let a = U128::from(0xDEAD_BEEF_u64);
+        let (lo, hi) = a.wide_mul(&r2_mod_n);
+        let a_m = wide_redc(lo, hi, modulus, n_prime);
+        let back = wide_redc(a_m, U128::from(0u64), modulus, n_prime);
+        assert_eq!(back, a);
+
+        // Multiplication test: compare with basic_mod_mul
+        let b = U128::from(0xCAFE_BABE_u64);
+        let expected = crate::mul::basic_mod_mul(a, b, modulus);
+        let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+        assert_eq!(got, expected);
+
+        // Exponentiation test
+        let base = U128::from(42u64);
+        let exp = U128::from(1000u64);
+        let expected = crate::exp::basic_mod_exp(base, exp, modulus);
+        let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+        assert_eq!(got, expected);
     }
 }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -300,7 +300,6 @@ where
 ///
 /// Uses R = 2^W (full type width) semantics with overflow-free reduction.
 /// The N' parameter must be computed for R = 2^W (e.g., via Newton's method).
-#[allow(dead_code)] // Public API for external use
 pub fn wide_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
@@ -550,23 +549,19 @@ where
         + num_traits::WrappingMul
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
-        + Parity,
+        + Parity
+        + core::ops::Rem<Output = T>,
 {
     // All methods use Newton internally, so delegate to the simple version
     basic_montgomery_mod_mul(a, b, modulus)
 }
 
-/// Reduce value modulo modulus using repeated subtraction.
-/// For values close to modulus this is efficient; for very large values
-/// callers should pre-reduce before calling Montgomery functions.
-fn reduce_mod<T>(mut val: T, modulus: T) -> T
+/// Reduce value modulo modulus.
+fn reduce_mod<T>(val: T, modulus: T) -> T
 where
-    T: Copy + PartialOrd + num_traits::WrappingSub,
+    T: Copy + core::ops::Rem<Output = T>,
 {
-    while val >= modulus {
-        val = val.wrapping_sub(&modulus);
-    }
-    val
+    val % modulus
 }
 
 /// Complete Montgomery modular multiplication (Basic): A * B mod N
@@ -586,7 +581,8 @@ where
         + num_traits::WrappingMul
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
-        + Parity,
+        + Parity
+        + core::ops::Rem<Output = T>,
 {
     if modulus == T::zero() || modulus.is_even() {
         return None;
@@ -637,6 +633,7 @@ where
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
         + Parity
+        + core::ops::Rem<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>,
 {
@@ -662,6 +659,7 @@ where
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
         + Parity
+        + core::ops::Rem<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>,
 {

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -370,32 +370,54 @@ where
     T::zero().wrapping_sub(&x)
 }
 
+/// Compute (val * 2^w) mod N via w modular doublings.
+fn mod_exp2<T>(val: T, modulus: T, w: usize) -> T
+where
+    T: Copy
+        + PartialEq
+        + PartialOrd
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingSub,
+{
+    // For modulus == 1, any value mod 1 == 0
+    if modulus == T::one() {
+        return T::zero();
+    }
+    let mut result = val;
+    for _ in 0..w {
+        result = mod_double(result, modulus);
+    }
+    result
+}
+
 /// Compute R mod N = 2^W mod N via W modular doublings starting from 1.
 fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
 where
     T: Copy
-        + num_traits::One
+        + PartialEq
         + PartialOrd
+        + num_traits::Zero
+        + num_traits::One
         + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::WrappingSub,
 {
-    let mut val = T::one();
-    for _ in 0..w {
-        val = mod_double(val, modulus);
-    }
-    val
+    mod_exp2(T::one(), modulus, w)
 }
 
 /// Compute R^2 mod N via W more modular doublings from (R mod N).
 fn compute_r2_mod_n<T>(r_mod_n: T, modulus: T, w: usize) -> T
 where
-    T: Copy + PartialOrd + num_traits::ops::overflowing::OverflowingAdd + num_traits::WrappingSub,
+    T: Copy
+        + PartialEq
+        + PartialOrd
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingSub,
 {
-    let mut val = r_mod_n;
-    for _ in 0..w {
-        val = mod_double(val, modulus);
-    }
-    val
+    mod_exp2(r_mod_n, modulus, w)
 }
 
 /// REDC on a double-width input (t_lo, t_hi).

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -209,7 +209,8 @@ where
 }
 
 /// Montgomery parameter computation (Basic) with default method
-/// Computes R, R^(-1) mod N, N', and R bit length for Montgomery arithmetic using trial search
+/// Computes R, R^(-1) mod N, N', and R bit length for Montgomery arithmetic
+/// Uses the default NPrimeMethod (Newton).
 /// Returns None if parameter computation fails
 pub fn basic_compute_montgomery_params<T>(modulus: T) -> Option<(T, T, T, usize)>
 where

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -315,6 +315,11 @@ where
 }
 
 /// Montgomery multiplication (Basic): (a * R) * (b * R) -> (a * b * R) mod N
+///
+/// **Warning**: This building-block function uses the legacy reduction path which
+/// can overflow for large moduli (see `basic_from_montgomery` warning). For
+/// overflow-free multiplication, use [`basic_montgomery_mod_mul`] which uses
+/// wide-REDC internally.
 pub fn basic_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
 where
     T: Copy
@@ -557,6 +562,10 @@ where
 }
 
 /// Reduce value modulo modulus.
+///
+/// **Note**: This function assumes unsigned types. For signed types, the `%`
+/// operator may return negative values, which would violate the `[0, modulus)`
+/// range required by Montgomery arithmetic.
 fn reduce_mod<T>(val: T, modulus: T) -> T
 where
     T: Copy + core::ops::Rem<Output = T>,

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -420,9 +420,35 @@ where
     mod_exp2(r_mod_n, modulus, w)
 }
 
+/// Accumulate the high half with carries from low-half addition.
+///
+/// Given the low-half carry `carry1`, adds it to `result` and returns the
+/// combined extra-bit flag (true if there was overflow from any addition).
+///
+/// Invariants maintained:
+/// - `result` is in range [0, modulus + 1] on entry (sum of two values < modulus plus carry)
+/// - Returns (result + carry1, extra_bit) where extra_bit indicates overflow
+#[inline]
+fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
+where
+    T: Copy + num_traits::One + num_traits::ops::overflowing::OverflowingAdd,
+{
+    if carry1 {
+        let (r2, carry3) = result.overflowing_add(&T::one());
+        (r2, carry2 || carry3)
+    } else {
+        (result, carry2)
+    }
+}
+
 /// REDC on a double-width input (t_lo, t_hi).
 ///
 /// Computes  (t_lo + t_hi * 2^W) * R^{-1}  mod N.
+///
+/// Invariants:
+/// - Inputs t_lo, t_hi represent a value T < N * R (product of two values < N)
+/// - modulus is odd and non-zero
+/// - n_prime = -N^{-1} mod 2^W
 fn wide_redc<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
@@ -445,16 +471,8 @@ where
     let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
 
     // high half:  t_hi + m_hi + carry1
-    let (mut result, carry2) = t_hi.overflowing_add(&m_hi);
-
-    let mut carry3 = false;
-    if carry1 {
-        let (r2, c3) = result.overflowing_add(&T::one());
-        result = r2;
-        carry3 = c3;
-    }
-
-    let extra_bit = carry2 || carry3;
+    let (result, carry2) = t_hi.overflowing_add(&m_hi);
+    let (result, extra_bit) = accumulate_high_half_carry(result, carry1, carry2);
 
     if extra_bit || result >= modulus {
         result.wrapping_sub(&modulus)
@@ -487,35 +505,6 @@ where
 // Public API: mod_mul / mod_exp using wide REDC
 // ---------------------------------------------------------------------------
 
-/// Compute N' for the wide-REDC path (R = 2^W).
-///
-/// All methods use Newton's method internally since it's designed for R = 2^W
-/// with wrapping arithmetic. The `method` parameter is accepted for API
-/// compatibility but doesn't affect the computation.
-///
-/// Returns None if modulus is zero or even.
-fn wide_n_prime<T>(modulus: T, _method: NPrimeMethod) -> Option<T>
-where
-    T: Copy
-        + num_traits::Zero
-        + num_traits::One
-        + PartialEq
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + Parity,
-{
-    if modulus == T::zero() || modulus.is_even() {
-        return None;
-    }
-    let w = type_bit_width::<T>();
-    // All methods use Newton for wide-REDC since it's designed for R = 2^W.
-    // The modulus is already validated (odd, non-zero) above, so Newton will succeed.
-    // We don't call the legacy param path because it can hang when modulus = T::MAX
-    // (the `while r <= modulus` loop never terminates for max values).
-    Some(compute_n_prime_newton(modulus, w))
-}
-
 /// Complete Montgomery modular multiplication with method selection (Basic): A * B mod N
 ///
 /// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
@@ -526,7 +515,7 @@ pub fn basic_montgomery_mod_mul_with_method<T>(
     a: T,
     b: T,
     modulus: T,
-    method: NPrimeMethod,
+    _method: NPrimeMethod,
 ) -> Option<T>
 where
     T: Copy
@@ -539,32 +528,10 @@ where
         + num_traits::WrappingMul
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
-        + Parity
-        // Legacy methods need these for basic_compute_montgomery_params_with_method
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::Div<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + Parity,
 {
-    let n_prime = wide_n_prime(modulus, method)?;
-    let w = type_bit_width::<T>();
-    let r_mod_n = compute_r_mod_n(modulus, w);
-    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
-
-    // Convert to Montgomery form via REDC(a * R^2)
-    let (lo, hi) = a.wide_mul(&r2_mod_n);
-    let a_m = wide_redc(lo, hi, modulus, n_prime);
-    let (lo, hi) = b.wide_mul(&r2_mod_n);
-    let b_m = wide_redc(lo, hi, modulus, n_prime);
-
-    // Multiply in Montgomery domain
-    let r_m = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
-
-    // Convert back: REDC(r_m, 0)
-    Some(wide_redc(r_m, T::zero(), modulus, n_prime))
+    // All methods use Newton internally, so delegate to the simple version
+    basic_montgomery_mod_mul(a, b, modulus)
 }
 
 /// Complete Montgomery modular multiplication (Basic): A * B mod N
@@ -616,7 +583,7 @@ pub fn basic_montgomery_mod_exp_with_method<T>(
     base: T,
     exponent: T,
     modulus: T,
-    method: NPrimeMethod,
+    _method: NPrimeMethod,
 ) -> Option<T>
 where
     T: Copy
@@ -631,41 +598,10 @@ where
         + num_traits::WrappingSub
         + Parity
         + core::ops::Shr<usize, Output = T>
-        + core::ops::ShrAssign<usize>
-        // Legacy methods need these for basic_compute_montgomery_params_with_method
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::Div<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::ShrAssign<usize>,
 {
-    let n_prime = wide_n_prime(modulus, method)?;
-    let w = type_bit_width::<T>();
-    let r_mod_n = compute_r_mod_n(modulus, w);
-    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
-
-    // 1 in Montgomery form = REDC(1 * R^2)
-    let (lo, hi) = T::one().wide_mul(&r2_mod_n);
-    let one_mont = wide_redc(lo, hi, modulus, n_prime);
-
-    let (lo, hi) = base.wide_mul(&r2_mod_n);
-    let mut base_mont = wide_redc(lo, hi, modulus, n_prime);
-    let mut result = one_mont;
-    let mut exp = exponent;
-
-    while exp > T::zero() {
-        if exp.is_odd() {
-            result = wide_montgomery_mul(result, base_mont, modulus, n_prime);
-        }
-        exp >>= 1;
-        if exp > T::zero() {
-            base_mont = wide_montgomery_mul(base_mont, base_mont, modulus, n_prime);
-        }
-    }
-
-    Some(wide_redc(result, T::zero(), modulus, n_prime))
+    // All methods use Newton internally, so delegate to the simple version
+    basic_montgomery_mod_exp(base, exponent, modulus)
 }
 
 /// Montgomery-based modular exponentiation (Basic): base^exponent mod modulus

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -19,7 +19,8 @@ pub enum NPrimeMethod {
     HenselsLifting,
     /// Newton's method - O(log W) complexity, works with R = 2^W (full type width).
     /// Uses wrapping arithmetic so R never needs to be represented explicitly.
-    /// This is the only method compatible with the wide-REDC path.
+    /// This is the method used internally by the wide-REDC path; other methods
+    /// are accepted for API compatibility but all use Newton internally.
     #[default]
     Newton,
 }
@@ -464,55 +465,40 @@ where
 // Public API: mod_mul / mod_exp using wide REDC
 // ---------------------------------------------------------------------------
 
-/// Compute N' for the wide-REDC path (R = 2^W) using the specified method.
+/// Compute N' for the wide-REDC path (R = 2^W).
 ///
-/// `Newton` uses wrapping arithmetic and works directly with R = 2^W.
-/// The other methods (`TrialSearch`, `ExtendedEuclidean`, `HenselsLifting`) use
-/// `basic_compute_montgomery_params_with_method` (where R is the smallest power
-/// of 2 exceeding the modulus), then re-derive N' for full-width R via Newton.
-fn wide_n_prime<T>(modulus: T, method: NPrimeMethod) -> Option<T>
+/// All methods use Newton's method internally since it's designed for R = 2^W
+/// with wrapping arithmetic. The `method` parameter is accepted for API
+/// compatibility but doesn't affect the computation.
+///
+/// Returns None if modulus is zero or even.
+fn wide_n_prime<T>(modulus: T, _method: NPrimeMethod) -> Option<T>
 where
     T: Copy
         + num_traits::Zero
         + num_traits::One
         + PartialEq
-        + PartialOrd
-        + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::WrappingMul
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
-        + Parity
-        // Legacy methods need these for basic_compute_montgomery_params_with_method
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::Div<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + Parity,
 {
     if modulus == T::zero() || modulus.is_even() {
         return None;
     }
     let w = type_bit_width::<T>();
-    match method {
-        NPrimeMethod::Newton => Some(compute_n_prime_newton(modulus, w)),
-        // The legacy methods validate the modulus through the old param path,
-        // then we compute N' for R = 2^W via Newton anyway (the old R doesn't
-        // apply to wide REDC).  This preserves the "returns None on bad input"
-        // behaviour of each legacy method.
-        other => {
-            // Will return None for even modulus, zero, etc.
-            basic_compute_montgomery_params_with_method(modulus, other)?;
-            Some(compute_n_prime_newton(modulus, w))
-        }
-    }
+    // All methods use Newton for wide-REDC since it's designed for R = 2^W.
+    // The modulus is already validated (odd, non-zero) above, so Newton will succeed.
+    // We don't call the legacy param path because it can hang when modulus = T::MAX
+    // (the `while r <= modulus` loop never terminates for max values).
+    Some(compute_n_prime_newton(modulus, w))
 }
 
 /// Complete Montgomery modular multiplication with method selection (Basic): A * B mod N
 ///
 /// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
-/// `method` selects how N' is validated/computed — see [`NPrimeMethod`].
+/// Note: The `method` parameter is accepted for API compatibility but all methods
+/// use Newton internally since it's designed for R = 2^W.
 /// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_mul_with_method<T>(
     a: T,
@@ -601,7 +587,8 @@ where
 /// Montgomery-based modular exponentiation with method selection (Basic): base^exponent mod modulus
 ///
 /// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
-/// `method` selects how N' is validated/computed — see [`NPrimeMethod`].
+/// Note: The `method` parameter is accepted for API compatibility but all methods
+/// use Newton internally since it's designed for R = 2^W.
 /// Returns None if modulus is even or zero.
 pub fn basic_montgomery_mod_exp_with_method<T>(
     base: T,

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -157,6 +157,11 @@ where
     // Step 3: Compute N' such that N * N' ≡ -1 (mod R) using selected method
     let n_prime = match method {
         NPrimeMethod::TrialSearch => compute_n_prime_trial_search_constrained(modulus, &r)?,
+        // Newton is mapped to ExtendedEuclidean in the constrained path.
+        // This is because constrained/strict paths use legacy R > N semantics
+        // (R = smallest power of 2 exceeding N), not the wide-REDC R = 2^W approach.
+        // Newton's method is designed for R = 2^W with wrapping arithmetic, so we
+        // fall back to ExtendedEuclidean which computes the same N' = -N^{-1} mod R.
         NPrimeMethod::ExtendedEuclidean | NPrimeMethod::Newton => {
             compute_n_prime_extended_euclidean_constrained(modulus, &r)?
         }

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -157,7 +157,7 @@ where
     // Step 3: Compute N' such that N * N' ≡ -1 (mod R) using selected method
     let n_prime = match method {
         NPrimeMethod::TrialSearch => compute_n_prime_trial_search_constrained(modulus, &r)?,
-        NPrimeMethod::ExtendedEuclidean => {
+        NPrimeMethod::ExtendedEuclidean | NPrimeMethod::Newton => {
             compute_n_prime_extended_euclidean_constrained(modulus, &r)?
         }
         NPrimeMethod::HenselsLifting => {

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_n_prime_method_enum() {
-        // Test that the enum default is ExtendedEuclidean
+        // Test that the enum default is Newton
         assert_eq!(NPrimeMethod::default(), NPrimeMethod::Newton);
     }
 

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -20,6 +20,7 @@ pub use basic_mont::{
     basic_montgomery_mod_mul_with_method,
     basic_montgomery_mul,
     basic_to_montgomery,
+    // wide_from_montgomery available via basic_mont::wide_from_montgomery
 };
 
 // Re-export constrained functions

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -20,7 +20,7 @@ pub use basic_mont::{
     basic_montgomery_mod_mul_with_method,
     basic_montgomery_mul,
     basic_to_montgomery,
-    // wide_from_montgomery available via basic_mont::wide_from_montgomery
+    wide_from_montgomery,
 };
 
 // Re-export constrained functions

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -83,7 +83,8 @@ mod tests {
         let explicit_trial_result =
             basic_compute_montgomery_params_with_method(13u32, NPrimeMethod::TrialSearch).unwrap();
 
-        // Both should produce identical results since TrialSearch is the default
+        // Both should produce identical results (Newton delegates to ExtendedEuclidean
+        // in the legacy param path, which agrees with TrialSearch)
         assert_eq!(default_result, explicit_trial_result);
 
         // Verify the explicit method call produces correct values
@@ -97,7 +98,7 @@ mod tests {
     #[test]
     fn test_n_prime_method_enum() {
         // Test that the enum default is ExtendedEuclidean
-        assert_eq!(NPrimeMethod::default(), NPrimeMethod::ExtendedEuclidean);
+        assert_eq!(NPrimeMethod::default(), NPrimeMethod::Newton);
     }
 
     #[test]
@@ -782,7 +783,7 @@ mod bnum_montgomery_tests {
         bnum::types::U256,
         strict: off, // OverflowingAdd + OverflowingSub is not implemented
         constrained: on,
-        basic: on,
+        basic: off, // basic_montgomery_mod_mul/exp now requires WideMul + OverflowingAdd
     );
 
     montgomery_test_module!(
@@ -806,7 +807,7 @@ mod bnum_montgomery_tests {
         crypto_bigint_patched::U256,
         strict: off, // &T + &T and &T - &T operations missing for Montgomery needs
         constrained: on, // Fixed trait bounds - now works with patched libraries
-        basic: on,
+        basic: on, // patched crate adds OverflowingAdd
     );
 
     montgomery_test_module!(

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -241,7 +241,8 @@ where
         crate::montgomery::NPrimeMethod::TrialSearch => {
             strict_compute_n_prime_trial_search(modulus, &r)?
         }
-        crate::montgomery::NPrimeMethod::ExtendedEuclidean => {
+        crate::montgomery::NPrimeMethod::ExtendedEuclidean
+        | crate::montgomery::NPrimeMethod::Newton => {
             strict_compute_n_prime_extended_euclidean(modulus, &r)?
         }
         crate::montgomery::NPrimeMethod::HenselsLifting => {

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -241,6 +241,11 @@ where
         crate::montgomery::NPrimeMethod::TrialSearch => {
             strict_compute_n_prime_trial_search(modulus, &r)?
         }
+        // Newton is mapped to ExtendedEuclidean in the strict path.
+        // This is because strict/constrained paths use legacy R > N semantics
+        // (R = smallest power of 2 exceeding N), not the wide-REDC R = 2^W approach.
+        // Newton's method is designed for R = 2^W with wrapping arithmetic, so we
+        // fall back to ExtendedEuclidean which computes the same N' = -N^{-1} mod R.
         crate::montgomery::NPrimeMethod::ExtendedEuclidean
         | crate::montgomery::NPrimeMethod::Newton => {
             strict_compute_n_prime_extended_euclidean(modulus, &r)?
@@ -415,7 +420,9 @@ where
 /// Complete Montgomery modular multiplication (Strict): A * B mod N
 /// Uses reference-based operations throughout to minimize copying of large integers
 ///
-/// This function uses the default NPrimeMethod (ExtendedEuclidean) for N' computation.
+/// This function uses the default NPrimeMethod (Newton) for N' computation.
+/// Note: In the strict path, Newton is mapped to ExtendedEuclidean since these
+/// paths use legacy R > N semantics rather than wide-REDC's R = 2^W.
 /// For performance-critical applications, consider using `strict_montgomery_mod_mul_with_method`
 /// to select the optimal N' computation method for your specific use case.
 ///
@@ -525,10 +532,13 @@ where
 /// Uses Montgomery arithmetic for efficient repeated multiplication with reference-based operations
 /// to minimize copying of large integers
 ///
-/// This function uses the default NPrimeMethod (ExtendedEuclidean) for N' computation.
+/// This function uses the default NPrimeMethod (Newton) for N' computation.
+/// Note: In the strict path, Newton is mapped to ExtendedEuclidean since these
+/// paths use legacy R > N semantics rather than wide-REDC's R = 2^W.
 /// For performance-critical applications or specific hardware optimization, consider using
 /// `strict_montgomery_mod_exp_with_method` to select the optimal N' computation method:
-/// - `ExtendedEuclidean`: Balanced performance, good for most use cases (default)
+/// - `Newton`: Default, mapped to ExtendedEuclidean in strict path
+/// - `ExtendedEuclidean`: Balanced performance, good for most use cases
 /// - `TrialSearch`: Simple but O(R) complexity, suitable for small moduli
 /// - `HenselsLifting`: Optimal for R = 2^k, best performance for power-of-2 radix
 ///

--- a/modmath/src/wide_mul.rs
+++ b/modmath/src/wide_mul.rs
@@ -1,9 +1,10 @@
 /// Widening multiplication producing a double-width result.
 ///
-/// When the `wide-mul` feature is enabled, delegates to
-/// `fixed_bigint::patch_num_traits::WideningMul`.
+/// When the `wide-mul` feature is enabled, types implementing
+/// `fixed_bigint::patch_num_traits::WideningMul` use an optimized path,
+/// while primitive integers use the fallback bit-by-bit algorithm.
 ///
-/// Without the feature, falls back to a generic bit-by-bit
+/// Without the feature, all types use the generic bit-by-bit
 /// algorithm using OverflowingAdd and Parity.
 pub trait WideMul {
     fn wide_mul(&self, rhs: &Self) -> (Self, Self)
@@ -11,7 +12,55 @@ pub trait WideMul {
         Self: Sized;
 }
 
-// --- Fallback: bit-by-bit double-and-add ---
+/// Bit-by-bit widening multiplication fallback.
+///
+/// Uses double-and-add algorithm that works with any type supporting
+/// the required traits. Uses `is_zero()` instead of comparison to
+/// minimize trait bounds.
+#[cfg(not(feature = "wide-mul"))]
+fn wide_mul_fallback<T>(lhs: T, rhs: T) -> (T, T)
+where
+    T: num_traits::ops::overflowing::OverflowingAdd
+        + crate::parity::Parity
+        + core::ops::Shr<usize, Output = T>
+        + num_traits::Zero
+        + num_traits::One
+        + Copy,
+{
+    let one = T::one();
+    let mut result_lo = T::zero();
+    let mut result_hi = T::zero();
+    let mut shift_lo = rhs;
+    let mut shift_hi = T::zero();
+    let mut a_rem = lhs;
+
+    while !a_rem.is_zero() {
+        if a_rem.is_odd() {
+            let (new_lo, carry) = result_lo.overflowing_add(&shift_lo);
+            result_lo = new_lo;
+            let (new_hi, _) = result_hi.overflowing_add(&shift_hi);
+            result_hi = new_hi;
+            if carry {
+                let (new_hi, _) = result_hi.overflowing_add(&one);
+                result_hi = new_hi;
+            }
+        }
+        // double the shift register
+        let (new_shift_lo, carry) = shift_lo.overflowing_add(&shift_lo);
+        shift_lo = new_shift_lo;
+        let (new_shift_hi, _) = shift_hi.overflowing_add(&shift_hi);
+        shift_hi = new_shift_hi;
+        if carry {
+            let (new_shift_hi, _) = shift_hi.overflowing_add(&one);
+            shift_hi = new_shift_hi;
+        }
+        a_rem = a_rem >> 1;
+    }
+
+    (result_lo, result_hi)
+}
+
+// --- Without wide-mul: blanket impl using fallback for all types ---
 #[cfg(not(feature = "wide-mul"))]
 impl<T> WideMul for T
 where
@@ -20,46 +69,14 @@ where
         + core::ops::Shr<usize, Output = T>
         + num_traits::Zero
         + num_traits::One
-        + Copy
-        + PartialOrd,
+        + Copy,
 {
     fn wide_mul(&self, rhs: &Self) -> (Self, Self) {
-        let zero = T::zero();
-        let one = T::one();
-        let mut result_lo = zero;
-        let mut result_hi = zero;
-        let mut shift_lo = *rhs;
-        let mut shift_hi = zero;
-        let mut a_rem = *self;
-
-        while a_rem > zero {
-            if a_rem.is_odd() {
-                let (new_lo, carry) = result_lo.overflowing_add(&shift_lo);
-                result_lo = new_lo;
-                let (new_hi, _) = result_hi.overflowing_add(&shift_hi);
-                result_hi = new_hi;
-                if carry {
-                    let (new_hi, _) = result_hi.overflowing_add(&one);
-                    result_hi = new_hi;
-                }
-            }
-            // double the shift register
-            let (new_shift_lo, carry) = shift_lo.overflowing_add(&shift_lo);
-            shift_lo = new_shift_lo;
-            let (new_shift_hi, _) = shift_hi.overflowing_add(&shift_hi);
-            shift_hi = new_shift_hi;
-            if carry {
-                let (new_shift_hi, _) = shift_hi.overflowing_add(&one);
-                shift_hi = new_shift_hi;
-            }
-            a_rem = a_rem >> 1;
-        }
-
-        (result_lo, result_hi)
+        wide_mul_fallback(*self, *rhs)
     }
 }
 
-// --- Optimized: delegate to WideningMul ---
+// --- With wide-mul: optimized impl for WideningMul types ---
 #[cfg(feature = "wide-mul")]
 impl<T> WideMul for T
 where

--- a/modmath/src/wide_mul.rs
+++ b/modmath/src/wide_mul.rs
@@ -17,6 +17,18 @@ pub trait WideMul {
 /// Uses double-and-add algorithm that works with any type supporting
 /// the required traits. Uses `is_zero()` instead of comparison to
 /// minimize trait bounds.
+///
+/// # Overflow invariants
+///
+/// The algorithm maintains a double-width accumulator (result_lo, result_hi) and
+/// a double-width shift register (shift_lo, shift_hi). The product of two W-bit
+/// values fits in 2W bits, so:
+/// - The shift register holds at most `rhs * 2^k` where k is the current bit position,
+///   which is bounded by `rhs * 2^(W-1) < 2^(2W)`.
+/// - The result accumulator holds at most `lhs * rhs < 2^(2W)`.
+///
+/// Therefore, high-half additions that overflow would indicate a bug in the algorithm,
+/// not in the inputs. We assert this in debug builds.
 #[cfg(not(feature = "wide-mul"))]
 fn wide_mul_fallback<T>(lhs: T, rhs: T) -> (T, T)
 where
@@ -38,21 +50,31 @@ where
         if a_rem.is_odd() {
             let (new_lo, carry) = result_lo.overflowing_add(&shift_lo);
             result_lo = new_lo;
-            let (new_hi, _) = result_hi.overflowing_add(&shift_hi);
+            let (new_hi, overflow1) = result_hi.overflowing_add(&shift_hi);
             result_hi = new_hi;
             if carry {
-                let (new_hi, _) = result_hi.overflowing_add(&one);
+                let (new_hi, overflow2) = result_hi.overflowing_add(&one);
                 result_hi = new_hi;
+                // High-half overflow means result > 2^(2W), which is impossible
+                // for the product of two W-bit values.
+                debug_assert!(!overflow2, "wide_mul: result high-half overflow");
+            } else {
+                debug_assert!(!overflow1, "wide_mul: result high-half overflow");
             }
         }
         // double the shift register
         let (new_shift_lo, carry) = shift_lo.overflowing_add(&shift_lo);
         shift_lo = new_shift_lo;
-        let (new_shift_hi, _) = shift_hi.overflowing_add(&shift_hi);
+        let (new_shift_hi, overflow1) = shift_hi.overflowing_add(&shift_hi);
         shift_hi = new_shift_hi;
         if carry {
-            let (new_shift_hi, _) = shift_hi.overflowing_add(&one);
+            let (new_shift_hi, overflow2) = shift_hi.overflowing_add(&one);
             shift_hi = new_shift_hi;
+            // Shift register overflow means shift > 2^(2W), impossible for rhs * 2^k
+            // where k < W.
+            debug_assert!(!overflow2, "wide_mul: shift high-half overflow");
+        } else {
+            debug_assert!(!overflow1, "wide_mul: shift high-half overflow");
         }
         a_rem = a_rem >> 1;
     }

--- a/modmath/src/wide_mul.rs
+++ b/modmath/src/wide_mul.rs
@@ -1,0 +1,189 @@
+/// Widening multiplication producing a double-width result.
+///
+/// When the `wide-mul` feature is enabled, delegates to
+/// `fixed_bigint::patch_num_traits::WideningMul`.
+///
+/// Without the feature, falls back to a generic bit-by-bit
+/// algorithm using OverflowingAdd and Parity.
+pub trait WideMul {
+    fn wide_mul(&self, rhs: &Self) -> (Self, Self)
+    where
+        Self: Sized;
+}
+
+// --- Fallback: bit-by-bit double-and-add ---
+#[cfg(not(feature = "wide-mul"))]
+impl<T> WideMul for T
+where
+    T: num_traits::ops::overflowing::OverflowingAdd
+        + crate::parity::Parity
+        + core::ops::Shr<usize, Output = T>
+        + num_traits::Zero
+        + num_traits::One
+        + Copy
+        + PartialOrd,
+{
+    fn wide_mul(&self, rhs: &Self) -> (Self, Self) {
+        let zero = T::zero();
+        let one = T::one();
+        let mut result_lo = zero;
+        let mut result_hi = zero;
+        let mut shift_lo = *rhs;
+        let mut shift_hi = zero;
+        let mut a_rem = *self;
+
+        while a_rem > zero {
+            if a_rem.is_odd() {
+                let (new_lo, carry) = result_lo.overflowing_add(&shift_lo);
+                result_lo = new_lo;
+                let (new_hi, _) = result_hi.overflowing_add(&shift_hi);
+                result_hi = new_hi;
+                if carry {
+                    let (new_hi, _) = result_hi.overflowing_add(&one);
+                    result_hi = new_hi;
+                }
+            }
+            // double the shift register
+            let (new_shift_lo, carry) = shift_lo.overflowing_add(&shift_lo);
+            shift_lo = new_shift_lo;
+            let (new_shift_hi, _) = shift_hi.overflowing_add(&shift_hi);
+            shift_hi = new_shift_hi;
+            if carry {
+                let (new_shift_hi, _) = shift_hi.overflowing_add(&one);
+                shift_hi = new_shift_hi;
+            }
+            a_rem = a_rem >> 1;
+        }
+
+        (result_lo, result_hi)
+    }
+}
+
+// --- Optimized: delegate to WideningMul ---
+#[cfg(feature = "wide-mul")]
+impl<T> WideMul for T
+where
+    T: Copy + fixed_bigint::patch_num_traits::WideningMul<Output = T>,
+{
+    fn wide_mul(&self, rhs: &Self) -> (Self, Self) {
+        fixed_bigint::patch_num_traits::WideningMul::widening_mul(*self, *rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u8_basics() {
+        assert_eq!(0u8.wide_mul(&0), (0, 0));
+        assert_eq!(1u8.wide_mul(&1), (1, 0));
+        assert_eq!(3u8.wide_mul(&7), (21, 0));
+        // 200 * 200 = 40000 = 0x9C40 -> (0x40, 0x9C) = (64, 156)
+        assert_eq!(200u8.wide_mul(&200), (64, 156));
+        // 255 * 255 = 65025 = 0xFE01 -> (0x01, 0xFE) = (1, 254)
+        assert_eq!(255u8.wide_mul(&255), (1, 254));
+    }
+
+    #[test]
+    fn test_u16_basics() {
+        assert_eq!(0u16.wide_mul(&0), (0, 0));
+        assert_eq!(1000u16.wide_mul(&1000), (16960, 15));
+        assert_eq!(u16::MAX.wide_mul(&u16::MAX), (1, u16::MAX - 1));
+    }
+
+    #[test]
+    fn test_u32_basics() {
+        assert_eq!(0u32.wide_mul(&0), (0, 0));
+        assert_eq!(u32::MAX.wide_mul(&u32::MAX), (1, u32::MAX - 1));
+        assert_eq!(u32::MAX.wide_mul(&2), (u32::MAX - 1, 1));
+    }
+
+    #[test]
+    fn test_u64_basics() {
+        assert_eq!(0u64.wide_mul(&0), (0, 0));
+        assert_eq!(u64::MAX.wide_mul(&u64::MAX), (1, u64::MAX - 1));
+        assert_eq!(u64::MAX.wide_mul(&1), (u64::MAX, 0));
+    }
+
+    #[test]
+    fn test_u8_exhaustive() {
+        for a in 0u16..=255 {
+            for b in 0u16..=255 {
+                let expected = a * b;
+                let (lo, hi) = (a as u8).wide_mul(&(b as u8));
+                let got = (hi as u16) << 8 | (lo as u16);
+                assert_eq!(
+                    got, expected,
+                    "wide_mul({a}, {b}): expected {expected}, got ({lo}, {hi})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_commutativity() {
+        let pairs: &[(u32, u32)] = &[
+            (0, 0),
+            (1, u32::MAX),
+            (12345, 67890),
+            (u32::MAX, u32::MAX),
+            (0x8000_0000, 2),
+        ];
+        for &(a, b) in pairs {
+            assert_eq!(a.wide_mul(&b), b.wide_mul(&a), "commutativity: {a} * {b}");
+        }
+    }
+
+    #[test]
+    fn test_fixed_bigint() {
+        use fixed_bigint::FixedUInt;
+        type U128 = FixedUInt<u32, 4>;
+
+        let a = U128::from(0xDEAD_BEEF_u64);
+        let b = U128::from(0xCAFE_BABE_u64);
+        let (lo, hi) = a.wide_mul(&b);
+
+        // Verify against u128 arithmetic
+        let a128 = 0xDEAD_BEEF_u128;
+        let b128 = 0xCAFE_BABE_u128;
+        let expected = a128 * b128;
+        let expected_lo = expected as u64;
+        let expected_hi = (expected >> 64) as u64;
+
+        assert_eq!(lo, U128::from(expected_lo));
+        assert_eq!(hi, U128::from(expected_hi));
+
+        // Build max = U128::MAX via !0
+        let max = !U128::from(0u64);
+        let one = U128::from(1u64);
+        let (lo, hi) = max.wide_mul(&max);
+        // MAX * MAX = (MAX-1) * 2^128 + 1
+        assert_eq!(lo, one);
+        assert_eq!(hi, max - one);
+
+        // Zero and identity
+        let zero = U128::from(0u64);
+        assert_eq!(a.wide_mul(&zero), (zero, zero));
+        assert_eq!(a.wide_mul(&one), (a, zero));
+
+        // Verify via U256: (hi << 128) | lo == a256 * b256
+        type U256 = FixedUInt<u32, 8>;
+
+        fn to_u256(lo: FixedUInt<u32, 4>, hi: FixedUInt<u32, 4>) -> FixedUInt<u32, 8> {
+            let mut buf = [0u8; 32];
+            let mut lo_buf = [0u8; 16];
+            let mut hi_buf = [0u8; 16];
+            lo.to_le_bytes(&mut lo_buf).unwrap();
+            hi.to_le_bytes(&mut hi_buf).unwrap();
+            buf[..16].copy_from_slice(&lo_buf);
+            buf[16..].copy_from_slice(&hi_buf);
+            U256::from_le_bytes(&buf)
+        }
+
+        let (lo, hi) = a.wide_mul(&b);
+        let a256 = U256::from(0xDEAD_BEEF_u64);
+        let b256 = U256::from(0xCAFE_BABE_u64);
+        assert_eq!(to_u256(lo, hi), a256 * b256);
+    }
+}

--- a/modmath/src/wide_mul.rs
+++ b/modmath/src/wide_mul.rs
@@ -99,6 +99,9 @@ where
 }
 
 // --- With wide-mul: optimized impl for WideningMul types ---
+// Note: fixed-bigint implements WideningMul for all primitive integers
+// (u8, u16, u32, u64) as well as FixedUInt, so this blanket impl
+// covers the same set of types as the fallback above.
 #[cfg(feature = "wide-mul")]
 impl<T> WideMul for T
 where


### PR DESCRIPTION
Replace broken basic_montgomery_mod_mul/mod_exp (mod_mul + reduction) with correct wide-REDC implementations using R = 2^W. Add Newton as NPrimeMethod default. Add WideMul trait with generic fallback.

## Summary by Sourcery

Switch basic Montgomery modular multiplication and exponentiation to a wide-REDC (R = 2^W) implementation with Newton-based N' computation, and introduce a generic widening multiplication trait to support overflow-safe arithmetic across integer types.

New Features:
- Add a wide_from_montgomery helper that performs overflow-free Montgomery reduction using wide-REDC semantics.
- Introduce a WideMul trait with a generic bit-by-bit fallback and optional optimized implementation via fixed-bigint's WideningMul.
- Add full wide-REDC based basic_montgomery_mod_mul and basic_montgomery_mod_exp APIs that work with any type implementing WideMul and required arithmetic traits.

Bug Fixes:
- Fix overflow issues in basic Montgomery reduction and modular exponentiation by replacing the old mod_mul-based path with a correct wide-REDC implementation using double-width intermediates.
- Ensure basic Montgomery operations correctly handle large moduli and inputs by reducing operands modulo N before conversion to Montgomery form and rejecting even/zero moduli.

Enhancements:
- Extend NPrimeMethod with a Newton variant and make it the default, mapping it to ExtendedEuclidean in legacy R > N parameter paths for constrained and strict Montgomery implementations.
- Refine documentation and warnings around basic_from_montgomery to clarify overflow risks and direct users to the wide-REDC based alternative.
- Add extensive tests for wide-REDC helpers, wide Montgomery round-trips, modular multiplication/exponentiation across u8/u32/u64 and FixedUInt, and input-reduction and error paths.
- Update strict and constrained Montgomery APIs to accept Newton as the default N' method while preserving existing R > N semantics internally.

Build:
- Bump the fixed-bigint dependency to 0.2.2 and introduce a wide-mul feature flag controlling use of its WideningMul and nightly feature wiring.

Documentation:
- Clarify NPrimeMethod behavior and defaults, including how Newton interacts with legacy R > N paths and wide-REDC, and improve doc comments on strict/constrained Montgomery APIs regarding default methods and semantics.

Tests:
- Port and expand wide-REDC tests into the basic Montgomery module, including exhaustive and cross-checked tests against reference mul/exp implementations and big-integer backends.
- Adjust bnum/crypto_bigint integration tests to reflect new WideMul and OverflowingAdd requirements for the basic Montgomery path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Public WideMul capability and a feature flag ("wide-mul") for optimized double-width multiplication.

* **Improvements**
  - Montgomery operations now include wide-REDC support and default to a Newton-based N' computation; method-aware variants exposed so callers can select computation methods.

* **Tests**
  - Expanded coverage for wide multiplication, wide-REDC round-trips, and Montgomery variants.

* **Chores**
  - Bumped fixed-bigint to v0.2.2 and updated nightly/feature wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->