### PR TITLE
A bunch of hacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 resolver="2"
 
 members = ["modmath"]
+
+[patch.crates-io]
+#fixed-bigint = { path = "../fixed-bigint" }

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = """
 Modular math implemented with traits.
@@ -16,10 +16,10 @@ keywords = ["numerics", "bignum"]
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false, optional = true }
 c0nst = { version = "0.2", optional = true }
-fixed-bigint = { version = "0.2.2", optional = true, default-features = false }
+fixed-bigint = { version = "0.2.5", optional = true, default-features = false }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.2.2" }
+fixed-bigint = { version = "0.2.5" }
 num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint" , path = "../bn/num-bigint" }
 num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
@@ -44,4 +44,5 @@ basic = []
 strict = []
 num-integer = ["dep:num-integer"]
 wide-mul = ["dep:fixed-bigint"]
+instrument = ["std"]
 nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint", "fixed-bigint/nightly"]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -35,7 +35,11 @@ where
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Rem<Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_ADD_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let a = a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_ADD_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let sum = a.wrapping_add(&(b % m));
     if sum >= m || sum < a {
         sum.wrapping_sub(&m)
@@ -55,7 +59,11 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     // maybe a should be `mut a`
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_ADD_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let a_mod = &a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_ADD_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let sum = a_mod.wrapping_add(&(b % m));
     if &sum >= m || sum < a_mod {
         sum.wrapping_sub(m)
@@ -75,7 +83,11 @@ where
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_ADD_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     a.rem_assign(m);
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_ADD_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let (sum, overflow) = a.overflowing_add(&(b % m));
 
     if &sum >= m || overflow {

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -61,9 +61,13 @@ where
         + core::ops::ShrAssign<usize>
         + Copy,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_EXP_ONE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut result = T::one() % modulus;
     let mut exp = exponent;
 
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_EXP_BASE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     base = base % modulus;
 
     while exp > T::zero() {
@@ -97,7 +101,11 @@ where
         + core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_EXP_BASE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     base.rem_assign(modulus);
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_EXP_ONE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut result = T::one() % modulus;
     let mut exp = T::zero().wrapping_add(exponent);
     while exp > T::zero() {
@@ -132,7 +140,11 @@ where
         + core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_EXP_ONE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut result = T::one() % modulus;
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_EXP_BASE.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     base.rem_assign(modulus);
     let mut exp = T::zero().overflowing_add(exponent).0;
 

--- a/modmath/src/instrument.rs
+++ b/modmath/src/instrument.rs
@@ -1,0 +1,217 @@
+//! Division/remainder instrumentation counters.
+//!
+//! When the `instrument` feature is enabled, every `%`, `%=`, and `/` operation
+//! in the modular arithmetic functions increments a static atomic counter.
+//! This lets you find out exactly where division budget is being spent.
+//!
+//! Usage from an application:
+//! ```ignore
+//! modmath::instrument::reset_all();
+//! // ... do work ...
+//! modmath::instrument::dump_nonzero();
+//! ```
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+// ---- add.rs ----
+/// strict_mod_add: a.rem_assign(m)
+pub static STRICT_ADD_A: AtomicU64 = AtomicU64::new(0);
+/// strict_mod_add: b % m
+pub static STRICT_ADD_B: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_add: &a % m
+pub static CONSTRAINED_ADD_A: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_add: b % m
+pub static CONSTRAINED_ADD_B: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_add: a % m
+pub static BASIC_ADD_A: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_add: b % m
+pub static BASIC_ADD_B: AtomicU64 = AtomicU64::new(0);
+
+// ---- sub.rs ----
+/// strict_mod_sub: a.rem_assign(m)
+pub static STRICT_SUB_A: AtomicU64 = AtomicU64::new(0);
+/// strict_mod_sub: b % m
+pub static STRICT_SUB_B: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_sub: &a % m
+pub static CONSTRAINED_SUB_A: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_sub: b % m
+pub static CONSTRAINED_SUB_B: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_sub: a % m
+pub static BASIC_SUB_A: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_sub: b % m
+pub static BASIC_SUB_B: AtomicU64 = AtomicU64::new(0);
+
+// ---- mul.rs ----
+/// strict_mod_mul: a.rem_assign(m)
+pub static STRICT_MUL_A: AtomicU64 = AtomicU64::new(0);
+/// strict_mod_mul: b % m
+pub static STRICT_MUL_B: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_mul: a.rem_assign(m)
+pub static CONSTRAINED_MUL_A: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_mul: b % m
+pub static CONSTRAINED_MUL_B: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_mul: a % m
+pub static BASIC_MUL_A: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_mul: b % m
+pub static BASIC_MUL_B: AtomicU64 = AtomicU64::new(0);
+
+// ---- exp.rs ----
+/// strict_mod_exp: T::one() % modulus
+pub static STRICT_EXP_ONE: AtomicU64 = AtomicU64::new(0);
+/// strict_mod_exp: base.rem_assign(modulus)
+pub static STRICT_EXP_BASE: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_exp: base.rem_assign(modulus)
+pub static CONSTRAINED_EXP_BASE: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_exp: T::one() % modulus
+pub static CONSTRAINED_EXP_ONE: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_exp: T::one() % modulus
+pub static BASIC_EXP_ONE: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_exp: base = base % modulus
+pub static BASIC_EXP_BASE: AtomicU64 = AtomicU64::new(0);
+
+// ---- inv.rs ----
+/// strict_mod_inv: &r / &new_r (loop body)
+pub static STRICT_INV_DIV: AtomicU64 = AtomicU64::new(0);
+/// constrained_mod_inv: &r / &new_r (loop body)
+pub static CONSTRAINED_INV_DIV: AtomicU64 = AtomicU64::new(0);
+/// basic_mod_inv: r / new_r (loop body, via Signed)
+pub static BASIC_INV_DIV: AtomicU64 = AtomicU64::new(0);
+
+// ---- strictest.rs ----
+/// strictest_mod_add: a % m
+pub static STRICTEST_ADD_A: AtomicU64 = AtomicU64::new(0);
+/// strictest_mod_add: b % m
+pub static STRICTEST_ADD_B: AtomicU64 = AtomicU64::new(0);
+/// strictest_mod_sub: a % m
+pub static STRICTEST_SUB_A: AtomicU64 = AtomicU64::new(0);
+/// strictest_mod_sub: b % m
+pub static STRICTEST_SUB_B: AtomicU64 = AtomicU64::new(0);
+/// strictest_mod_mul: a % m
+pub static STRICTEST_MUL_A: AtomicU64 = AtomicU64::new(0);
+/// strictest_mod_mul: b % m
+pub static STRICTEST_MUL_B: AtomicU64 = AtomicU64::new(0);
+
+// ---- external (ed25519 lazy_field.rs) ----
+/// lazy_mod_mul: product % p (direct Rem op in ed25519 hot path)
+pub static LAZY_MUL_REM: AtomicU64 = AtomicU64::new(0);
+/// force_reduce: a % p (direct Rem op in ed25519)
+pub static LAZY_FORCE_REDUCE: AtomicU64 = AtomicU64::new(0);
+
+// ---- montgomery/basic_mont.rs ----
+/// reduce_mod: val % modulus
+pub static MONT_REDUCE_MOD: AtomicU64 = AtomicU64::new(0);
+/// compute_n_prime_trial_search: (modulus * n_prime) % r (loop)
+pub static MONT_NPRIME_TRIAL: AtomicU64 = AtomicU64::new(0);
+/// compute_n_prime_hensels_lifting: (modulus * n_prime + 1) % target_mod (loop)
+pub static MONT_NPRIME_HENSEL_LOOP: AtomicU64 = AtomicU64::new(0);
+/// compute_n_prime_hensels_lifting: final check (modulus * n_prime) % r
+pub static MONT_NPRIME_HENSEL_FINAL: AtomicU64 = AtomicU64::new(0);
+/// compute_n_prime_extended_euclidean: uses basic_mod_inv internally
+pub static MONT_NPRIME_EUCLID: AtomicU64 = AtomicU64::new(0);
+
+/// Helper macro to collect all counters for iteration.
+macro_rules! all_counters {
+    ($callback:ident) => {
+        $callback!(
+            STRICT_ADD_A,
+            STRICT_ADD_B,
+            CONSTRAINED_ADD_A,
+            CONSTRAINED_ADD_B,
+            BASIC_ADD_A,
+            BASIC_ADD_B,
+            STRICT_SUB_A,
+            STRICT_SUB_B,
+            CONSTRAINED_SUB_A,
+            CONSTRAINED_SUB_B,
+            BASIC_SUB_A,
+            BASIC_SUB_B,
+            STRICT_MUL_A,
+            STRICT_MUL_B,
+            CONSTRAINED_MUL_A,
+            CONSTRAINED_MUL_B,
+            BASIC_MUL_A,
+            BASIC_MUL_B,
+            STRICT_EXP_ONE,
+            STRICT_EXP_BASE,
+            CONSTRAINED_EXP_BASE,
+            CONSTRAINED_EXP_ONE,
+            BASIC_EXP_ONE,
+            BASIC_EXP_BASE,
+            STRICT_INV_DIV,
+            CONSTRAINED_INV_DIV,
+            BASIC_INV_DIV,
+            STRICTEST_ADD_A,
+            STRICTEST_ADD_B,
+            STRICTEST_SUB_A,
+            STRICTEST_SUB_B,
+            STRICTEST_MUL_A,
+            STRICTEST_MUL_B,
+            LAZY_MUL_REM,
+            LAZY_FORCE_REDUCE,
+            MONT_REDUCE_MOD,
+            MONT_NPRIME_TRIAL,
+            MONT_NPRIME_HENSEL_LOOP,
+            MONT_NPRIME_HENSEL_FINAL,
+            MONT_NPRIME_EUCLID
+        );
+    };
+}
+
+/// Reset all counters to zero.
+pub fn reset_all() {
+    macro_rules! do_reset {
+        ($($name:ident),+) => {
+            { $( $name.store(0, Ordering::Relaxed); )+ }
+        };
+    }
+    all_counters!(do_reset);
+}
+
+/// Get total division count across all counters.
+pub fn total_count() -> u64 {
+    let mut total = 0u64;
+    macro_rules! do_sum {
+        ($($name:ident),+) => {
+            { $( total += $name.load(Ordering::Relaxed); )+ }
+        };
+    }
+    all_counters!(do_sum);
+    total
+}
+
+/// Return a Vec of (name, count) for all non-zero counters.
+/// Requires std feature.
+#[cfg(feature = "std")]
+pub fn nonzero_counts() -> Vec<(&'static str, u64)> {
+    let mut result = Vec::new();
+    macro_rules! do_collect {
+        ($($name:ident),+) => {
+            { $(
+                let v = $name.load(Ordering::Relaxed);
+                if v > 0 {
+                    result.push((stringify!($name), v));
+                }
+            )+ }
+        };
+    }
+    all_counters!(do_collect);
+    result
+}
+
+/// Print all non-zero counters to stdout.
+/// Requires std feature.
+#[cfg(feature = "std")]
+pub fn dump_nonzero() {
+    let counts = nonzero_counts();
+    if counts.is_empty() {
+        println!("[instrument] No division/remainder operations recorded.");
+        return;
+    }
+    println!("[instrument] Division/remainder operation counts:");
+    let mut total = 0u64;
+    for (name, count) in &counts {
+        println!("  {:<30} {:>10}", name, count);
+        total += count;
+    }
+    println!("  {:<30} {:>10}", "TOTAL", total);
+}

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -46,6 +46,8 @@ where
     let mut new_r = a;
 
     while new_r != T::zero() {
+        #[cfg(feature = "instrument")]
+        crate::instrument::STRICT_INV_DIV.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         let quotient = &r / &new_r;
 
         // clone
@@ -93,6 +95,8 @@ where
     let mut new_r = a;
 
     while new_r != T::zero() {
+        #[cfg(feature = "instrument")]
+        crate::instrument::CONSTRAINED_INV_DIV.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         let quotient = &r / &new_r;
 
         let tmp_t = new_t.clone();
@@ -133,6 +137,8 @@ where
     let mut new_r = Signed::new(a, false);
 
     while new_r != Signed::new(T::zero(), false) {
+        #[cfg(feature = "instrument")]
+        crate::instrument::BASIC_INV_DIV.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         let quotient = r / new_r;
 
         let tmp_t = new_t;

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -21,7 +21,7 @@
 //! wont work with `num-bigint` and `ibig` as both require heap
 //! allocation.
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "instrument")), no_std)]
 
 mod add;
 mod exp;
@@ -56,6 +56,13 @@ pub use montgomery::{
     basic_montgomery_mul,
     basic_to_montgomery,
     wide_from_montgomery,
+    // Wide-REDC primitives for precomputed Montgomery contexts
+    type_bit_width,
+    compute_n_prime_newton,
+    compute_r_mod_n,
+    compute_r2_mod_n,
+    wide_redc,
+    wide_montgomery_mul,
     constrained_compute_montgomery_params,
     constrained_compute_montgomery_params_with_method,
     constrained_from_montgomery,
@@ -74,12 +81,19 @@ pub use montgomery::{
     strict_montgomery_mod_mul_with_method,
     strict_to_montgomery,
 };
+#[cfg(feature = "wide-mul")]
+pub use montgomery::{cios_montgomery_mul, CiosMontMul};
 #[cfg(feature = "nightly")]
 pub use mul::const_mod_mul;
 pub use mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};
 #[cfg(feature = "nightly")]
 pub use sub::const_mod_sub;
 pub use sub::{basic_mod_sub, constrained_mod_sub, strict_mod_sub};
+
+mod strictest;
+
+#[cfg(feature = "instrument")]
+pub mod instrument;
 
 #[cfg(test)]
 #[macro_export]

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -48,6 +48,8 @@ where
     // Current implementation is fine for small numbers but inefficient for large moduli
     let mut n_prime = T::one();
     loop {
+        #[cfg(feature = "instrument")]
+        crate::instrument::MONT_NPRIME_TRIAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         if (modulus * n_prime) % r == target {
             return Some(n_prime);
         }
@@ -83,6 +85,8 @@ where
     // Or: N' ≡ -modulus^(-1) (mod R)
 
     // Use basic_mod_inv to find modulus^(-1) mod R
+    #[cfg(feature = "instrument")]
+    crate::instrument::MONT_NPRIME_EUCLID.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     if let Some(modulus_inv) = basic_mod_inv(modulus, r) {
         // N' = -modulus^(-1) mod R = R - modulus^(-1) mod R
         if modulus_inv == T::zero() {
@@ -134,6 +138,8 @@ where
         //     x_new = x - x - 1/modulus  (but we work mod powers of 2)
 
         let target_mod = T::one() << k; // 2^k
+        #[cfg(feature = "instrument")]
+        crate::instrument::MONT_NPRIME_HENSEL_LOOP.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         let check_val = (modulus * n_prime + T::one()) % target_mod;
 
         if check_val != T::zero() {
@@ -148,6 +154,8 @@ where
     }
 
     // Final check and adjustment to ensure modulus * N' ≡ -1 (mod R)
+    #[cfg(feature = "instrument")]
+    crate::instrument::MONT_NPRIME_HENSEL_FINAL.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let final_check = (modulus * n_prime) % r;
     let target = r - T::one(); // -1 mod R
 
@@ -355,7 +363,7 @@ where
 // ---------------------------------------------------------------------------
 
 /// Bit width of type T (e.g. 32 for u32, 128 for FixedUInt<u32,4>).
-const fn type_bit_width<T>() -> usize {
+pub const fn type_bit_width<T>() -> usize {
     core::mem::size_of::<T>() * 8
 }
 
@@ -376,7 +384,7 @@ where
 ///
 /// Invariant: after each iteration, `modulus * x ≡ 1 (mod 2^precision)`.
 /// We return `0 - x` so that `modulus * N' ≡ -1 (mod 2^W)`.
-fn compute_n_prime_newton<T>(modulus: T, w: usize) -> T
+pub fn compute_n_prime_newton<T>(modulus: T, w: usize) -> T
 where
     T: Copy
         + num_traits::One
@@ -420,7 +428,7 @@ where
 }
 
 /// Compute R mod N = 2^W mod N via W modular doublings starting from 1.
-fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
+pub fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
 where
     T: Copy
         + PartialEq
@@ -434,7 +442,7 @@ where
 }
 
 /// Compute R^2 mod N via W more modular doublings from (R mod N).
-fn compute_r2_mod_n<T>(r_mod_n: T, modulus: T, w: usize) -> T
+pub fn compute_r2_mod_n<T>(r_mod_n: T, modulus: T, w: usize) -> T
 where
     T: Copy
         + PartialEq
@@ -475,7 +483,7 @@ where
 /// - Inputs t_lo, t_hi represent a value T < N * R (product of two values < N)
 /// - modulus is odd and non-zero
 /// - n_prime = -N^{-1} mod 2^W
-fn wide_redc<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
+pub fn wide_redc<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
         + num_traits::Zero
@@ -512,7 +520,7 @@ where
 // ---------------------------------------------------------------------------
 
 /// Montgomery multiplication using wide REDC: REDC(a_mont * b_mont).
-fn wide_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T) -> T
+pub fn wide_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
         + num_traits::Zero
@@ -570,6 +578,8 @@ fn reduce_mod<T>(val: T, modulus: T) -> T
 where
     T: Copy + core::ops::Rem<Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::MONT_REDUCE_MOD.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     val % modulus
 }
 

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -1,0 +1,232 @@
+//! CIOS (Coarsely Integrated Operand Scanning) Montgomery multiplication.
+//!
+//! Interleaves multiplication and reduction in a single pass, using
+//! 2N²+N limb multiplies instead of 3N² for separate wide-mul + REDC.
+//!
+//! The algorithm operates entirely through the [`MulAccOps`] trait,
+//! never touching raw limb arrays.
+
+#[cfg(feature = "wide-mul")]
+use fixed_bigint::MulAccOps;
+#[cfg(feature = "wide-mul")]
+use fixed_bigint::const_numtraits::ConstBorrowingSub;
+#[cfg(feature = "wide-mul")]
+use num_traits::ops::overflowing::OverflowingAdd;
+#[cfg(feature = "wide-mul")]
+use num_traits::{One, WrappingMul, Zero};
+
+/// CIOS Montgomery multiplication: `a * b * R⁻¹ mod modulus`.
+///
+/// Both `a` and `b` must be in Montgomery form and in `[0, modulus)`.
+/// `n_prime_0` is the lowest word of `−N⁻¹ mod R`.
+///
+/// The algorithm fuses multiplication and REDC into a single double-loop,
+/// saving ~25 % of limb multiplies compared to separate wide-mul + REDC.
+#[cfg(feature = "wide-mul")]
+pub fn cios_montgomery_mul<T: MulAccOps + PartialOrd + ConstBorrowingSub>(
+    a: &T,
+    b: &T,
+    modulus: &T,
+    n_prime_0: T::Word,
+) -> Option<T>
+where
+    T::Word: num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + core::ops::Add<Output = T::Word>,
+{
+    let n = T::word_count();
+    let mut acc = T::default();
+    let mut acc_hi = <T::Word as Zero>::zero();
+    let mut acc_hi2 = <T::Word as Zero>::zero();
+
+    for i in 0..n {
+        let ai = a.get_word(i)?;
+
+        // Phase 1: acc += a[i] * b
+        let carry = T::mul_acc_row(ai, b, &mut acc, <T::Word as Zero>::zero());
+        let (sum, overflow) = acc_hi.overflowing_add(&carry);
+        acc_hi = sum;
+        if overflow {
+            acc_hi2 = acc_hi2 + <T::Word as One>::one();
+        }
+
+        // Compute reduction factor: m = acc[0] * n_prime_0 (mod word)
+        let m = acc.get_word(0)?.wrapping_mul(&n_prime_0);
+
+        // Phase 2: [acc, acc_hi] = ([acc, acc_hi] + m * modulus) >> word_bits
+        let new_overflow = T::mul_acc_shift_row(m, modulus, &mut acc, acc_hi);
+        acc_hi = acc_hi2 + new_overflow;
+        acc_hi2 = <T::Word as Zero>::zero();
+    }
+
+    // Final conditional subtraction
+    if acc_hi > <T::Word as Zero>::zero() || acc >= *modulus {
+        let (result, _) = <T as ConstBorrowingSub>::borrowing_sub(acc, *modulus, false);
+        acc = result;
+    }
+    Some(acc)
+}
+
+/// Convenience trait: types that support CIOS Montgomery multiplication.
+///
+/// Implemented automatically for any `T: MulAccOps`.  Higher-level code
+/// (e.g. `MontgomeryCtx`) can bound on this trait instead of requiring
+/// knowledge of `MulAccOps::Word` or the CIOS call signature.
+#[cfg(feature = "wide-mul")]
+pub trait CiosMontMul: MulAccOps {
+    fn cios_mont_mul(a: Self, b: Self, modulus: Self, n_prime: Self) -> Option<Self>;
+}
+
+#[cfg(feature = "wide-mul")]
+impl<T: MulAccOps + PartialOrd + ConstBorrowingSub> CiosMontMul for T
+where
+    T::Word: num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + core::ops::Add<Output = T::Word>,
+{
+    #[inline]
+    fn cios_mont_mul(a: Self, b: Self, modulus: Self, n_prime: Self) -> Option<Self> {
+        cios_montgomery_mul(&a, &b, &modulus, n_prime.get_word(0)?)
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "wide-mul")]
+mod tests {
+    use super::*;
+    use crate::montgomery::basic_mont::{
+        compute_n_prime_newton, compute_r2_mod_n, compute_r_mod_n, type_bit_width, wide_montgomery_mul, wide_redc,
+    };
+
+    /// Verify CIOS matches wide_montgomery_mul for u8 FixedUInt.
+    #[test]
+    fn test_cios_vs_wide_redc_u8() {
+        use fixed_bigint::FixedUInt;
+        type U16 = FixedUInt<u8, 2>;
+
+        let modulus = U16::from(13u16);
+        let w = type_bit_width::<U16>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+        // Test all pairs in [0, 13)
+        for a_val in 0u16..13 {
+            for b_val in 0u16..13 {
+                let a = U16::from(a_val);
+                let b = U16::from(b_val);
+
+                // Convert to Montgomery form
+                let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+                let a_m = wide_redc(lo, hi, modulus, n_prime);
+                let (lo, hi) = crate::WideMul::wide_mul(&b, &r2_mod_n);
+                let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+                // Multiply via wide-REDC (reference)
+                let expected = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
+
+                // Multiply via CIOS
+                let got = cios_montgomery_mul(&a_m, &b_m, &modulus, n_prime.get_word(0).unwrap()).unwrap();
+
+                assert_eq!(
+                    got, expected,
+                    "CIOS mismatch for {a_val}*{b_val} mod 13: got {got:?}, expected {expected:?}"
+                );
+            }
+        }
+    }
+
+    /// Verify CIOS with a larger type (u32 words, 4 limbs = 128-bit).
+    #[test]
+    fn test_cios_u32x4() {
+        use fixed_bigint::FixedUInt;
+        type U128 = FixedUInt<u32, 4>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64); // 2^128 - 59 (odd)
+        let w = type_bit_width::<U128>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+        let test_vals = [0u64, 1, 2, 42, 0xDEAD_BEEF, 0xCAFE_BABE];
+        for &a_val in &test_vals {
+            for &b_val in &test_vals {
+                let a = U128::from(a_val);
+                let b = U128::from(b_val);
+
+                let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+                let a_m = wide_redc(lo, hi, modulus, n_prime);
+                let (lo, hi) = crate::WideMul::wide_mul(&b, &r2_mod_n);
+                let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+                let expected = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
+                let got = cios_montgomery_mul(&a_m, &b_m, &modulus, n_prime.get_word(0).unwrap()).unwrap();
+
+                assert_eq!(
+                    got, expected,
+                    "CIOS mismatch for {a_val:#x}*{b_val:#x}"
+                );
+            }
+        }
+    }
+
+    /// Verify CIOS round-trip: to_mont → CIOS multiply → from_mont = (a*b) mod N.
+    #[test]
+    fn test_cios_roundtrip() {
+        use fixed_bigint::FixedUInt;
+        type U128 = FixedUInt<u32, 4>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64);
+        let w = type_bit_width::<U128>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+        let a = U128::from(0xDEAD_BEEF_u64);
+        let b = U128::from(0xCAFE_BABE_u64);
+
+        // Convert to Montgomery form
+        let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+        let a_m = wide_redc(lo, hi, modulus, n_prime);
+        let (lo, hi) = crate::WideMul::wide_mul(&b, &r2_mod_n);
+        let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+        // CIOS multiply in Montgomery domain
+        let result_m = cios_montgomery_mul(&a_m, &b_m, &modulus, n_prime.get_word(0).unwrap()).unwrap();
+
+        // Convert back
+        let result = wide_redc(result_m, U128::from(0u64), modulus, n_prime);
+
+        // Compare with basic_mod_mul
+        let expected = crate::mul::basic_mod_mul(a, b, modulus);
+        assert_eq!(result, expected);
+    }
+
+    /// Test CiosMontMul convenience trait.
+    #[test]
+    fn test_cios_mont_mul_trait() {
+        use fixed_bigint::FixedUInt;
+        type U128 = FixedUInt<u32, 4>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64);
+        let w = type_bit_width::<U128>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+        let a = U128::from(42u64);
+        let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+        let a_m = wide_redc(lo, hi, modulus, n_prime);
+        let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+        let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+        // Use the trait method
+        let result = CiosMontMul::cios_mont_mul(a_m, b_m, modulus, n_prime).unwrap();
+        let expected = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
+        assert_eq!(result, expected);
+    }
+}

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -7,6 +7,9 @@ pub mod constrained_mont;
 
 pub mod strict_mont;
 
+#[cfg(feature = "wide-mul")]
+pub mod cios;
+
 // Re-export basic functions for backwards compatibility
 #[rustfmt::skip]
 pub use basic_mont::{
@@ -21,6 +24,13 @@ pub use basic_mont::{
     basic_montgomery_mul,
     basic_to_montgomery,
     wide_from_montgomery,
+    // Wide-REDC primitives for precomputed Montgomery contexts
+    type_bit_width,
+    compute_n_prime_newton,
+    compute_r_mod_n,
+    compute_r2_mod_n,
+    wide_redc,
+    wide_montgomery_mul,
 };
 
 // Re-export constrained functions
@@ -49,6 +59,10 @@ pub use strict_mont::{
     strict_montgomery_mod_mul_with_method,
     strict_to_montgomery,
 };
+
+// Re-export CIOS Montgomery multiplication
+#[cfg(feature = "wide-mul")]
+pub use cios::{cios_montgomery_mul, CiosMontMul};
 
 #[cfg(test)]
 mod tests {

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -66,7 +66,11 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_MUL_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut a = a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_MUL_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut b = b % m;
     let m1 = m;
     let mut result = T::zero();
@@ -112,7 +116,11 @@ where
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_MUL_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     a.rem_assign(m);
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_MUL_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut b = b % m;
 
     let mut result = T::zero();
@@ -158,7 +166,11 @@ where
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_MUL_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     a.rem_assign(m);
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_MUL_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut b = b % m;
 
     let mut result = T::zero();

--- a/modmath/src/strictest.rs
+++ b/modmath/src/strictest.rs
@@ -1,0 +1,203 @@
+/// Fast modular addition assuming inputs are already reduced to [0, m)
+/// SAFETY: Caller must ensure a, b ∈ [0, m)
+pub fn strictest_mod_add_no_reduce<T>(a: &T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub,
+{
+    debug_assert!(a < m, "Input a must be reduced: a < m");
+    debug_assert!(b < m, "Input b must be reduced: b < m");
+    
+    let (sum, overflow) = a.overflowing_add(b);
+    if &sum >= m || overflow {
+        sum.overflowing_sub(m).0
+    } else {
+        sum
+    }
+}
+
+/// Safe modular addition that reduces inputs first
+pub fn strictest_mod_add<T>(a: &T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub,
+    for<'b> &'b T: core::ops::Rem<&'b T, Output = T>,
+{
+    // Reduce operands first to prevent overflow
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICTEST_ADD_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let a_reduced = a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICTEST_ADD_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let b_reduced = b % m;
+    strictest_mod_add_no_reduce(&a_reduced, &b_reduced, m)
+}
+
+/// Fast modular subtraction assuming inputs are already reduced to [0, m)
+/// SAFETY: Caller must ensure a, b ∈ [0, m)
+pub fn strictest_mod_sub_no_reduce<T>(a: &T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::overflowing::OverflowingSub,
+{
+    debug_assert!(a < m, "Input a must be reduced: a < m");
+    debug_assert!(b < m, "Input b must be reduced: b < m");
+    
+    if a >= b {
+        // No underflow case: simply subtract
+        let (diff, _) = a.overflowing_sub(b);
+        diff
+    } else {
+        // Underflow case: compute m - (b - a)
+        // This is equivalent to (a - b) mod m in positive representation
+        let (b_minus_a, _) = b.overflowing_sub(a);
+        let (result, _) = m.overflowing_sub(&b_minus_a);
+        result
+    }
+}
+
+/// Safe modular subtraction that reduces inputs first
+pub fn strictest_mod_sub<T>(a: &T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::overflowing::OverflowingSub
+        + num_traits::ops::overflowing::OverflowingAdd,
+    for<'b> &'b T: core::ops::Rem<&'b T, Output = T>,
+{
+    // Reduce operands first
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICTEST_SUB_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let a_reduced = a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICTEST_SUB_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let b_reduced = b % m;
+    strictest_mod_sub_no_reduce(&a_reduced, &b_reduced, m)
+}
+
+pub fn strictest_mod_mul<T>(a: &T, b: &T, m: &T) -> T
+where
+    T: Clone
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub
+        + core::cmp::PartialOrd
+        + core::ops::Shr<usize, Output = T>,
+    for<'b> &'b T: core::ops::Rem<&'b T, Output = T> + core::ops::BitAnd<Output = T>,
+{
+    // Reduce operands first to prevent overflow
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICTEST_MUL_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let mut a_cur = a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICTEST_MUL_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    let mut b_cur = b % m;
+    let mut result = T::zero();
+    let one = T::one();
+    
+    // Binary multiplication algorithm (peasant multiplication)
+    while b_cur > T::zero() {
+        // If current bit of b is set, add current a to result
+        if &b_cur & &one == one {
+            let (sum, overflow) = result.overflowing_add(&a_cur);
+            result = if &sum >= m || overflow {
+                sum.overflowing_sub(m).0
+            } else {
+                sum
+            };
+        }
+        
+        // Double a_cur (mod m) and halve b_cur
+        let (doubled, overflow) = a_cur.overflowing_add(&a_cur);
+        a_cur = if &doubled >= m || overflow {
+            doubled.overflowing_sub(m).0
+        } else {
+            doubled
+        };
+        b_cur = b_cur >> 1;
+    }
+    result
+}
+
+#[cfg(test)]
+mod strictest_mod_add_tests {
+    use super::*;
+
+    #[test]
+    fn test_strictest_mod_add() {
+        // 10 + 20 = 30, 30 % 30 = 0
+        let a = 10;
+        let b = 20;
+        let m = 30;
+        let result = strictest_mod_add(&a, &b, &m);
+        assert_eq!(result, 0);
+    }
+    
+    #[test]
+    fn test_strictest_mod_sub() {
+        // 10 - 20 = -10, -10 % 30 = 20 (in positive modular arithmetic)
+        let a = 10;
+        let b = 20;
+        let m = 30;
+        let result = strictest_mod_sub(&a, &b, &m);
+        assert_eq!(result, 20);
+    }
+
+    #[test]
+    fn test_strictest_mod_mul() {
+        // 10 * 20 = 200, 200 % 30 = 20
+        let a = 10;
+        let b = 20;
+        let m = 30;
+        let result = strictest_mod_mul(&a, &b, &m);
+        assert_eq!(result, 20);
+    }
+
+    #[test]
+    fn test_strictest_mod_add_edge_cases() {
+        // Test with zero
+        assert_eq!(strictest_mod_add(&0u32, &5u32, &7u32), 5);
+        assert_eq!(strictest_mod_add(&5u32, &0u32, &7u32), 5);
+        
+        // Test with values larger than modulus
+        assert_eq!(strictest_mod_add(&15u32, &20u32, &7u32), 0); // (1 + 6) % 7 = 0
+        
+        // Test overflow prevention
+        assert_eq!(strictest_mod_add(&6u32, &6u32, &7u32), 5); // (6 + 6) % 7 = 5
+    }
+
+    #[test]
+    fn test_strictest_mod_sub_edge_cases() {
+        // Test normal subtraction
+        assert_eq!(strictest_mod_sub(&10u32, &3u32, &13u32), 7);
+        
+        // Test underflow case
+        assert_eq!(strictest_mod_sub(&3u32, &10u32, &13u32), 6); // (3 - 10) % 13 = -7 % 13 = 6
+        
+        // Test with zero
+        assert_eq!(strictest_mod_sub(&5u32, &0u32, &7u32), 5);
+        assert_eq!(strictest_mod_sub(&0u32, &5u32, &7u32), 2); // (0 - 5) % 7 = -5 % 7 = 2
+        
+        // Test with equal values
+        assert_eq!(strictest_mod_sub(&5u32, &5u32, &7u32), 0);
+    }
+
+    #[test]
+    fn test_strictest_mod_mul_edge_cases() {
+        // Test with zero
+        assert_eq!(strictest_mod_mul(&0u32, &5u32, &7u32), 0);
+        assert_eq!(strictest_mod_mul(&5u32, &0u32, &7u32), 0);
+        
+        // Test with one
+        assert_eq!(strictest_mod_mul(&1u32, &5u32, &7u32), 5);
+        assert_eq!(strictest_mod_mul(&5u32, &1u32, &7u32), 5);
+        
+        // Test large values: 15%7=1, 17%7=3, 1*3=3
+        assert_eq!(strictest_mod_mul(&15u32, &17u32, &7u32), 3);
+        
+        // Test powers of 2
+        assert_eq!(strictest_mod_mul(&4u32, &4u32, &7u32), 2); // (4 * 4) % 7 = 16 % 7 = 2
+    }
+}

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -35,7 +35,11 @@ where
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Rem<Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_SUB_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let a = a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::BASIC_SUB_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let diff = a.wrapping_sub(&(b % m));
     if diff > a {
         // If we wrapped around (underflow)
@@ -55,7 +59,11 @@ where
         + num_traits::ops::wrapping::WrappingSub,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_SUB_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let a_mod = &a % m;
+    #[cfg(feature = "instrument")]
+    crate::instrument::CONSTRAINED_SUB_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let diff = a_mod.wrapping_sub(&(b % m));
     if diff > a_mod {
         // If we wrapped around (underflow)
@@ -76,7 +84,11 @@ where
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_SUB_A.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     a.rem_assign(m);
+    #[cfg(feature = "instrument")]
+    crate::instrument::STRICT_SUB_B.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let (diff, overflow) = a.overflowing_sub(&(b % m));
 
     if overflow {


### PR DESCRIPTION
## Summary by Sourcery

Add configurable instrumentation for division and remainder operations, expose additional Montgomery wide-REDC helpers, and introduce an optimized CIOS-based Montgomery multiplication path with supporting utilities.

New Features:
- Introduce an `instrument` feature with atomic counters to track division and remainder usage across modular arithmetic operations.
- Add a `strictest` module providing reduced-input-optimized modular add, sub, and mul operations, plus safe wrappers that perform reduction first.
- Implement CIOS-based Montgomery multiplication and a convenience trait for wide-mul types behind the `wide-mul` feature flag.
- Expose internal Montgomery helper functions and wide-REDC primitives publicly for constructing precomputed Montgomery contexts.

Enhancements:
- Relax the `no_std` attribute when tests or instrumentation are enabled to allow use of `std` for metrics reporting.
- Upgrade the `fixed-bigint` dependency to version `0.2.5` and bump the crate version to `0.1.4`.

Build:
- Add an `instrument` feature in Cargo.toml that enables instrumentation and depends on `std`.

Tests:
- Add unit tests validating the `strictest` modular operations across core behaviors and edge cases.
- Add tests that verify CIOS Montgomery multiplication against existing wide-REDC implementations and round-trip modular multiplication.