### PR TITLE
Fix the trait

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage data
         working-directory: modmath
         run: |
-          cargo llvm-cov --lcov --output-path lcov.info
+          cargo llvm-cov --features wide-mul --lcov --output-path lcov.info
 
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -37,12 +37,19 @@ jobs:
       if: matrix.rust == 'stable'
       working-directory: modmath
       run: cargo clippy -- -D warnings
+    - name: Run clippy (wide-mul)
+      if: matrix.rust == 'stable'
+      working-directory: modmath
+      run: cargo clippy --features wide-mul -- -D warnings
     - name: Build
       working-directory: modmath
       run: cargo build
     - name: Run tests
       working-directory: modmath
       run: cargo test --verbose
+    - name: Run tests (wide-mul)
+      working-directory: modmath
+      run: cargo test --verbose --features wide-mul
     - name: Run tests with nightly feature
       if: matrix.rust == 'nightly'
       working-directory: modmath

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = """
 Modular math implemented with traits.

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -35,19 +35,21 @@ where
     debug_assert!(b < modulus, "CIOS input b must be in [0, modulus)");
 
     let n = T::word_count();
+    let zero = <T::Word as Zero>::zero();
+    let one = <T::Word as One>::one();
     let mut acc = T::default();
-    let mut acc_hi = <T::Word as Zero>::zero();
-    let mut acc_hi2 = <T::Word as Zero>::zero();
+    let mut acc_hi = zero;
+    let mut acc_hi2 = zero;
 
     for i in 0..n {
         let ai = a.get_word(i)?;
 
         // Phase 1: acc += a[i] * b
-        let carry = T::mul_acc_row(ai, b, &mut acc, <T::Word as Zero>::zero());
+        let carry = T::mul_acc_row(ai, b, &mut acc, zero);
         let (sum, overflow) = acc_hi.overflowing_add(&carry);
         acc_hi = sum;
         if overflow {
-            acc_hi2 = acc_hi2 + <T::Word as One>::one();
+            acc_hi2 = acc_hi2 + one;
         }
 
         // Compute reduction factor: m = acc[0] * n_prime_0 (mod word)
@@ -58,15 +60,15 @@ where
         // Safety: acc_hi2 ∈ {0,1} (reset each iteration, incremented at most once)
         // and new_overflow ∈ {0,1} (bool→word from mul_acc_shift_row), so max sum = 2.
         debug_assert!(
-            new_overflow == <T::Word as Zero>::zero() || new_overflow == <T::Word as One>::one(),
+            new_overflow == zero || new_overflow == one,
             "mul_acc_shift_row must return 0 or 1"
         );
         acc_hi = acc_hi2 + new_overflow;
-        acc_hi2 = <T::Word as Zero>::zero();
+        acc_hi2 = zero;
     }
 
     // Final conditional subtraction
-    if acc_hi > <T::Word as Zero>::zero() || acc >= *modulus {
+    if acc_hi > zero || acc >= *modulus {
         let (result, _) = <T as ConstBorrowingSub>::borrowing_sub(acc, *modulus, false);
         acc = result;
     }

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -36,18 +36,18 @@ where
 
     let n = T::word_count();
     let mut acc = T::default();
-    let mut acc_hi = Zero::zero();
-    let mut acc_hi2 = Zero::zero();
+    let mut acc_hi = <T::Word as Zero>::zero();
+    let mut acc_hi2 = <T::Word as Zero>::zero();
 
     for i in 0..n {
         let ai = a.get_word(i)?;
 
         // Phase 1: acc += a[i] * b
-        let carry = T::mul_acc_row(ai, b, &mut acc, Zero::zero());
+        let carry = T::mul_acc_row(ai, b, &mut acc, <T::Word as Zero>::zero());
         let (sum, overflow) = acc_hi.overflowing_add(&carry);
         acc_hi = sum;
         if overflow {
-            acc_hi2 = acc_hi2 + One::one();
+            acc_hi2 = acc_hi2 + <T::Word as One>::one();
         }
 
         // Compute reduction factor: m = acc[0] * n_prime_0 (mod word)
@@ -58,15 +58,15 @@ where
         // Safety: acc_hi2 ∈ {0,1} (reset each iteration, incremented at most once)
         // and new_overflow ∈ {0,1} (bool→word from mul_acc_shift_row), so max sum = 2.
         debug_assert!(
-            new_overflow == Zero::zero() || new_overflow == One::one(),
+            new_overflow == <T::Word as Zero>::zero() || new_overflow == <T::Word as One>::one(),
             "mul_acc_shift_row must return 0 or 1"
         );
         acc_hi = acc_hi2 + new_overflow;
-        acc_hi2 = Zero::zero();
+        acc_hi2 = <T::Word as Zero>::zero();
     }
 
     // Final conditional subtraction
-    if acc_hi > Zero::zero() || acc >= *modulus {
+    if acc_hi > <T::Word as Zero>::zero() || acc >= *modulus {
         let (result, _) = <T as ConstBorrowingSub>::borrowing_sub(acc, *modulus, false);
         acc = result;
     }
@@ -79,14 +79,7 @@ where
 /// with the required `Word` bounds.  Higher-level code (e.g. `MontgomeryCtx`)
 /// can bound on this trait instead of requiring knowledge of `MulAccOps::Word`
 /// or the CIOS call signature.
-pub trait CiosMontMul: MulAccOps + PartialOrd + ConstBorrowingSub
-where
-    Self::Word: num_traits::Zero
-        + num_traits::One
-        + num_traits::WrappingMul
-        + num_traits::ops::overflowing::OverflowingAdd
-        + core::ops::Add<Output = Self::Word>,
-{
+pub trait CiosMontMul: MulAccOps + PartialOrd + ConstBorrowingSub {
     fn cios_mont_mul(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Option<Self>;
 }
 
@@ -111,6 +104,10 @@ mod tests {
         compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n, type_bit_width,
         wide_montgomery_mul, wide_redc,
     };
+
+    /// Compile-time check: CiosMontMul must be usable as a generic bound
+    /// without requiring the consumer to constrain `T::Word`.
+    fn _assert_generic_bound<T: CiosMontMul>() {}
 
     /// Verify CIOS matches wide_montgomery_mul for u8 FixedUInt.
     #[test]

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -801,12 +801,21 @@ mod bnum_montgomery_tests {
         basic: off, // basic_montgomery_mod_mul/exp now requires WideMul + OverflowingAdd
     );
 
+    #[cfg(not(feature = "wide-mul"))]
     montgomery_test_module!(
         bnum_patched,
         bnum_patched::types::U256,
         strict: off, // Complex trait bounds for Montgomery operations not fully compatible
         constrained: on,
         basic: on,
+    );
+    #[cfg(feature = "wide-mul")]
+    montgomery_test_module!(
+        bnum_patched,
+        bnum_patched::types::U256,
+        strict: off,
+        constrained: on,
+        basic: off, // WideMul requires WideningMul, not implemented for bnum
     );
 
     montgomery_test_module!(
@@ -817,12 +826,21 @@ mod bnum_montgomery_tests {
         basic: off, // RemAssign and other traits missing
     );
 
+    #[cfg(not(feature = "wide-mul"))]
     montgomery_test_module!(
         crypto_bigint_patched,
         crypto_bigint_patched::U256,
         strict: off, // &T + &T and &T - &T operations missing for Montgomery needs
         constrained: on, // Fixed trait bounds - now works with patched libraries
         basic: on, // patched crate adds OverflowingAdd
+    );
+    #[cfg(feature = "wide-mul")]
+    montgomery_test_module!(
+        crypto_bigint_patched,
+        crypto_bigint_patched::U256,
+        strict: off,
+        constrained: on,
+        basic: off, // WideMul requires WideningMul, not implemented for crypto-bigint
     );
 
     montgomery_test_module!(


### PR DESCRIPTION
## Summary by Sourcery

Relax CIOS Montgomery multiplication trait bounds and update CI to exercise the `wide-mul` feature in linting, testing, and coverage.

Bug Fixes:
- Fix CIOS Montgomery multiplication to use `T::Word`-scoped `Zero` and `One` so the trait remains usable as a generic bound without extra word constraints.

CI:
- Extend Rust CI workflow to run clippy and tests with the `wide-mul` feature enabled.
- Run coverage collection with the `wide-mul` feature enabled to better reflect feature-flagged code paths.

Tests:
- Add a compile-time assertion ensuring `CiosMontMul` can be used as a generic bound without requiring consumers to constrain `T::Word`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI expanded to run linting, tests, and coverage with the "wide‑mul" feature to broaden build variants.
  * Test configuration adjusted to exercise alternate test modules depending on the "wide‑mul" feature flag for wider compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->