### PR TITLE
v0.2.0: Field/FieldCt lift, CT siblings, basic/constrained/strict mod…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+.DS_Store

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 description = """
 Modular math implemented with traits.
@@ -16,10 +16,11 @@ keywords = ["numerics", "bignum"]
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false, optional = true }
 c0nst = { version = "0.2", optional = true }
-fixed-bigint = { version = "0.2.5", optional = true, default-features = false }
+fixed-bigint = { version = "0.3", optional = true, default-features = false }
+subtle = { version = "2.6", default-features = false }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.2.5" }
+fixed-bigint = { version = "0.3" }
 num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint" , path = "../bn/num-bigint" }
 num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
@@ -37,10 +38,23 @@ ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.g
 paste = "1"
 
 [features]
-default = []
+# `wide-mul` is on by default so `cargo doc`, `cargo test`, and `cargo
+# build` all include the Field/Residue surface, Montgomery wide-REDC
+# primitives, and CIOS family without requiring an explicit
+# `--features wide-mul` flag. Consumers who want a lean modmath without
+# fixed-bigint can opt out with `default-features = false`.
+default = ["wide-mul"]
 constrained = []
 basic = []
 strict = []
 num-integer = ["dep:num-integer"]
 wide-mul = ["dep:fixed-bigint"]
 nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint", "fixed-bigint/nightly"]
+
+# docs.rs (published documentation) builds with `wide-mul` explicitly
+# enabled as defense-in-depth — covers the case where someone publishes
+# with a future config that drops it from defaults. Without this, docs.rs
+# would build with default features only and the wide-mul-gated public
+# API could become invisible.
+[package.metadata.docs.rs]
+features = ["wide-mul"]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -35,8 +35,19 @@ where
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Rem<Output = T>,
 {
-    let a = a % m;
-    let sum = a.wrapping_add(&(b % m));
+    basic_mod_add_pr(a % m, b % m, m)
+}
+
+/// # Modular Addition (Basic, pre-reduced)
+/// Precondition: `a < m` and `b < m`. No `Rem` bound.
+pub fn basic_mod_add_pr<T>(a: T, b: T, m: T) -> T
+where
+    T: core::cmp::PartialOrd
+        + Copy
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub,
+{
+    let sum = a.wrapping_add(&b);
     if sum >= m || sum < a {
         sum.wrapping_sub(&m)
     } else {
@@ -54,10 +65,21 @@ where
         + num_traits::ops::wrapping::WrappingSub,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
-    // maybe a should be `mut a`
     let a_mod = &a % m;
-    let sum = a_mod.wrapping_add(&(b % m));
-    if &sum >= m || sum < a_mod {
+    let b_mod = b % m;
+    constrained_mod_add_pr(a_mod, &b_mod, m)
+}
+
+/// # Modular Addition (Constrained, pre-reduced)
+/// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
+pub fn constrained_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub,
+{
+    let sum = a.wrapping_add(b);
+    if &sum >= m || sum < a {
         sum.wrapping_sub(m)
     } else {
         sum
@@ -76,8 +98,19 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     a.rem_assign(m);
-    let (sum, overflow) = a.overflowing_add(&(b % m));
+    let b_mod = b % m;
+    strict_mod_add_pr(a, &b_mod, m)
+}
 
+/// # Modular Addition (Strict, pre-reduced)
+/// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
+pub fn strict_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub,
+{
+    let (sum, overflow) = a.overflowing_add(b);
     if &sum >= m || overflow {
         sum.overflowing_sub(m).0
     } else {
@@ -335,12 +368,52 @@ mod bnum_add_tests {
         basic: off, // Copy cannot be implemented, heap allocation
     );
 
+    // Default (Nct-personality) FixedUInt provides Rem; the wrapper
+    // functions are usable here. See fixed_bigint_pr_tests below for
+    // additional _pr API coverage. (Ct-typed FixedUInt intentionally
+    // omits Rem — the schoolbook reduce-then-add is variable-time, so a
+    // Ct value passed to these wrappers would be a compile error.)
     add_test_module!(
         fixed_bigint,
         fixed_bigint::FixedUInt,
-        type U256 = FixedUInt<u32, 4>;
+        type U256 = fixed_bigint::FixedUInt<u32, 4>;
         strict: on,
         constrained: on,
         basic: on,
     );
+}
+
+#[cfg(test)]
+mod fixed_bigint_pr_tests {
+    use super::{basic_mod_add_pr, constrained_mod_add_pr, strict_mod_add_pr};
+    type U256 = fixed_bigint::FixedUInt<u32, 4>;
+
+    #[test]
+    fn test_mod_add_basic_pr() {
+        let m = U256::from(20u8);
+        let a = U256::from(7u8);
+        let b = U256::from(8u8);
+        let expected = U256::from(15u8); // 7 + 8 = 15, < 20
+
+        assert_eq!(strict_mod_add_pr(a, &b, &m), expected);
+        let a = U256::from(7u8);
+        assert_eq!(constrained_mod_add_pr(a, &b, &m), expected);
+        let a = U256::from(7u8);
+        assert_eq!(basic_mod_add_pr(a, b, m), expected);
+    }
+
+    #[test]
+    fn test_mod_add_wraps_pr() {
+        // a + b >= m: subtract m
+        let m = U256::from(20u8);
+        let a = U256::from(15u8);
+        let b = U256::from(13u8);
+        let expected = U256::from(8u8); // 15 + 13 = 28 ≡ 8 (mod 20)
+
+        assert_eq!(strict_mod_add_pr(a, &b, &m), expected);
+        let a = U256::from(15u8);
+        assert_eq!(constrained_mod_add_pr(a, &b, &m), expected);
+        let a = U256::from(15u8);
+        assert_eq!(basic_mod_add_pr(a, b, m), expected);
+    }
 }

--- a/modmath/src/basic/mod.rs
+++ b/modmath/src/basic/mod.rs
@@ -12,10 +12,13 @@
 //!
 //! ## Pre-reduced variants
 //!
-//! [`pre_reduced`] mirrors this module's surface but assumes inputs
-//! are already in `[0, m)`, skipping the `% m` reduction step. Works
-//! for backends without `core::ops::Rem` and is the right entry point
-//! inside loops where reduction is handled separately.
+//! [`pre_reduced`] re-exports `add` / `sub` / `mul` / `exp` siblings that
+//! assume inputs are already in `[0, m)` and skip the `% m` reduction
+//! step. Works for backends without `core::ops::Rem` and is the right
+//! entry point inside loops where reduction is handled separately.
+//! Note: `inv` has no pre-reduced sibling — modular inverse via the
+//! extended Euclidean algorithm inside `inv` performs its own
+//! magnitude-dependent loop, with no useful "pre-reduced" shortcut.
 
 #[doc(inline)]
 pub use crate::add::basic_mod_add as add;

--- a/modmath/src/basic/mod.rs
+++ b/modmath/src/basic/mod.rs
@@ -1,0 +1,44 @@
+//! Schoolbook modular arithmetic for `Copy`-bound types.
+//!
+//! Use this module when the operand type satisfies `T: Copy + ...` —
+//! primitive integers (`u8`, `u16`, `u32`, `u64`, `u128`) and
+//! `Copy`-impl'ing bigints (`fixed_bigint::FixedUInt`,
+//! `crypto_bigint::Uint`).
+//!
+//! For backends that don't impl `Copy`, see
+//! [`modmath::constrained`](crate::constrained) (`Clone`-bound,
+//! mixed value/reference parameters) or [`modmath::strict`](crate::strict)
+//! (reference-based throughout).
+//!
+//! ## Pre-reduced variants
+//!
+//! [`pre_reduced`] mirrors this module's surface but assumes inputs
+//! are already in `[0, m)`, skipping the `% m` reduction step. Works
+//! for backends without `core::ops::Rem` and is the right entry point
+//! inside loops where reduction is handled separately.
+
+#[doc(inline)]
+pub use crate::add::basic_mod_add as add;
+#[doc(inline)]
+pub use crate::exp::basic_mod_exp as exp;
+#[doc(inline)]
+pub use crate::inv::basic_mod_inv as inv;
+#[doc(inline)]
+pub use crate::mul::basic_mod_mul as mul;
+#[doc(inline)]
+pub use crate::sub::basic_mod_sub as sub;
+
+pub mod montgomery;
+
+/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
+/// no `Rem` bound.
+pub mod pre_reduced {
+    #[doc(inline)]
+    pub use crate::add::basic_mod_add_pr as add;
+    #[doc(inline)]
+    pub use crate::exp::basic_mod_exp_pr as exp;
+    #[doc(inline)]
+    pub use crate::mul::basic_mod_mul_pr as mul;
+    #[doc(inline)]
+    pub use crate::sub::basic_mod_sub_pr as sub;
+}

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -1,0 +1,103 @@
+//! Montgomery arithmetic for `Copy`-bound types.
+//!
+//! Two algorithm families live under this module:
+//!
+//! - **R > N path**: textbook Montgomery construction. Pick `R` as the
+//!   smallest power of 2 greater than the modulus, precompute
+//!   `R⁻¹ mod N` and `N' = -N⁻¹ mod R`, transform values into
+//!   Montgomery form, multiply in the Mont domain, transform back.
+//!   Building blocks: [`compute_params`], [`to_mont`], [`from_mont`],
+//!   [`mul`].
+//!
+//! - **Wide-REDC path** (`R = 2^W` exactly the word width): the
+//!   complete-pipeline operations [`mod_mul`] and [`mod_exp`] use this
+//!   internally. Overflow-free for full-width moduli; no caller-visible
+//!   Montgomery params required.
+//!
+//! For the high-level type-safe surface, see
+//! [`modmath::Field`](crate::Field) — Montgomery context with
+//! lifetime-branded residues.
+//!
+//! ## N' computation method
+//!
+//! [`compute_params`] uses a default algorithm internally. To pick
+//! between trial-search / extended-Euclidean / Hensel's lifting, use
+//! [`compute_params_with_method`] with an explicit
+//! [`crate::NPrimeMethod`] choice. (The complete pipelines [`mod_mul`]
+//! and [`mod_exp`] use wide-REDC which mandates Newton; method
+//! selection is meaningful only on the R>N building-block path.)
+
+// R > N path building blocks
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_compute_montgomery_params as compute_params;
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_compute_montgomery_params_with_method as compute_params_with_method;
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_from_montgomery as from_mont;
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_montgomery_mul as mul;
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_to_montgomery as to_mont;
+
+// Wide-REDC complete-pipeline operations
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp as mod_exp;
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul as mod_mul;
+
+/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
+/// the input `% m` reduction step is skipped.
+pub mod pre_reduced {
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr as mod_exp;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr as mod_mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mul_pr as mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_to_montgomery_pr as to_mont;
+}
+
+/// Constant-time variants. The complete-pipeline operations with
+/// branchless conditional-subtract finalize via
+/// `subtle::ConditionallySelectable`, removing the operand-magnitude
+/// side-channel on the final reduction step.
+///
+/// Only `mod_exp` has both NCT and CT siblings here today; there is no
+/// `mod_mul_ct` because the underlying source crate hasn't published
+/// one (the CIOS path is the canonical CT-mul entry point — see
+/// [`modmath::montgomery::cios::cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)).
+pub mod ct {
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_ct as mod_exp;
+
+    /// Pre-reduced CT variants.
+    pub mod pre_reduced {
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_ct as mod_exp;
+    }
+}
+
+/// Wide-REDC primitives at the `R = 2^W` working width — by-value
+/// operands, `Copy`-bound `T`. These are the building blocks the
+/// [`mod_mul`] / [`mod_exp`] pipelines call internally; consumers
+/// reach for them directly when implementing their own Montgomery
+/// pipelines (PQC's `Mont` newtype pattern, RSA's `ModMathParams`).
+///
+/// For the reference-based variant suitable for non-`Copy` bigint
+/// backends, see [`modmath::strict::montgomery::wide`](crate::strict::montgomery::wide).
+pub mod wide {
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::wide_montgomery_mul as mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::wide_redc as redc;
+
+    /// Constant-time finalize. Branchless conditional-subtract via
+    /// `subtle::ConditionallySelectable`.
+    pub mod ct {
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::wide_montgomery_mul_ct as mul;
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::wide_redc_ct as redc;
+    }
+}

--- a/modmath/src/constrained/mod.rs
+++ b/modmath/src/constrained/mod.rs
@@ -1,0 +1,44 @@
+//! Schoolbook modular arithmetic for `Clone`-bound types with mixed
+//! by-value and by-reference parameters.
+//!
+//! Use this module when the operand type satisfies `T: Clone + ...`
+//! but not necessarily `Copy` — heap-allocated bigints like
+//! `num_bigint::BigUint`, `ibig::UBig`, and `bnum` types fit here.
+//!
+//! See [`modmath::basic`](crate::basic) for the simpler `Copy`-bound
+//! surface and [`modmath::strict`](crate::strict) for the
+//! reference-only surface (works with backends that don't expose
+//! `WrappingMul` / `WrappingSub` on owned values).
+//!
+//! ## Pre-reduced variants
+//!
+//! [`pre_reduced`] mirrors this module's surface but assumes inputs
+//! are already in `[0, m)`, skipping the `% m` reduction step. Works
+//! for backends without `core::ops::Rem` and is the right entry point
+//! inside loops where reduction is handled separately.
+
+#[doc(inline)]
+pub use crate::add::constrained_mod_add as add;
+#[doc(inline)]
+pub use crate::exp::constrained_mod_exp as exp;
+#[doc(inline)]
+pub use crate::inv::constrained_mod_inv as inv;
+#[doc(inline)]
+pub use crate::mul::constrained_mod_mul as mul;
+#[doc(inline)]
+pub use crate::sub::constrained_mod_sub as sub;
+
+pub mod montgomery;
+
+/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
+/// no `Rem` bound.
+pub mod pre_reduced {
+    #[doc(inline)]
+    pub use crate::add::constrained_mod_add_pr as add;
+    #[doc(inline)]
+    pub use crate::exp::constrained_mod_exp_pr as exp;
+    #[doc(inline)]
+    pub use crate::mul::constrained_mod_mul_pr as mul;
+    #[doc(inline)]
+    pub use crate::sub::constrained_mod_sub_pr as sub;
+}

--- a/modmath/src/constrained/mod.rs
+++ b/modmath/src/constrained/mod.rs
@@ -12,10 +12,13 @@
 //!
 //! ## Pre-reduced variants
 //!
-//! [`pre_reduced`] mirrors this module's surface but assumes inputs
-//! are already in `[0, m)`, skipping the `% m` reduction step. Works
-//! for backends without `core::ops::Rem` and is the right entry point
-//! inside loops where reduction is handled separately.
+//! [`pre_reduced`] re-exports `add` / `sub` / `mul` / `exp` siblings that
+//! assume inputs are already in `[0, m)` and skip the `% m` reduction
+//! step. Works for backends without `core::ops::Rem` and is the right
+//! entry point inside loops where reduction is handled separately.
+//! Note: `inv` has no pre-reduced sibling — modular inverse via the
+//! extended Euclidean algorithm inside `inv` performs its own
+//! magnitude-dependent loop, with no useful "pre-reduced" shortcut.
 
 #[doc(inline)]
 pub use crate::add::constrained_mod_add as add;

--- a/modmath/src/constrained/montgomery.rs
+++ b/modmath/src/constrained/montgomery.rs
@@ -1,0 +1,44 @@
+//! R > N Montgomery arithmetic for `Clone`-bound types with
+//! mixed by-value / by-reference parameters.
+//!
+//! Textbook Montgomery: pick `R` as the smallest power of 2 greater
+//! than the modulus, precompute `R⁻¹ mod N` and `N' = -N⁻¹ mod R`,
+//! transform values into Montgomery form, multiply in the Mont domain,
+//! transform back. Use [`compute_params`] to derive the parameters,
+//! [`to_mont`] / [`from_mont`] for representation transforms, and
+//! [`mul`] for in-Mont multiplication. The full-pipeline operations
+//! [`mod_mul`] and [`mod_exp`] wrap precompute + transform + arith.
+//!
+//! ## Distinction between `mul` and `mod_mul`
+//!
+//! - [`mul`] — takes Mont-form values and Montgomery params; returns
+//!   a Mont-form value. The in-domain multiplication step.
+//! - [`mod_mul`] — takes raw values and the modulus only; internally
+//!   computes Mont params, transforms inputs, multiplies, transforms
+//!   back. The complete `a * b mod m` pipeline.
+//!
+//! ## N' computation method
+//!
+//! [`compute_params`] uses a default algorithm. To pick explicitly
+//! between trial-search / extended-Euclidean / Hensel's lifting, use
+//! [`compute_params_with_method`], [`mod_mul_with_method`], or
+//! [`mod_exp_with_method`] with a [`crate::NPrimeMethod`] choice.
+
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_compute_montgomery_params as compute_params;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_compute_montgomery_params_with_method as compute_params_with_method;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_from_montgomery as from_mont;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_montgomery_mod_exp as mod_exp;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_montgomery_mod_exp_with_method as mod_exp_with_method;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_montgomery_mod_mul as mod_mul;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_montgomery_mod_mul_with_method as mod_mul_with_method;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_montgomery_mul as mul;
+#[doc(inline)]
+pub use crate::montgomery::constrained_mont::constrained_to_montgomery as to_mont;

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -85,6 +85,11 @@ where
         + core::ops::ShrAssign<usize>
         + Copy,
 {
+    // x mod 1 == 0 for every x, including 1. The square-and-multiply loop
+    // below starts with `result = T::one()` and would return 1 in that case.
+    if modulus == T::one() {
+        return T::zero();
+    }
     let mut result = T::one();
     let mut exp = exponent;
 
@@ -139,6 +144,10 @@ where
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>,
 {
+    // See `basic_mod_exp_pr` for the modulus==1 rationale.
+    if modulus == &T::one() {
+        return T::zero();
+    }
     let mut result = T::one();
     let mut exp = T::zero().wrapping_add(exponent);
     while exp > T::zero() {
@@ -196,6 +205,10 @@ where
         + core::ops::Shr<usize, Output = T>,
     for<'a> T: core::ops::ShrAssign<usize>,
 {
+    // See `basic_mod_exp_pr` for the modulus==1 rationale.
+    if modulus == &T::one() {
+        return T::zero();
+    }
     let mut result = T::one();
     let mut exp = T::zero().overflowing_add(exponent).0;
 
@@ -624,5 +637,27 @@ mod fixed_bigint_pr_tests {
         assert_eq!(constrained_mod_exp_pr(base, &exp, &m), expected);
         let base = U256::from(7u8);
         assert_eq!(basic_mod_exp_pr(base, exp, m), expected);
+    }
+
+    /// Regression: every value mod 1 is 0, including 1. The square-and-multiply
+    /// loop starts with `result = T::one()` and used to return 1 here.
+    #[test]
+    fn test_mod_exp_modulus_one_pr() {
+        let m = U256::from(1u8);
+        let zero = U256::from(0u8);
+        // Exercise a representative grid of (base, exponent) pairs.
+        let bases = [0u8, 1, 2, 7, 42, 255];
+        let exps = [0u8, 1, 2, 5, 100];
+        for &b in &bases {
+            for &e in &exps {
+                let base = U256::from(b);
+                let exp = U256::from(e);
+                assert_eq!(strict_mod_exp_pr(base, &exp, &m), zero);
+                let base = U256::from(b);
+                assert_eq!(constrained_mod_exp_pr(base, &exp, &m), zero);
+                let base = U256::from(b);
+                assert_eq!(basic_mod_exp_pr(base, exp, m), zero);
+            }
+        }
     }
 }

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "nightly")]
 use super::mul::const_mod_mul;
-use super::mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};
+use super::mul::{basic_mod_mul_pr, constrained_mod_mul_pr, strict_mod_mul_pr};
 
 #[cfg(feature = "nightly")]
 use fixed_bigint::const_numtraits::{
@@ -48,7 +48,7 @@ c0nst::c0nst! {
 /// # Modular Exponentiation (Basic)
 /// Simple version that operates on values and copies them. Requires
 /// `WrappingAdd` and `WrappingSub` traits to be implemented.
-pub fn basic_mod_exp<T>(mut base: T, exponent: T, modulus: T) -> T
+pub fn basic_mod_exp<T>(base: T, exponent: T, modulus: T) -> T
 where
     T: PartialOrd
         + num_traits::One
@@ -61,19 +61,41 @@ where
         + core::ops::ShrAssign<usize>
         + Copy,
 {
-    let mut result = T::one() % modulus;
-    let mut exp = exponent;
+    if modulus == T::one() {
+        return T::zero();
+    }
+    basic_mod_exp_pr(base % modulus, exponent, modulus)
+}
 
-    base = base % modulus;
+/// # Modular Exponentiation (Basic, pre-reduced)
+/// Precondition: `base < modulus` and `modulus > 1`. No `Rem` bound.
+///
+/// Note: this only removes the division side-channel from the signature.
+/// The square-and-multiply loop still branches on `exp.is_odd()`; for a
+/// constant-time ladder, use the Montgomery wide-REDC path.
+pub fn basic_mod_exp_pr<T>(mut base: T, exponent: T, modulus: T) -> T
+where
+    T: PartialOrd
+        + num_traits::One
+        + num_traits::Zero
+        + crate::parity::Parity
+        + core::ops::Shr<usize, Output = T>
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub
+        + core::ops::ShrAssign<usize>
+        + Copy,
+{
+    let mut result = T::one();
+    let mut exp = exponent;
 
     while exp > T::zero() {
         if exp.is_odd() {
-            result = basic_mod_mul(result, base, modulus);
+            result = basic_mod_mul_pr(result, base, modulus);
         }
         exp >>= 1;
 
         if exp > T::zero() {
-            base = basic_mod_mul(base, base, modulus);
+            base = basic_mod_mul_pr(base, base, modulus);
         }
     }
     result
@@ -97,17 +119,39 @@ where
         + core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
+    if modulus == &T::one() {
+        return T::zero();
+    }
     base.rem_assign(modulus);
-    let mut result = T::one() % modulus;
+    constrained_mod_exp_pr(base, exponent, modulus)
+}
+
+/// # Modular Exponentiation (Constrained, pre-reduced)
+/// Precondition: `base < *modulus` and `*modulus > 1`. No `Rem` family bound.
+pub fn constrained_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
+where
+    T: PartialOrd
+        + num_traits::One
+        + num_traits::Zero
+        + crate::parity::Parity
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub
+        + core::ops::ShrAssign<usize>
+        + core::ops::Shr<usize, Output = T>,
+{
+    let mut result = T::one();
     let mut exp = T::zero().wrapping_add(exponent);
     while exp > T::zero() {
         if exp.is_odd() {
-            result = constrained_mod_mul(result, &base, modulus);
+            result = constrained_mod_mul_pr(result, &base, modulus);
         }
         exp >>= 1;
         if exp > T::zero() {
+            // Squaring step: `mul_pr` consumes `a` (first arg) and borrows
+            // `b` (second arg); when both come from the same `base`, we
+            // still need one clone so the borrow doesn't alias the move.
             let tmp_base = T::zero().wrapping_add(&base);
-            base = constrained_mod_mul(base, &tmp_base, modulus);
+            base = constrained_mod_mul_pr(base, &tmp_base, modulus);
         }
     }
     result
@@ -132,19 +176,41 @@ where
         + core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
-    let mut result = T::one() % modulus;
+    if modulus == &T::one() {
+        return T::zero();
+    }
     base.rem_assign(modulus);
+    strict_mod_exp_pr(base, exponent, modulus)
+}
+
+/// # Modular Exponentiation (Strict, pre-reduced)
+/// Precondition: `base < *modulus` and `*modulus > 1`. No `Rem` family bound.
+pub fn strict_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
+where
+    T: PartialOrd
+        + num_traits::One
+        + num_traits::Zero
+        + crate::parity::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub
+        + core::ops::Shr<usize, Output = T>,
+    for<'a> T: core::ops::ShrAssign<usize>,
+{
+    let mut result = T::one();
     let mut exp = T::zero().overflowing_add(exponent).0;
 
     while exp > T::zero() {
         if exp.is_odd() {
-            result = strict_mod_mul(result, &base, modulus);
+            result = strict_mod_mul_pr(result, &base, modulus);
         }
         exp >>= 1;
 
         if exp > T::zero() {
+            // Squaring step: `mul_pr` consumes `a` (first arg) and borrows
+            // `b` (second arg); when both come from the same `base`, we
+            // still need one clone so the borrow doesn't alias the move.
             let tmp_base = T::zero().overflowing_add(&base).0;
-            base = strict_mod_mul(base, &tmp_base, modulus);
+            base = strict_mod_mul_pr(base, &tmp_base, modulus);
         }
     }
     result
@@ -512,6 +578,9 @@ mod bnum_exp_tests {
         basic: off, // Copy cannot be implemented, heap allocation
     );
 
+    // Default (Nct-personality) FixedUInt provides Rem; the wrapper
+    // functions are usable here. The Ct personality intentionally omits
+    // Rem (variable-time on operand magnitudes).
     exp_test_module!(
         fixed_bigint,
         fixed_bigint::FixedUInt,
@@ -520,4 +589,40 @@ mod bnum_exp_tests {
         constrained: on,
         basic: on,
     );
+}
+
+#[cfg(test)]
+mod fixed_bigint_pr_tests {
+    use super::{basic_mod_exp_pr, constrained_mod_exp_pr, strict_mod_exp_pr};
+    type U256 = fixed_bigint::FixedUInt<u8, 4>;
+
+    #[test]
+    fn test_mod_exp_basic_pr() {
+        // 5^3 mod 13 = 125 mod 13 = 8
+        let base = U256::from(5u8);
+        let exp = U256::from(3u8);
+        let m = U256::from(13u8);
+        let expected = U256::from(8u8);
+
+        assert_eq!(strict_mod_exp_pr(base, &exp, &m), expected);
+        let base = U256::from(5u8);
+        assert_eq!(constrained_mod_exp_pr(base, &exp, &m), expected);
+        let base = U256::from(5u8);
+        assert_eq!(basic_mod_exp_pr(base, exp, m), expected);
+    }
+
+    #[test]
+    fn test_mod_exp_zero_exponent_pr() {
+        // x^0 mod m = 1 (for m > 1)
+        let base = U256::from(7u8);
+        let exp = U256::from(0u8);
+        let m = U256::from(13u8);
+        let expected = U256::from(1u8);
+
+        assert_eq!(strict_mod_exp_pr(base, &exp, &m), expected);
+        let base = U256::from(7u8);
+        assert_eq!(constrained_mod_exp_pr(base, &exp, &m), expected);
+        let base = U256::from(7u8);
+        assert_eq!(basic_mod_exp_pr(base, exp, m), expected);
+    }
 }

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -68,7 +68,8 @@ where
 }
 
 /// # Modular Exponentiation (Basic, pre-reduced)
-/// Precondition: `base < modulus` and `modulus > 1`. No `Rem` bound.
+/// Precondition: if `modulus > 1`, then `base < modulus`. No `Rem` bound.
+/// Returns `0` when `modulus == 1`.
 ///
 /// Note: this only removes the division side-channel from the signature.
 /// The square-and-multiply loop still branches on `exp.is_odd()`; for a
@@ -132,7 +133,8 @@ where
 }
 
 /// # Modular Exponentiation (Constrained, pre-reduced)
-/// Precondition: `base < *modulus` and `*modulus > 1`. No `Rem` family bound.
+/// Precondition: if `*modulus > 1`, then `base < *modulus`. No `Rem` family bound.
+/// Returns `0` when `*modulus == 1`.
 pub fn constrained_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
 where
     T: PartialOrd
@@ -193,7 +195,8 @@ where
 }
 
 /// # Modular Exponentiation (Strict, pre-reduced)
-/// Precondition: `base < *modulus` and `*modulus > 1`. No `Rem` family bound.
+/// Precondition: if `*modulus > 1`, then `base < *modulus`. No `Rem` family bound.
+/// Returns `0` when `*modulus == 1`.
 pub fn strict_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
 where
     T: PartialOrd

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1,0 +1,982 @@
+//! `Field<T, P>` — Montgomery-form modular arithmetic context, parameterized
+//! over the limb personality (`P: Personality`).
+//!
+//! This module owns the *generic* Montgomery surface (`mul`, `exp`, `add`,
+//! `sub`, `reduce`, `into_raw`, `zero`, `one`); curve- or RSA-specific
+//! specializations (`lazy_add`, Fermat `inv`, Solinas reduction, etc.) live
+//! in consumer crates that wrap these types.
+//!
+//! ## Personality parameter
+//!
+//! `Field<T, P>` selects the *algorithm* at the modmath level (variable-
+//! time CIOS with branching finalize vs. CT CIOS with conditional-select
+//! finalize); the personality of `T` itself (e.g. `FixedUInt<W, N, Nct>`
+//! vs `FixedUInt<W, N, Ct>`) selects the *limb-primitive* bodies. In
+//! practice the two personalities co-vary at the construction site —
+//! you build `Field<FixedUInt<W, N, Nct>, Nct>` for verify paths and
+//! `Field<FixedUInt<W, N, Ct>, Ct>` for signing paths. Type aliases
+//! [`FieldCt`] / [`FieldNct`] (and the matching [`ResidueCt`] /
+//! [`ResidueNct`]) are the canonical per-personality spellings — they
+//! read naturally at the call site and sidestep the type-inference
+//! ambiguity that bare `Field::new(modulus)` hits when two `impl`
+//! blocks (Nct/Ct) are both method-resolution candidates.
+//!
+//! Because the Nct and Ct algorithms have **different trait bounds on `T`**
+//! (`T: CiosMontMul` for Nct vs `T: CiosMontMulCt + ConditionallySelectable`
+//! for Ct), the per-personality method bodies live in separate `impl`
+//! blocks rather than dispatching via `match P::TAG`. Only the bounds
+//! shared by both algorithms (precompute, `new`, `zero`, `one`, the
+//! residue brand) live in the common `impl<T, P: Personality>` block.
+//!
+//! ## Branding
+//!
+//! Each `Field<T, P>` instance is implicitly tagged by its borrow lifetime
+//! `'f`, and the residues it produces carry that same brand plus the
+//! personality parameter:
+//!
+//! ```ignore
+//! let field = Field::new(modulus).unwrap();
+//! let r: Residue<'_, U256, Nct> = field.reduce(&seven);
+//! ```
+//!
+//! The borrow checker prevents a `Residue` from outliving its parent
+//! `Field`, and the `P` parameter prevents an Nct residue from being fed
+//! to a Ct method (and vice versa) at compile time. Covariance does not
+//! prevent mixing residues from two `Field` instances built in the same
+//! scope with the same `P` — a known limitation matched by ed25519's
+//! `field.rs`. A generative brand
+//! (`PhantomData<fn(&'f ()) -> &'f ()>` + closure) would close that gap
+//! when a future consumer needs it.
+
+use core::marker::PhantomData;
+
+use fixed_bigint::{Ct, Nct, Personality};
+
+use crate::montgomery::basic_mont::{
+    wide_montgomery_mul, wide_montgomery_mul_ct, wide_redc, wide_redc_ct,
+};
+use crate::montgomery::{
+    CiosMontMul, CiosMontMulCt, compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n,
+    type_bit_width,
+};
+use crate::parity::Parity;
+use crate::wide_mul::WideMul;
+
+// ---------------------------------------------------------------------------
+// Field<T, P>
+// ---------------------------------------------------------------------------
+
+/// Montgomery context over modulus `T`, with algorithm choice driven by
+/// the personality marker `P` (defaults to [`Nct`] = variable-time fast
+/// path).
+///
+/// Use `Field<T, Nct>` for operations on **public** data only — signature
+/// verification, RSA public-key encryption, anything whose inputs are not
+/// secret. Use `Field<T, Ct>` (also reachable via the [`FieldCt`] type
+/// alias) for secret-handling paths.
+///
+/// `Clone` is a trivial 4×`T` memcpy — it does NOT re-run the
+/// `compute_r_mod_n` / `compute_r2_mod_n` precompute that `new()` does.
+/// Callers building a `Field` once per key and then reusing it (e.g.
+/// RSA-CRT) should clone the prebuilt instance rather than calling
+/// `new()` again with the same modulus.
+#[derive(Clone, Debug)]
+pub struct Field<T, P: Personality = Nct> {
+    modulus: T,
+    n_prime: T,
+    r_mod_n: T,
+    r2_mod_n: T,
+    _p: PhantomData<fn() -> P>,
+}
+
+/// Alias for the Nct variant of [`Field`]. Equivalent to `Field<T, Nct>`
+/// (matches the default personality). Provided for symmetry with
+/// [`FieldCt`] and to side-step the construction-site type-ambiguity
+/// pitfall — `FieldNct::new(modulus)` resolves unambiguously without
+/// the type-annotation/turbofish friction of `Field::new(modulus)`.
+pub type FieldNct<T> = Field<T, Nct>;
+
+/// Alias for the Ct variant of [`Field`]. Equivalent to `Field<T, Ct>`.
+/// Reads naturally at construction sites and sidesteps the type-inference
+/// ambiguity that bare `Field::new(modulus)` hits — `FieldCt::new(modulus)`
+/// resolves unambiguously because the alias fixes `P = Ct` at the type
+/// level. Symmetric with [`FieldNct`].
+pub type FieldCt<T> = Field<T, Ct>;
+
+/// A value in `Field<T, P>`, stored implicitly in Montgomery form.
+///
+/// The `'f` lifetime brand ties this residue to its parent `Field`; the
+/// `P` parameter ties it to the parent's algorithm personality. The
+/// borrow checker rejects code that uses a residue after its `Field` is
+/// dropped, or that mixes residues across personalities. See module docs
+/// for the covariance caveat.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Residue<'f, T, P: Personality = Nct> {
+    mont: T,
+    _brand: PhantomData<&'f ()>,
+    _p: PhantomData<fn() -> P>,
+}
+
+/// Alias for the Nct variant of [`Residue`]. Equivalent to
+/// `Residue<'f, T, Nct>`. Symmetric with [`ResidueCt`].
+pub type ResidueNct<'f, T> = Residue<'f, T, Nct>;
+
+/// Alias for the Ct variant of [`Residue`]. Equivalent to
+/// `Residue<'f, T, Ct>`. Symmetric with [`ResidueNct`].
+pub type ResidueCt<'f, T> = Residue<'f, T, Ct>;
+
+// ---------------------------------------------------------------------------
+// Shared impls (any P)
+// ---------------------------------------------------------------------------
+
+impl<T: Copy, P: Personality> Residue<'_, T, P> {
+    /// Returns the underlying Montgomery-form value.
+    ///
+    /// **Escape hatch.** Intended for downstream specialization layers
+    /// (e.g. `Curve25519Field`) that implement fast paths reading the raw
+    /// limbs. General consumers should not call this — use the methods on
+    /// [`Field`] instead.
+    pub fn mont_value(self) -> T {
+        self.mont
+    }
+}
+
+impl<T, P: Personality> Field<T, P> {
+    /// Construct a `Field` directly from already-computed Montgomery
+    /// parameters. **`const fn` — usable in const initializers.**
+    ///
+    /// Intended for callers whose modulus is statically known at compile
+    /// time (curve constants, PQC parameters, RSA group constants for a
+    /// fixed key, etc.) and who want to expose the Field as a `const`
+    /// associated item or static, rather than paying the runtime
+    /// [`new`](Self::new) precompute on each instantiation.
+    ///
+    /// **The caller is responsible for the correctness of `n_prime`,
+    /// `r_mod_n`, and `r2_mod_n`** — see [`compute_n_prime_newton`],
+    /// [`compute_r_mod_n`], and [`compute_r2_mod_n`] for the algorithms.
+    /// Those helpers are not `const fn` today (their bodies use trait
+    /// method calls on `T`), so const-initializer callers must either
+    /// hand-compute the values, use a build script, or — for primitive
+    /// integers — compute them in a non-const context once at startup
+    /// and cache.
+    ///
+    /// No invariant checking is performed here. Passing inconsistent
+    /// parameters produces a `Field` whose arithmetic methods return
+    /// silently incorrect results.
+    ///
+    /// [`compute_n_prime_newton`]: crate::compute_n_prime_newton
+    /// [`compute_r_mod_n`]: crate::compute_r_mod_n
+    /// [`compute_r2_mod_n`]: crate::compute_r2_mod_n
+    pub const fn from_precomputed(modulus: T, n_prime: T, r_mod_n: T, r2_mod_n: T) -> Self {
+        Self {
+            modulus,
+            n_prime,
+            r_mod_n,
+            r2_mod_n,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T, P: Personality> Field<T, P>
+where
+    T: Copy
+        + PartialEq
+        + PartialOrd
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + num_traits::ops::overflowing::OverflowingAdd
+        + Parity,
+{
+    /// Construct a new `Field` over the given (odd, nonzero) `modulus`.
+    ///
+    /// Returns `None` if `modulus` is zero or even (Montgomery requires odd N).
+    /// The precompute (`compute_r_mod_n` / `compute_r2_mod_n`) is
+    /// personality-agnostic — only depends on common modular arithmetic.
+    pub fn new(modulus: T) -> Option<Self> {
+        if modulus == T::zero() || modulus.is_even() {
+            return None;
+        }
+        let w = type_bit_width::<T>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+        Some(Self {
+            modulus,
+            n_prime,
+            r_mod_n,
+            r2_mod_n,
+            _p: PhantomData,
+        })
+    }
+
+    /// Returns the modulus by reference.
+    ///
+    /// Returning `&T` rather than `T` avoids a memcpy of the full modulus
+    /// (~256 bytes for 2048-bit FixedUInt) at the call site. Consumers that
+    /// need a `T` by value can copy at the use point.
+    pub fn modulus(&self) -> &T {
+        &self.modulus
+    }
+
+    /// The additive identity (0 in Montgomery form is 0).
+    pub fn zero(&self) -> Residue<'_, T, P> {
+        Residue {
+            mont: T::zero(),
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// The multiplicative identity (1 in Montgomery form is `R mod N`).
+    pub fn one(&self) -> Residue<'_, T, P> {
+        Residue {
+            mont: self.r_mod_n,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Reconstruct a [`Residue`] from a raw value already in Montgomery form.
+    ///
+    /// **Escape hatch.** Intended for downstream specialization layers that
+    /// persist or compute Montgomery-form values outside this module and
+    /// need to re-attach the brand. The caller must guarantee `mont` is in
+    /// `[0, modulus)` and represents some value `x` such that
+    /// `mont == x * R mod modulus`.
+    pub fn residue_from_mont(&self, mont: T) -> Residue<'_, T, P> {
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nct-only impls — variable-time CIOS with branching finalize
+// ---------------------------------------------------------------------------
+
+impl<T> Field<T, Nct>
+where
+    T: Copy
+        + PartialEq
+        + PartialOrd
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + num_traits::ops::overflowing::OverflowingAdd
+        + Parity,
+{
+    /// Convert a raw value `< modulus` (or arbitrary value, which is then
+    /// reduced) to Montgomery form. Returns a brand-tagged [`Residue`].
+    pub fn reduce(&self, raw: &T) -> Residue<'_, T, Nct>
+    where
+        T: WideMul,
+    {
+        let mont = wide_montgomery_mul(*raw, self.r2_mod_n, self.modulus, self.n_prime);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Convert a [`Residue`] back to its raw `T` representative in `[0, modulus)`.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn into_raw(&self, r: &Residue<'_, T, Nct>) -> T
+    where
+        T: WideMul,
+    {
+        wide_redc(r.mont, T::zero(), self.modulus, self.n_prime)
+    }
+
+    /// Modular addition: `(a + b) mod modulus`.
+    ///
+    /// **The conditional-subtract here is non-negotiable.** Future consumers
+    /// with a modulus narrower than `T::BITS` may be tempted to skip the
+    /// `wrapping_add` + cond-sub path (since `2 * modulus < 2^T::BITS` for
+    /// them, the wraparound never fires). That's a correct optimization, but
+    /// it belongs in a specialization layer (e.g. `Curve25519Field` in the
+    /// ed25519 crate), not in `modmath::Field`. Patches removing the
+    /// wrapping path will break RSA-CRT (full-width modulus, no slack) and
+    /// any other consumer at full type width; ed25519 has slack and uses its
+    /// own lazy variant in `Curve25519Field`.
+    pub fn add(&self, a: &Residue<'_, T, Nct>, b: &Residue<'_, T, Nct>) -> Residue<'_, T, Nct> {
+        let mont = crate::add::basic_mod_add_pr(a.mont, b.mont, self.modulus);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular subtraction: `(a - b) mod modulus`.
+    ///
+    /// Same load-bearing contract as [`add`](Self::add) — the borrow-detect
+    /// branch is required at full type width.
+    pub fn sub(&self, a: &Residue<'_, T, Nct>, b: &Residue<'_, T, Nct>) -> Residue<'_, T, Nct> {
+        let mont = crate::sub::basic_mod_sub_pr(a.mont, b.mont, self.modulus);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular multiplication via CIOS Montgomery multiplication.
+    ///
+    /// CIOS interleaves multiplication and reduction in one pass (~2N² + N
+    /// limb mults vs ~3N² for separate wide-mul + REDC), which dominates the
+    /// inner-loop cost on constrained cores. The functional output is
+    /// identical to `wide_montgomery_mul`.
+    ///
+    /// Marked `#[inline]` deliberately: this is the documented inner-loop
+    /// wrapper for Montgomery exponentiation, the body is a single trait
+    /// method call, and skipping it across crate boundaries costs ~250
+    /// cycles per call under `opt-level="z"` on Cortex-M. Not blanket cargo
+    /// culting — surgical on the actual hot path.
+    #[inline]
+    pub fn mul(&self, a: &Residue<'_, T, Nct>, b: &Residue<'_, T, Nct>) -> Residue<'_, T, Nct>
+    where
+        T: CiosMontMul,
+    {
+        let mont = CiosMontMul::cios_mont_mul(&a.mont, &b.mont, &self.modulus, &self.n_prime)
+            .expect("CIOS mul cannot fail with valid Montgomery parameters");
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular exponentiation via square-and-multiply.
+    ///
+    /// `base` is taken as a [`Residue`] (already in Montgomery form); `exp`
+    /// is a raw `T`. The result is a [`Residue`] in Montgomery form.
+    ///
+    /// **Variable-time in `exp`.** The loop iterates `bit_length(exp)` times
+    /// and branches on each bit. Do not call with a secret `exp` — use the
+    /// Ct-variant `Field<T, Ct>::exp` instead.
+    pub fn exp(&self, base: &Residue<'_, T, Nct>, exp: &T) -> Residue<'_, T, Nct>
+    where
+        T: CiosMontMul + core::ops::ShrAssign<usize>,
+    {
+        let mut result = self.r_mod_n;
+        let mut base_var = base.mont;
+        let mut exp_val = *exp;
+        while exp_val > T::zero() {
+            if exp_val.is_odd() {
+                result =
+                    CiosMontMul::cios_mont_mul(&result, &base_var, &self.modulus, &self.n_prime)
+                        .expect("CIOS mul cannot fail with valid Montgomery parameters");
+            }
+            exp_val >>= 1;
+            if exp_val > T::zero() {
+                base_var =
+                    CiosMontMul::cios_mont_mul(&base_var, &base_var, &self.modulus, &self.n_prime)
+                        .expect("CIOS mul cannot fail with valid Montgomery parameters");
+            }
+        }
+        Residue {
+            mont: result,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ct-only impls — CT CIOS with conditional-select finalize
+// ---------------------------------------------------------------------------
+
+impl<'f, T> Residue<'f, T, Ct>
+where
+    T: subtle::ConditionallySelectable,
+{
+    /// Conditionally swap two residues in constant time.
+    ///
+    /// If `choice` is set, `a` and `b` exchange Montgomery-form values;
+    /// otherwise both are left unchanged. The operation is branchless.
+    ///
+    /// This is the primitive used by Montgomery ladders (x25519 scalar
+    /// multiplication, RSA blinded exponentiation). It is the **only**
+    /// residue swap that should appear in such a ladder; `std::mem::swap`
+    /// is not guaranteed to be branchless.
+    pub fn cswap(choice: subtle::Choice, a: &mut Self, b: &mut Self) {
+        T::conditional_swap(&mut a.mont, &mut b.mont, choice);
+    }
+}
+
+impl<T> Field<T, Ct>
+where
+    T: Copy
+        + PartialEq
+        + PartialOrd
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + num_traits::ops::overflowing::OverflowingAdd
+        + Parity,
+{
+    /// Convert a raw value to Montgomery form. Constant-time finalize.
+    pub fn reduce(&self, raw: &T) -> Residue<'_, T, Ct>
+    where
+        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+    {
+        let mont = wide_montgomery_mul_ct(*raw, self.r2_mod_n, self.modulus, self.n_prime);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Convert a [`Residue`] back to raw form. Constant-time finalize.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn into_raw(&self, r: &Residue<'_, T, Ct>) -> T
+    where
+        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+    {
+        wide_redc_ct(r.mont, T::zero(), self.modulus, self.n_prime)
+    }
+
+    /// Modular addition — constant-time finalize.
+    ///
+    /// See `Field<T, Nct>::add` for the load-bearing comment about why the
+    /// wrapping cond-sub path is non-negotiable.
+    pub fn add(&self, a: &Residue<'_, T, Ct>, b: &Residue<'_, T, Ct>) -> Residue<'_, T, Ct>
+    where
+        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+    {
+        let sum = a.mont.wrapping_add(&b.mont);
+        let sub = sum.wrapping_sub(&self.modulus);
+        // Carry from wrapping: sum < a means wraparound occurred.
+        let carry = sum.ct_lt(&a.mont);
+        // Result >= modulus when !(sum < modulus).
+        let ge_m = !sum.ct_lt(&self.modulus);
+        let needs_sub = carry | ge_m;
+        let mont = T::conditional_select(&sum, &sub, needs_sub);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular subtraction — constant-time finalize.
+    ///
+    /// Same contract as `Field<T, Nct>::sub`.
+    pub fn sub(&self, a: &Residue<'_, T, Ct>, b: &Residue<'_, T, Ct>) -> Residue<'_, T, Ct>
+    where
+        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+    {
+        let diff = a.mont.wrapping_sub(&b.mont);
+        let corrected = diff.wrapping_add(&self.modulus);
+        // borrow == (a < b)
+        let borrow = a.mont.ct_lt(&b.mont);
+        let mont = T::conditional_select(&diff, &corrected, borrow);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular multiplication via CIOS — constant-time finalize.
+    ///
+    /// See `Field<T, Nct>::mul` for the rationale on CIOS vs. wide-REDC and
+    /// the `#[inline]` justification.
+    #[inline]
+    pub fn mul(&self, a: &Residue<'_, T, Ct>, b: &Residue<'_, T, Ct>) -> Residue<'_, T, Ct>
+    where
+        T: CiosMontMulCt,
+    {
+        let mont = CiosMontMulCt::cios_mont_mul_ct(&a.mont, &b.mont, &self.modulus, &self.n_prime)
+            .expect("CIOS-CT mul cannot fail with valid Montgomery parameters");
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular exponentiation — constant-time over `exp`.
+    ///
+    /// Implements a fixed-iteration Montgomery ladder over all
+    /// `bit_length(T)` bits of the exponent. Both square and multiply are
+    /// performed every iteration; the result is selected branchlessly. Loop
+    /// count does not depend on `exp`; per-iteration timing does not depend
+    /// on the bit pattern.
+    pub fn exp(&self, base: &Residue<'_, T, Ct>, exp: &T) -> Residue<'_, T, Ct>
+    where
+        T: CiosMontMulCt
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeEq
+            + core::ops::Shr<usize, Output = T>
+            + core::ops::BitAnd<Output = T>,
+    {
+        let w = type_bit_width::<T>();
+        let one = T::one();
+        let mut result = self.r_mod_n;
+
+        for i in (0..w).rev() {
+            // Always square.
+            result =
+                CiosMontMulCt::cios_mont_mul_ct(&result, &result, &self.modulus, &self.n_prime)
+                    .expect("CIOS-CT mul cannot fail with valid Montgomery parameters");
+            // Always compute the conditional product.
+            let multiplied =
+                CiosMontMulCt::cios_mont_mul_ct(&result, &base.mont, &self.modulus, &self.n_prime)
+                    .expect("CIOS-CT mul cannot fail with valid Montgomery parameters");
+            // Select based on bit i of exp.
+            let bit_t = (*exp >> i) & one;
+            let choice = bit_t.ct_eq(&one);
+            result = T::conditional_select(&result, &multiplied, choice);
+        }
+        Residue {
+            mont: result,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular exponentiation — constant-time over the base, **variable-time
+    /// over the exponent**. Use when the exponent is public.
+    ///
+    /// This is the right primitive for several common cryptographic shapes:
+    ///
+    /// - **RSA encrypt / verify** — `m^e mod n` with the secret message `m`
+    ///   and the public exponent `e` (typically 65537). Saves `bit_length(T)
+    ///   - bit_length(e)` squarings vs. the fixed-iteration ladder, which is
+    ///   ~2031 squarings at 2048-bit modulus when `e = 65537`.
+    /// - **Curve25519 Fermat inverse** — `a^(p-2) mod p` where `p - 2` is the
+    ///   curve constant `2^255 - 21`. The exponent is public; the base is
+    ///   the secret intermediate `Z`. Skip-on-zero square-and-multiply
+    ///   matches the ~252-of-255 bits set without spending the per-bit
+    ///   `conditional_select` cost of the fixed-iteration ladder.
+    /// - **Curve25519 square root** — `a^((p+3)/8) mod p`, same shape.
+    ///
+    /// The squarings and multiplications themselves go through CT primitives
+    /// ([`cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)),
+    /// so the
+    /// base and intermediate Montgomery values do not leak through timing.
+    /// What DOES leak is the bit pattern of `exp` — which is fine by
+    /// construction: the caller asserts the exponent is public.
+    ///
+    /// **Do not call with a secret exponent.** Use [`exp`](Self::exp)
+    /// instead, which is a fixed-iteration Montgomery ladder.
+    pub fn exp_public_exp(&self, base: &Residue<'_, T, Ct>, exp: &T) -> Residue<'_, T, Ct>
+    where
+        T: CiosMontMulCt + core::ops::Shr<usize, Output = T> + core::ops::BitAnd<Output = T>,
+    {
+        let w = type_bit_width::<T>();
+        let one = T::one();
+        let zero = T::zero();
+
+        // Find the position of the highest set bit (1-indexed: hi == top + 1).
+        // This loop and the rest of the function leak `bit_length(exp)`,
+        // which is the documented contract — `exp` is public.
+        let mut hi = w;
+        while hi > 0 {
+            if (*exp >> (hi - 1)) & one != zero {
+                break;
+            }
+            hi -= 1;
+        }
+
+        if hi == 0 {
+            // exp == 0: return 1 in Montgomery form.
+            return Residue {
+                mont: self.r_mod_n,
+                _brand: PhantomData,
+                _p: PhantomData,
+            };
+        }
+
+        // The top bit is set, so result starts at `base` (base^1 contribution
+        // for the 2^(hi-1) term). Then iterate over the remaining bits.
+        let mut result = base.mont;
+        for i in (0..hi - 1).rev() {
+            // Square.
+            result =
+                CiosMontMulCt::cios_mont_mul_ct(&result, &result, &self.modulus, &self.n_prime)
+                    .expect("CIOS-CT mul cannot fail with valid Montgomery parameters");
+            // Multiply only when the bit is set — branch on a public value.
+            if (*exp >> i) & one != zero {
+                result = CiosMontMulCt::cios_mont_mul_ct(
+                    &result,
+                    &base.mont,
+                    &self.modulus,
+                    &self.n_prime,
+                )
+                .expect("CIOS-CT mul cannot fail with valid Montgomery parameters");
+            }
+        }
+
+        Residue {
+            mont: result,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NCT -> CT bridge (no generic `From` impl)
+// ---------------------------------------------------------------------------
+//
+// Under fixed-bigint's personality typestate, the bridge from a
+// `Field<T, Nct>` to a `Field<T, Ct>` over the same modulus value is not
+// a single type-level conversion — `T` itself has to cross personalities.
+// A `Field<TNct, Nct>` is only useful when `TNct` resolves to an Nct-typed
+// FixedUInt (so `MulAccOps::GetWordOutput = Option<...>` and
+// `CiosMontMul` resolves); a `Field<TCt, Ct>` is only useful when `TCt`
+// resolves to a Ct-typed FixedUInt (so `ConditionallySelectable` resolves).
+// Nct and Ct are distinct types, so a generic `From<Field<T, Nct>> for
+// Field<T, Ct>` over a single `T` lands you in a methodless variant on one
+// side or the other (the bounds in the per-P impl blocks don't resolve).
+//
+// The actual bridge pattern is:
+//
+// ```ignore
+// let f = Field::new(modulus_nct).unwrap();             // Field<TNct, Nct>
+// let modulus_ct: U256Ct = (*f.modulus()).into();       // free Nct -> Ct
+// let fc = Field::<_, Ct>::new(modulus_ct).unwrap();    // recompute params
+// // (or use the FieldCt alias: FieldCt::new(modulus_ct))
+// ```
+//
+// The recompute cost is the ~2·bit_length(T) modular doublings of
+// `compute_r_mod_n` + `compute_r2_mod_n` — ~10–15µs at 2048-bit on M3.
+// For long-lived keys (RSA-CRT) this is amortized; for ed25519 verify
+// it's noise. Consumers wanting a zero-cost personality bridge can
+// implement a type-specific bridge in their wrapper (see ed25519's
+// `Curve25519Field`).
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fixed_bigint::FixedUInt;
+
+    // Field<T, P> requires the right combination of T-bounds for the chosen
+    // P (CiosMontMul for Nct, CiosMontMulCt for Ct), which in practice means
+    // T must be a FixedUInt of the matching personality. Small tests use
+    // FixedUInt<u8, 2> aliases for tight ranges; larger tests use the U128
+    // family. Cross-personality tests bridge values via `.into()` (Nct → Ct)
+    // and `.forget_ct()` (explicit Ct → Nct).
+    type U16 = FixedUInt<u8, 2>;
+    type U16Ct = FixedUInt<u8, 2, Ct>;
+    type U128Ct = FixedUInt<u32, 4, Ct>;
+
+    fn u16(n: u16) -> U16 {
+        U16::from(n)
+    }
+
+    fn u16ct(n: u16) -> U16Ct {
+        U16Ct::from(n)
+    }
+
+    #[test]
+    fn round_trip_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        for raw in 0u16..13 {
+            let r = f.reduce(&u16(raw));
+            assert_eq!(f.into_raw(&r), u16(raw), "round trip failed for {raw}");
+        }
+    }
+
+    #[test]
+    fn add_sub_mul_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        for a_raw in 0u16..13 {
+            for b_raw in 0u16..13 {
+                let a = f.reduce(&u16(a_raw));
+                let b = f.reduce(&u16(b_raw));
+                assert_eq!(f.into_raw(&f.add(&a, &b)), u16((a_raw + b_raw) % 13));
+                assert_eq!(
+                    f.into_raw(&f.sub(&a, &b)),
+                    u16((a_raw + 13 - b_raw) % 13),
+                    "sub failed for {a_raw}, {b_raw}"
+                );
+                assert_eq!(f.into_raw(&f.mul(&a, &b)), u16((a_raw * b_raw) % 13));
+            }
+        }
+    }
+
+    #[test]
+    fn zero_one_identity_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        let z = f.zero();
+        let o = f.one();
+        assert_eq!(f.into_raw(&z), u16(0));
+        assert_eq!(f.into_raw(&o), u16(1));
+        // a + 0 = a, a * 1 = a
+        for raw in 0u16..13 {
+            let a = f.reduce(&u16(raw));
+            assert_eq!(f.into_raw(&f.add(&a, &z)), u16(raw));
+            assert_eq!(f.into_raw(&f.mul(&a, &o)), u16(raw));
+        }
+    }
+
+    #[test]
+    fn exp_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        // 7^5 mod 13 = 11
+        let base = f.reduce(&u16(7));
+        let result = f.exp(&base, &u16(5));
+        assert_eq!(f.into_raw(&result), u16(11));
+        // x^0 = 1
+        let r0 = f.exp(&base, &u16(0));
+        assert_eq!(f.into_raw(&r0), u16(1));
+    }
+
+    #[test]
+    fn ct_round_trip_small() {
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        for raw in 0u16..13 {
+            let r = f.reduce(&u16ct(raw));
+            assert_eq!(f.into_raw(&r), u16ct(raw));
+        }
+    }
+
+    #[test]
+    fn ct_matches_nct_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        let fc = FieldCt::new(u16ct(13)).unwrap();
+        for a_raw in 0u16..13 {
+            for b_raw in 0u16..13 {
+                let a = f.reduce(&u16(a_raw));
+                let b = f.reduce(&u16(b_raw));
+                let ac = fc.reduce(&u16ct(a_raw));
+                let bc = fc.reduce(&u16ct(b_raw));
+
+                assert_eq!(
+                    f.into_raw(&f.add(&a, &b)),
+                    fc.into_raw(&fc.add(&ac, &bc)).forget_ct()
+                );
+                assert_eq!(
+                    f.into_raw(&f.sub(&a, &b)),
+                    fc.into_raw(&fc.sub(&ac, &bc)).forget_ct()
+                );
+                assert_eq!(
+                    f.into_raw(&f.mul(&a, &b)),
+                    fc.into_raw(&fc.mul(&ac, &bc)).forget_ct()
+                );
+            }
+        }
+        // exp cross-check
+        let base = f.reduce(&u16(7));
+        let base_ct = fc.reduce(&u16ct(7));
+        for e in 0u16..20 {
+            assert_eq!(
+                f.into_raw(&f.exp(&base, &u16(e))),
+                fc.into_raw(&fc.exp(&base_ct, &u16ct(e))).forget_ct()
+            );
+        }
+    }
+
+    #[test]
+    fn ct_cswap_small() {
+        use subtle::Choice;
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        let mut a = f.reduce(&u16ct(3));
+        let mut b = f.reduce(&u16ct(7));
+        // choice = 0: no swap
+        ResidueCt::cswap(Choice::from(0), &mut a, &mut b);
+        assert_eq!(f.into_raw(&a), u16ct(3));
+        assert_eq!(f.into_raw(&b), u16ct(7));
+        // choice = 1: swap
+        ResidueCt::cswap(Choice::from(1), &mut a, &mut b);
+        assert_eq!(f.into_raw(&a), u16ct(7));
+        assert_eq!(f.into_raw(&b), u16ct(3));
+    }
+
+    /// Under personality, the safe NCT → CT bridge requires converting the
+    /// underlying T's personality (free `.into()` from fixed-bigint), then
+    /// constructing a fresh `Field<_, Ct>` on the Ct-typed modulus. Same-T
+    /// `Field<T, Nct> -> Field<T, Ct>` conversion is degenerate (the per-P
+    /// impl blocks have disjoint trait bounds, so the result is a methodless
+    /// variant); this test documents the actual bridge pattern.
+    #[test]
+    fn nct_to_ct_upgrade_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        let modulus_ct: U16Ct = (*f.modulus()).into();
+        let fc = FieldCt::new(modulus_ct).unwrap();
+        let a = fc.reduce(&u16ct(7));
+        let b = fc.reduce(&u16ct(5));
+        assert_eq!(fc.into_raw(&fc.mul(&a, &b)), u16ct(9)); // 35 mod 13 = 9
+    }
+
+    #[test]
+    fn exp_public_exp_matches_ct_exp_small() {
+        // For every (base, exp) pair, exp_public_exp must produce the same
+        // result as the fixed-iteration ladder exp.
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        let base = f.reduce(&u16ct(7));
+        for e in 0u16..32 {
+            let via_ladder = f.exp(&base, &u16ct(e));
+            let via_pub = f.exp_public_exp(&base, &u16ct(e));
+            assert_eq!(
+                f.into_raw(&via_ladder),
+                f.into_raw(&via_pub),
+                "exp_public_exp mismatch at e={e}"
+            );
+        }
+    }
+
+    #[test]
+    fn exp_public_exp_matches_ct_exp_u128() {
+        // Same cross-check at FixedUInt<u32, 4> sizes against a few
+        // characteristic exponents: 0, 1, small, a value with both low and
+        // high set bits.
+        let modulus = !U128Ct::from(0u64) - U128Ct::from(58u64);
+        let f = FieldCt::new(modulus).unwrap();
+        let base = f.reduce(&U128Ct::from(0xDEAD_BEEF_u64));
+        let exps = [
+            U128Ct::from(0u64),
+            U128Ct::from(1u64),
+            U128Ct::from(7u64),
+            U128Ct::from(65537u64), // RSA-style public exponent
+            U128Ct::from(0xCAFE_BABEu64),
+        ];
+        for e in &exps {
+            let via_ladder = f.exp(&base, e);
+            let via_pub = f.exp_public_exp(&base, e);
+            assert_eq!(
+                f.into_raw(&via_ladder),
+                f.into_raw(&via_pub),
+                "exp_public_exp mismatch at e={e:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn brand_round_trip_fixed_bigint_u128() {
+        // A larger odd modulus.
+        let modulus = !U128Ct::from(0u64) - U128Ct::from(58u64);
+        let f = FieldCt::new(modulus).unwrap();
+        let raw = U128Ct::from(0xDEAD_BEEF_u64);
+        let r = f.reduce(&raw);
+        assert_eq!(f.into_raw(&r), raw);
+    }
+
+    #[test]
+    fn residue_from_mont_escape_hatch_small() {
+        // Round-trip via the escape hatch: reduce -> mont_value -> residue_from_mont.
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        for raw in 0u16..13 {
+            let r = f.reduce(&u16(raw));
+            let mont = r.mont_value();
+            let r2 = f.residue_from_mont(mont);
+            assert_eq!(f.into_raw(&r2), u16(raw));
+        }
+    }
+
+    /// Documented limitation: covariance allows mixing residues across two
+    /// distinct Field instances built in the same scope. Asserts current
+    /// behavior (the compiler does NOT reject this) so a future generative
+    /// brand can be observed as a hardening change.
+    #[test]
+    fn covariance_mixes_residues_documented_limitation() {
+        let f1: Field<U16> = Field::new(u16(13)).unwrap();
+        let f2: Field<U16> = Field::new(u16(13)).unwrap();
+        let r1 = f1.reduce(&u16(5));
+        // f2 accepting r1 compiles today. This is a documented limitation; a
+        // generative brand would make this a type error.
+        let _ = f2.into_raw(&r1);
+    }
+
+    /// Personality demonstration: the same `Field` type signature
+    /// parameterized differently (`<_, Nct>` vs `<_, Ct>`) computes the
+    /// same modular arithmetic, with the personality choice driving which
+    /// algorithm (variable-time branch vs CT conditional-select finalize)
+    /// the compiler routes to via the per-P impl blocks.
+    ///
+    /// Also exercises the residue type discipline: a `Residue<_, _, Nct>`
+    /// passed to a `Field<_, Ct>` method would be a compile error
+    /// (different `P` parameter), and vice versa. Cross-personality
+    /// comparison goes through `.forget_ct()` rather than a same-type
+    /// `assert_eq!`.
+    #[test]
+    fn field_p_personality_cross_check_small() {
+        // Same modulus value, two personalities.
+        let m_nct = u16(13);
+        let m_ct: U16Ct = m_nct.into();
+
+        let f_nct: Field<U16, Nct> = Field::new(m_nct).unwrap();
+        let f_ct: Field<U16Ct, Ct> = Field::new(m_ct).unwrap();
+
+        // Pick a non-trivial product and exponentiation.
+        let a_nct = f_nct.reduce(&u16(7));
+        let b_nct = f_nct.reduce(&u16(5));
+        let a_ct = f_ct.reduce(&u16ct(7));
+        let b_ct = f_ct.reduce(&u16ct(5));
+
+        // Multiplication agrees across personalities.
+        let mul_nct = f_nct.into_raw(&f_nct.mul(&a_nct, &b_nct));
+        let mul_ct = f_ct.into_raw(&f_ct.mul(&a_ct, &b_ct));
+        assert_eq!(mul_nct, mul_ct.forget_ct());
+
+        // Exponentiation agrees (with different algorithms underneath:
+        // f_nct.exp is variable-time square-and-multiply, f_ct.exp is
+        // fixed-iteration ladder).
+        let exp_nct = f_nct.into_raw(&f_nct.exp(&a_nct, &u16(11)));
+        let exp_ct = f_ct.into_raw(&f_ct.exp(&a_ct, &u16ct(11)));
+        assert_eq!(exp_nct, exp_ct.forget_ct());
+    }
+
+    /// The `FieldNct<T>` alias side-steps the construction-site type-
+    /// ambiguity that bare `Field::new(modulus)` hits — no type annotation
+    /// or turbofish required, because the alias fixes `P = Nct` at the
+    /// type level (mirroring how `FieldCt::new` fixes `P = Ct`).
+    ///
+    /// Symmetric `ResidueNct` alias also exists for downstream consumers
+    /// who want symmetric naming. Used here just for the type spelling.
+    #[test]
+    fn field_nct_alias_resolves_without_annotation() {
+        let f = FieldNct::new(u16(13)).unwrap();
+        let r: ResidueNct<'_, U16> = f.reduce(&u16(7));
+        assert_eq!(f.into_raw(&r), u16(7));
+        let two = f.reduce(&u16(2));
+        assert_eq!(f.into_raw(&f.mul(&r, &two)), u16(14 % 13));
+    }
+
+    /// `from_precomputed` is `const fn` and usable in a const initializer.
+    /// This is the constructor static-modulus consumers (PQC, embedded RSA
+    /// with a baked key, etc.) reach for when they want to expose a `Field`
+    /// as a `const` associated item rather than paying the runtime
+    /// `Field::new` precompute.
+    ///
+    /// Demonstrated here over `u32` (primitive) — `Field<u32, Nct>` is
+    /// methodless because `u32` doesn't impl `CiosMontMul` (MulAccOps is
+    /// FixedUInt-only), but `from_precomputed` itself works for any
+    /// `T: Copy`. The intended consumer path is a downstream Mont-newtype
+    /// wrapper that calls modmath's standalone `wide_montgomery_mul[_ct]`
+    /// free functions, using `f.modulus()` to read the static modulus.
+    #[test]
+    fn from_precomputed_const_construction_u32() {
+        // Hand-computed Montgomery params for modulus 13 at word width 32:
+        //   n_prime  = -13^-1 mod 2^32 = 0x4EC4EC4F
+        //   r_mod_n  = 2^32 mod 13     = 9
+        //   r2_mod_n = (2^32)^2 mod 13 = 3
+        const F: Field<u32, Nct> = Field::from_precomputed(13u32, 0x4EC4EC4F, 9, 3);
+        assert_eq!(*F.modulus(), 13u32);
+        // The struct fields are accessible to anyone in the same crate
+        // through Field::modulus(); downstream consumers driving the Mont
+        // newtype pattern will pull modulus + n_prime + r/r2 via a Modulus
+        // trait extension on their own side and call modmath's standalone
+        // primitives. This test just proves the const-context construction
+        // path is real.
+    }
+}

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -317,6 +317,14 @@ mod bnum_inv_tests {
         basic: off, // Copy is not implemented, heap
     );
 
+    // fixed_bigint inv tests run on the Nct personality (the type alias
+    // default). The Ct personality intentionally lacks `Div`/`Rem` because
+    // EEA's inner loop count depends on operand magnitudes — schoolbook
+    // modular inverse is fundamentally variable-time and so does not
+    // belong on a CT-typed FixedUInt. Calling `basic_mod_inv` etc. with a
+    // Ct-typed value is a compile error rather than silent NCT execution,
+    // which is the safety property the personality typestate exists to
+    // enforce.
     inv_test_module!(
         fixed_bigint,
         fixed_bigint::FixedUInt,

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -4,22 +4,40 @@
 
 //! Modular math implemented with traits.
 //!
-//! This crate provides modular arithmetic implemented not for
-//! any particular type, but for any type that implements minimal
-//! set of `core::ops::` and `num_traits::` traits.
+//! Provides modular arithmetic against any type implementing a minimal
+//! set of `core::ops::` and `num_traits::` traits — primitive integers
+//! or any bigint backend.
 //!
-//! All provided functions are simply free functions.
+//! Schoolbook surface lives in three bound-flavor modules:
 //!
-//! There are three verions of each: `basic` that has least amount
-//! of constraints, but requires `Copy` to be implemented for the type.
-//! `constrained` requires `Clone`.
-//! `strict` requires neither, but has most other constaints to be able to
-//! operate with references and [`Overflowing`](https://docs.rs/num-traits/latest/num_traits/ops/overflowing) arithmetic.
-
-//! Tested with builtin integers and [`num-bigint`](https://crates.io/crates/num-bigint), [`crypto-bigint`](https://crates.io/crates/crypto-bigint), [`bnum`](https://crates.io/crates/bnum), [`ibig`](https://crates.io/crates/ibig)
-//! and [`fixed-bigint`](https://crates.io/crates/fixed-bigint) crates. `basic` versions of functions
-//! wont work with `num-bigint` and `ibig` as both require heap
-//! allocation.
+//! - [`basic`] — requires `Copy`. Operands by value.
+//! - [`constrained`] — requires `Clone` instead. Mixed value / reference operands.
+//! - [`strict`] — reference-based throughout. [`Overflowing`] instead of
+//!   `Wrapping` arithmetic.
+//!
+//! Montgomery surface: [`Field`] / [`FieldCt`] / [`FieldNct`] are the
+//! high-level type with precomputed parameters and lifetime-branded
+//! [`Residue`] values. Each flavor's `montgomery` submodule has the
+//! free-function building blocks (`compute_params`, `to_mont`, `mul`,
+//! `mod_mul`, …); `<flavor>::montgomery::wide::*` exposes the wide-REDC
+//! primitives (`redc`, `mul`, plus `ct::*` siblings).
+//!
+//! Constant-time variants — branchless finalize via [`subtle`] — sit
+//! alongside their non-CT siblings ([`FieldCt`], `Field<T, Ct>`, `_ct`
+//! function suffixes, `<flavor>::montgomery::wide::ct::*`).
+//!
+//! Tested against built-in integers, [`num-bigint`], [`crypto-bigint`],
+//! [`bnum`], [`ibig`], and [`fixed-bigint`]. The `basic` flavor's `Copy`
+//! bound rules out heap-allocated backends (`num-bigint`, `ibig`); those
+//! use `constrained` or `strict`.
+//!
+//! [`Overflowing`]: https://docs.rs/num-traits/latest/num_traits/ops/overflowing
+//! [`subtle`]: https://crates.io/crates/subtle
+//! [`num-bigint`]: https://crates.io/crates/num-bigint
+//! [`crypto-bigint`]: https://crates.io/crates/crypto-bigint
+//! [`bnum`]: https://crates.io/crates/bnum
+//! [`ibig`]: https://crates.io/crates/ibig
+//! [`fixed-bigint`]: https://crates.io/crates/fixed-bigint
 
 mod add;
 mod exp;
@@ -28,65 +46,50 @@ mod parity;
 mod sub;
 mod wide_mul;
 
+#[cfg(feature = "wide-mul")]
+mod field;
 mod inv;
-mod montgomery;
+pub mod montgomery;
 
+// Bound-flavor module hubs. Pure re-exports of the existing per-flavor
+// schoolbook functions, renamed to drop the now-redundant `*_mod_` prefix
+// (we're already inside `modmath::basic` / etc.). Old crate-root names
+// (`basic_mod_add`, …) continue to work in parallel during the migration
+// window.
+pub mod basic;
+pub mod constrained;
+pub mod strict;
+
+#[cfg(feature = "wide-mul")]
+pub use field::{Field, FieldCt, FieldNct, Residue, ResidueCt, ResidueNct};
 pub use parity::Parity;
 pub use wide_mul::WideMul;
 
 #[cfg(feature = "nightly")]
 pub use add::const_mod_add;
-pub use add::{basic_mod_add, constrained_mod_add, strict_mod_add};
 #[cfg(feature = "nightly")]
 pub use exp::const_mod_exp;
-pub use exp::{basic_mod_exp, constrained_mod_exp, strict_mod_exp};
-pub use inv::{basic_mod_inv, constrained_mod_inv, strict_mod_inv};
+// `NPrimeMethod` is the algorithm selector for R>N `*_with_method`
+// computations. Used through `modmath::{basic,constrained,strict}::montgomery::
+// compute_params_with_method` and the `mod_{mul,exp}_with_method` siblings.
+//
+// Wide-REDC primitives and convenience wrappers stay at the crate root for
+// now (algorithm-only, flavor-neutral); a future reorg may group them under
+// `modmath::montgomery::wide::*`.
 #[rustfmt::skip]
 pub use montgomery::{
     NPrimeMethod,
-    basic_compute_montgomery_params,
-    basic_compute_montgomery_params_with_method,
-    basic_from_montgomery,
-    basic_montgomery_mod_exp,
-    basic_montgomery_mod_exp_with_method,
-    basic_montgomery_mod_mul,
-    basic_montgomery_mod_mul_with_method,
-    basic_montgomery_mul,
-    basic_to_montgomery,
-    wide_from_montgomery,
-    // Wide-REDC primitives for precomputed Montgomery contexts
     type_bit_width,
     compute_n_prime_newton,
     compute_r_mod_n,
     compute_r2_mod_n,
-    wide_redc,
-    wide_montgomery_mul,
-    constrained_compute_montgomery_params,
-    constrained_compute_montgomery_params_with_method,
-    constrained_from_montgomery,
-    constrained_montgomery_mod_exp,
-    constrained_montgomery_mod_exp_with_method,
-    constrained_montgomery_mod_mul,
-    constrained_montgomery_mod_mul_with_method,
-    constrained_montgomery_mul,
-    constrained_to_montgomery,
-    strict_compute_montgomery_params,
-    strict_compute_montgomery_params_with_method,
-    strict_from_montgomery,
-    strict_montgomery_mod_exp,
-    strict_montgomery_mod_exp_with_method,
-    strict_montgomery_mod_mul,
-    strict_montgomery_mod_mul_with_method,
-    strict_to_montgomery,
 };
 #[cfg(feature = "wide-mul")]
-pub use montgomery::{CiosMontMul, cios_montgomery_mul};
+pub use montgomery::{CiosMontMul, CiosMontMulCt};
 #[cfg(feature = "nightly")]
 pub use mul::const_mod_mul;
-pub use mul::{basic_mod_mul, constrained_mod_mul, strict_mod_mul};
 #[cfg(feature = "nightly")]
 pub use sub::const_mod_sub;
-pub use sub::{basic_mod_sub, constrained_mod_sub, strict_mod_sub};
 
 #[cfg(test)]
 #[macro_export]

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -51,11 +51,10 @@ mod field;
 mod inv;
 pub mod montgomery;
 
-// Bound-flavor module hubs. Pure re-exports of the existing per-flavor
-// schoolbook functions, renamed to drop the now-redundant `*_mod_` prefix
-// (we're already inside `modmath::basic` / etc.). Old crate-root names
-// (`basic_mod_add`, …) continue to work in parallel during the migration
-// window.
+// Bound-flavor module hubs. Re-export the per-flavor schoolbook functions
+// under short names (`modmath::basic::add` for `basic_mod_add`, etc.) —
+// the `*_mod_` prefix becomes redundant once you're inside `modmath::basic`
+// or sibling.
 pub mod basic;
 pub mod constrained;
 pub mod strict;
@@ -69,13 +68,12 @@ pub use wide_mul::WideMul;
 pub use add::const_mod_add;
 #[cfg(feature = "nightly")]
 pub use exp::const_mod_exp;
-// `NPrimeMethod` is the algorithm selector for R>N `*_with_method`
-// computations. Used through `modmath::{basic,constrained,strict}::montgomery::
-// compute_params_with_method` and the `mod_{mul,exp}_with_method` siblings.
-//
-// Wide-REDC primitives and convenience wrappers stay at the crate root for
-// now (algorithm-only, flavor-neutral); a future reorg may group them under
-// `modmath::montgomery::wide::*`.
+// Flavor-neutral Montgomery primitives at the crate root: `NPrimeMethod`
+// (algorithm selector for R>N `*_with_method` computations, used through
+// `modmath::{basic,constrained,strict}::montgomery::compute_params_with_method`)
+// plus the precompute helpers (`compute_n_prime_newton`, `compute_r_mod_n`,
+// `compute_r2_mod_n`) and `type_bit_width`. The flavor-keyed wide-REDC
+// wrappers live under `modmath::{basic,constrained,strict}::montgomery::wide::*`.
 #[rustfmt::skip]
 pub use montgomery::{
     NPrimeMethod,

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -480,6 +480,10 @@ where
 /// Invariants maintained:
 /// - `result` is in range [0, modulus + 1] on entry (sum of two values < modulus plus carry)
 /// - Returns (result + carry1, extra_bit) where extra_bit indicates overflow
+///
+/// This is the variable-time path: branches on `carry1` and on `carry3`
+/// via `||` short-circuit. Used by the NCT REDC functions. For the CT
+/// REDC path, see [`accumulate_high_half_carry_ct`].
 fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
 where
     T: num_traits::One + num_traits::ops::overflowing::OverflowingAdd,
@@ -490,6 +494,34 @@ where
     } else {
         (result, carry2)
     }
+}
+
+/// Constant-time analog of [`accumulate_high_half_carry`].
+///
+/// Same semantics — adds `carry1` to `result` and returns the combined
+/// extra-bit flag — but eliminates the value-dependent branches. The
+/// addition is always performed; the result is selected branchlessly via
+/// `subtle::ConditionallySelectable`. The boolean carry combination uses
+/// bitwise ops (`&`, `|`) on `subtle::Choice` rather than `&&` / `||` so
+/// the new carry computation does not short-circuit on operand value.
+///
+/// Called by the CT REDC functions (`wide_redc_ct`, `strict_wide_redc_ct`).
+fn accumulate_high_half_carry_ct<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
+where
+    T: num_traits::One
+        + num_traits::ops::overflowing::OverflowingAdd
+        + subtle::ConditionallySelectable,
+{
+    use subtle::Choice;
+    let c1 = Choice::from(carry1 as u8);
+    let c2 = Choice::from(carry2 as u8);
+    // Always compute the addition; branchlessly choose whether to keep it.
+    let (r2, carry3) = result.overflowing_add(&T::one());
+    let c3 = Choice::from(carry3 as u8);
+    let chosen = T::conditional_select(&result, &r2, c1);
+    // new_carry = carry2 | (carry1 & carry3) — bitwise, no short-circuit.
+    let new_carry: bool = (c2 | (c1 & c3)).into();
+    (chosen, new_carry)
 }
 
 /// REDC on a double-width input (t_lo, t_hi) — variable-time.
@@ -599,7 +631,7 @@ where
     let (m_lo, m_hi) = m.wide_mul(&modulus);
     let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
     let (result, carry2) = t_hi.overflowing_add(&m_hi);
-    let (result, extra_bit) = accumulate_high_half_carry(result, carry1, carry2);
+    let (result, extra_bit) = accumulate_high_half_carry_ct(result, carry1, carry2);
 
     // Branchless final reduction: needs_sub = extra_bit | !(result < modulus)
     let sub_result = result.wrapping_sub(&modulus);
@@ -630,7 +662,7 @@ where
     let (m_lo, m_hi) = m.wide_mul(modulus);
     let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
     let (result, carry2) = t_hi.overflowing_add(&m_hi);
-    let (result, extra_bit) = accumulate_high_half_carry(result, carry1, carry2);
+    let (result, extra_bit) = accumulate_high_half_carry_ct(result, carry1, carry2);
 
     let sub_result = result.wrapping_sub(modulus);
     let result_lt_modulus = result.ct_lt(modulus);
@@ -1712,6 +1744,27 @@ mod tests {
                     ct.forget_ct(),
                     "mod_exp_pr_ct mismatch at base={base:?} exp={exp:?}"
                 );
+            }
+        }
+    }
+
+    /// Equivalence of the NCT and CT high-half accumulators. Exhaustive over
+    /// `result` (u8), both carry flags. Confirms `accumulate_high_half_carry_ct`
+    /// produces the same `(result, extra_bit)` pair as `accumulate_high_half_carry`
+    /// for every input — the swap inside `wide_redc_ct` / `strict_wide_redc_ct`
+    /// is purely a side-channel hardening, not a semantic change.
+    #[test]
+    fn test_accumulate_high_half_carry_ct_matches_nct_u8() {
+        for result in 0u8..=255 {
+            for &carry1 in &[false, true] {
+                for &carry2 in &[false, true] {
+                    let nct = accumulate_high_half_carry(result, carry1, carry2);
+                    let ct = accumulate_high_half_carry_ct(result, carry1, carry2);
+                    assert_eq!(
+                        nct, ct,
+                        "mismatch at result={result} carry1={carry1} carry2={carry2}"
+                    );
+                }
             }
         }
     }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -19,8 +19,11 @@ pub enum NPrimeMethod {
     HenselsLifting,
     /// Newton's method - O(log W) complexity, works with R = 2^W (full type width).
     /// Uses wrapping arithmetic so R never needs to be represented explicitly.
-    /// This is the method used internally by the wide-REDC path; other methods
-    /// are accepted for API compatibility but all use Newton internally.
+    /// The default. The wide-REDC path uses Newton unconditionally (it's the
+    /// only N' method that fits R = 2^W). On the R>N path (where R is the
+    /// smallest power of 2 above N rather than the full type width),
+    /// `*_compute_montgomery_params_with_method` maps `Newton` to
+    /// `ExtendedEuclidean` since Newton's R = 2^W assumption doesn't hold there.
     #[default]
     Newton,
 }
@@ -43,9 +46,9 @@ where
     // We need to find N' where modulus * N' ≡ R - 1 (mod R)
     let target = r - T::one(); // This is -1 mod R
 
-    // Simple trial search for N'
-    // TODO: Replace with Extended Euclidean Algorithm for O(log R) complexity instead of O(R)
-    // Current implementation is fine for small numbers but inefficient for large moduli
+    // Simple O(R) trial search for N'. Adequate for small moduli; the
+    // ExtendedEuclidean and HenselsLifting NPrimeMethod variants offer
+    // O(log R) alternatives for larger moduli.
     let mut n_prime = T::one();
     loop {
         if (modulus * n_prime) % r == target {
@@ -199,7 +202,7 @@ where
         NPrimeMethod::ExtendedEuclidean => compute_n_prime_extended_euclidean(modulus, r)?,
         NPrimeMethod::HenselsLifting => compute_n_prime_hensels_lifting(modulus, r, r_bits)?,
         NPrimeMethod::Newton => {
-            // In this legacy param path (R > N, smallest power of 2),
+            // In this R > N param path (smallest power of 2 above N),
             // delegate to ExtendedEuclidean which computes -N^{-1} mod R
             // using the same mathematical identity.
             compute_n_prime_extended_euclidean(modulus, r)?
@@ -247,12 +250,29 @@ where
     crate::mul::basic_mod_mul(a, r, modulus)
 }
 
+/// Convert to Montgomery form (Basic, pre-reduced): a -> (a * R) mod N
+/// Precondition: `a < modulus` and `r < modulus`. No `Rem` bound.
+pub fn basic_to_montgomery_pr<T>(a: T, modulus: T, r: T) -> T
+where
+    T: core::cmp::PartialOrd
+        + Copy
+        + num_traits::Zero
+        + num_traits::One
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub
+        + core::ops::Shr<usize, Output = T>
+        + crate::parity::Parity,
+{
+    crate::mul::basic_mod_mul_pr(a, r, modulus)
+}
+
 /// Convert from Montgomery form (Basic): (a * R) -> a mod N
-/// Uses Montgomery reduction algorithm with legacy R > N semantics.
+/// Uses Montgomery reduction algorithm with R > N semantics.
 ///
 /// **Warning**: This function can overflow for large moduli where m * N exceeds
-/// the type width. For overflow-free reduction, use [`wide_from_montgomery`]
-/// which uses wide-REDC with R = 2^W.
+/// the type width. For overflow-free reduction, use [`wide_redc`] (call as
+/// `wide_redc(a_mont, T::zero(), modulus, n_prime)`) which uses wide-REDC
+/// with R = 2^W.
 pub fn basic_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
 where
     T: Copy
@@ -289,37 +309,20 @@ where
 
     // Step 2: t = (a_mont + m * N) >> r_bits
     // WARNING: m * N can overflow for large moduli (m < R, N < R, so
-    // m*N can reach R^2). Use wide_from_montgomery for overflow-free reduction.
+    // m*N can reach R^2). Use wide_redc(a_mont, T::zero(), modulus, n_prime)
+    // for overflow-free reduction.
     let t = (a_mont + m * modulus) >> r_bits;
 
     // Step 3: Final reduction
     if t >= modulus { t - modulus } else { t }
 }
 
-/// Convert from Montgomery form using wide-REDC: (a * R) -> a mod N
-///
-/// Uses R = 2^W (full type width) semantics with overflow-free reduction.
-/// The N' parameter must be computed for R = 2^W (e.g., via Newton's method).
-pub fn wide_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T) -> T
-where
-    T: Copy
-        + num_traits::Zero
-        + num_traits::One
-        + PartialOrd
-        + WideMul
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingSub,
-{
-    wide_redc(a_mont, T::zero(), modulus, n_prime)
-}
-
 /// Montgomery multiplication (Basic): (a * R) * (b * R) -> (a * b * R) mod N
 ///
-/// **Warning**: This building-block function uses the legacy reduction path which
-/// can overflow for large moduli (see `basic_from_montgomery` warning). For
-/// overflow-free multiplication, use [`basic_montgomery_mod_mul`] which uses
-/// wide-REDC internally.
+/// **Warning**: This building-block function uses the R > N reduction path which
+/// can overflow for large moduli (see [`basic_from_montgomery`] warning). For
+/// overflow-free multiplication, use [`crate::basic::montgomery::mod_mul`]
+/// which uses wide-REDC internally.
 pub fn basic_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
 where
     T: Copy
@@ -342,11 +345,33 @@ where
     // 1. Compute product = a_mont * b_mont (mod N)
     // 2. Apply Montgomery reduction to get (a * b * R) mod N
 
-    // TODO(Phase 1): Replace mod_mul + from_montgomery with proper Montgomery
-    // reduction using WideningMul. Current mod_mul is O(k) double-and-add which
-    // defeats the performance purpose of Montgomery, and from_montgomery's
-    // m * N intermediate can overflow at key sizes. See ROADMAP.md Phase 1.
+    // Note: this R>N path uses double-and-add mod_mul (O(k)), which
+    // defeats Montgomery's perf purpose; the m*N intermediate in
+    // from_montgomery can also overflow at key sizes. For overflow-free
+    // multiplication, route through wide-REDC / CIOS instead.
     let product = crate::mul::basic_mod_mul(a_mont, b_mont, modulus);
+    basic_from_montgomery(product, modulus, n_prime, r_bits)
+}
+
+/// Montgomery multiplication (Basic, pre-reduced)
+/// Precondition: `a_mont < modulus` and `b_mont < modulus`. No `Rem` bound.
+pub fn basic_montgomery_mul_pr<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialOrd
+        + core::ops::Mul<Output = T>
+        + core::ops::Add<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::Shl<usize, Output = T>
+        + core::ops::BitAnd<Output = T>
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub
+        + crate::parity::Parity,
+{
+    let product = crate::mul::basic_mod_mul_pr(a_mont, b_mont, modulus);
     basic_from_montgomery(product, modulus, n_prime, r_bits)
 }
 
@@ -457,7 +482,7 @@ where
 /// - Returns (result + carry1, extra_bit) where extra_bit indicates overflow
 fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
 where
-    T: Copy + num_traits::One + num_traits::ops::overflowing::OverflowingAdd,
+    T: num_traits::One + num_traits::ops::overflowing::OverflowingAdd,
 {
     if carry1 {
         let (r2, carry3) = result.overflowing_add(&T::one());
@@ -467,9 +492,16 @@ where
     }
 }
 
-/// REDC on a double-width input (t_lo, t_hi).
+/// REDC on a double-width input (t_lo, t_hi) — variable-time.
 ///
 /// Computes  (t_lo + t_hi * 2^W) * R^{-1}  mod N.
+///
+/// Final reduction is a predicted branch. Timing leaks operand magnitude.
+/// Use [`wide_redc_ct`] in constant-time-sensitive contexts (signing keys,
+/// scalar multiplication on secret data). For verify/public-key paths the
+/// branched version is significantly faster — on Cortex-M3 the branchless
+/// finalize is ~6× slower because the cond-sub branch is highly predictable
+/// while the branchless mask construction does limb-wise work every call.
 ///
 /// Invariants:
 /// - Inputs t_lo, t_hi represent a value T < N * R (product of two values < N)
@@ -507,6 +539,105 @@ where
     }
 }
 
+/// REDC on a double-width input — variable-time, reference-based inputs.
+///
+/// Same algorithm as [`wide_redc`] but takes all operands by reference,
+/// avoiding the per-call value copy. For `Copy` types (`u32`, `FixedUInt`)
+/// the compiler register-passes either way; the by-ref form matters for
+/// non-Copy bigint backends where each value pass would clone.
+///
+/// Drops the `Copy` bound — usable with backends that don't impl it.
+pub fn strict_wide_redc<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
+where
+    T: num_traits::Zero
+        + num_traits::One
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub,
+{
+    let m = t_lo.wrapping_mul(n_prime);
+    let (m_lo, m_hi) = m.wide_mul(modulus);
+    let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
+    let (result, carry2) = t_hi.overflowing_add(&m_hi);
+    let (result, extra_bit) = accumulate_high_half_carry(result, carry1, carry2);
+
+    if extra_bit || &result >= modulus {
+        result.wrapping_sub(modulus)
+    } else {
+        result
+    }
+}
+
+/// REDC on a double-width input (t_lo, t_hi) — constant-time finalize.
+///
+/// Same algorithm as [`wide_redc`] but performs the final reduction step
+/// branchlessly via `subtle::ConditionallySelectable` and
+/// `subtle::ConstantTimeLess`, removing the operand-magnitude side-channel
+/// on the `result >= modulus` comparison.
+///
+/// Use this in CT-sensitive paths (private-key operations, secret scalar
+/// multiplication). On platforms with branch prediction the branchless
+/// finalize is a few percent slower than [`wide_redc`]; on simple cores
+/// (Cortex-M0/M3) the gap is much larger (~5–6×). Choose at the call site.
+pub fn wide_redc_ct<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+{
+    use subtle::Choice;
+
+    let m = t_lo.wrapping_mul(&n_prime);
+    let (m_lo, m_hi) = m.wide_mul(&modulus);
+    let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
+    let (result, carry2) = t_hi.overflowing_add(&m_hi);
+    let (result, extra_bit) = accumulate_high_half_carry(result, carry1, carry2);
+
+    // Branchless final reduction: needs_sub = extra_bit | !(result < modulus)
+    let sub_result = result.wrapping_sub(&modulus);
+    let result_lt_modulus = result.ct_lt(&modulus);
+    let needs_sub = Choice::from(extra_bit as u8) | !result_lt_modulus;
+    T::conditional_select(&result, &sub_result, needs_sub)
+}
+
+/// REDC on a double-width input — constant-time finalize, reference-based inputs.
+///
+/// Same algorithm as [`wide_redc_ct`] but takes all operands by reference,
+/// avoiding the per-call value copy. See [`strict_wide_redc`] for the
+/// rationale on dropping `Copy`.
+pub fn strict_wide_redc_ct<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
+where
+    T: num_traits::Zero
+        + num_traits::One
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+{
+    use subtle::Choice;
+
+    let m = t_lo.wrapping_mul(n_prime);
+    let (m_lo, m_hi) = m.wide_mul(modulus);
+    let (_discard_lo, carry1) = t_lo.overflowing_add(&m_lo);
+    let (result, carry2) = t_hi.overflowing_add(&m_hi);
+    let (result, extra_bit) = accumulate_high_half_carry(result, carry1, carry2);
+
+    let sub_result = result.wrapping_sub(modulus);
+    let result_lt_modulus = result.ct_lt(modulus);
+    let needs_sub = Choice::from(extra_bit as u8) | !result_lt_modulus;
+    T::conditional_select(&result, &sub_result, needs_sub)
+}
+
 // ---------------------------------------------------------------------------
 // Wide-REDC Montgomery multiply helper
 // ---------------------------------------------------------------------------
@@ -527,39 +658,68 @@ where
     wide_redc(lo, hi, modulus, n_prime)
 }
 
-// ---------------------------------------------------------------------------
-// Public API: mod_mul / mod_exp using wide REDC
-// ---------------------------------------------------------------------------
-
-/// Complete Montgomery modular multiplication with method selection (Basic): A * B mod N
+/// Montgomery multiplication using wide REDC — constant-time finalize.
 ///
-/// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
-/// Note: The `method` parameter is accepted for API compatibility but all methods
-/// use Newton internally since it's designed for R = 2^W.
-/// Returns None if modulus is even or zero.
-pub fn basic_montgomery_mod_mul_with_method<T>(
-    a: T,
-    b: T,
-    modulus: T,
-    _method: NPrimeMethod,
-) -> Option<T>
+/// Same shape as [`wide_montgomery_mul`] but routes through [`wide_redc_ct`].
+/// Use in CT-sensitive paths.
+pub fn wide_montgomery_mul_ct<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
         + num_traits::Zero
         + num_traits::One
-        + PartialEq
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+{
+    let (lo, hi) = a_mont.wide_mul(&b_mont);
+    wide_redc_ct(lo, hi, modulus, n_prime)
+}
+
+/// Montgomery multiplication using wide REDC — reference-based inputs.
+///
+/// Same shape as [`wide_montgomery_mul`] but takes operands by reference,
+/// avoiding per-call copies on non-Copy bigint backends. Delegates to
+/// [`strict_wide_redc`] for the reduction.
+pub fn strict_wide_montgomery_mul<T>(a_mont: &T, b_mont: &T, modulus: &T, n_prime: &T) -> T
+where
+    T: num_traits::Zero
+        + num_traits::One
         + PartialOrd
         + WideMul
         + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + Parity
-        + core::ops::Rem<Output = T>,
+        + num_traits::WrappingSub,
 {
-    // All methods use Newton internally, so delegate to the simple version
-    basic_montgomery_mod_mul(a, b, modulus)
+    let (lo, hi) = a_mont.wide_mul(b_mont);
+    strict_wide_redc(&lo, &hi, modulus, n_prime)
 }
+
+/// Montgomery multiplication using wide REDC — constant-time finalize,
+/// reference-based inputs.
+///
+/// Same shape as [`wide_montgomery_mul_ct`] but takes operands by reference.
+/// Delegates to [`strict_wide_redc_ct`].
+pub fn strict_wide_montgomery_mul_ct<T>(a_mont: &T, b_mont: &T, modulus: &T, n_prime: &T) -> T
+where
+    T: num_traits::Zero
+        + num_traits::One
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+{
+    let (lo, hi) = a_mont.wide_mul(b_mont);
+    strict_wide_redc_ct(&lo, &hi, modulus, n_prime)
+}
+
+// ---------------------------------------------------------------------------
+// Public API: mod_mul / mod_exp using wide REDC
+// ---------------------------------------------------------------------------
 
 /// Reduce value modulo modulus.
 ///
@@ -596,40 +756,14 @@ where
     if modulus == T::zero() || modulus.is_even() {
         return None;
     }
-    let w = type_bit_width::<T>();
-    let n_prime = compute_n_prime_newton(modulus, w);
-    let r_mod_n = compute_r_mod_n(modulus, w);
-    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
-
-    // Reduce inputs to [0, modulus) before Montgomery conversion
-    let a_red = reduce_mod(a, modulus);
-    let b_red = reduce_mod(b, modulus);
-
-    // Convert to Montgomery form via REDC(a * R^2)
-    let (lo, hi) = a_red.wide_mul(&r2_mod_n);
-    let a_m = wide_redc(lo, hi, modulus, n_prime);
-    let (lo, hi) = b_red.wide_mul(&r2_mod_n);
-    let b_m = wide_redc(lo, hi, modulus, n_prime);
-
-    // Multiply in Montgomery domain
-    let r_m = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
-
-    // Convert back: REDC(r_m, 0)
-    Some(wide_redc(r_m, T::zero(), modulus, n_prime))
+    basic_montgomery_mod_mul_pr(reduce_mod(a, modulus), reduce_mod(b, modulus), modulus)
 }
 
-/// Montgomery-based modular exponentiation with method selection (Basic): base^exponent mod modulus
+/// Complete Montgomery modular multiplication (Basic, pre-reduced): A * B mod N
 ///
-/// Uses wide REDC (R = 2^W) for correct overflow-free Montgomery reduction.
-/// Note: The `method` parameter is accepted for API compatibility but all methods
-/// use Newton internally since it's designed for R = 2^W.
-/// Returns None if modulus is even or zero.
-pub fn basic_montgomery_mod_exp_with_method<T>(
-    base: T,
-    exponent: T,
-    modulus: T,
-    _method: NPrimeMethod,
-) -> Option<T>
+/// Precondition: `a < modulus` and `b < modulus`. No `Rem` bound. Returns
+/// None only if modulus is even or zero.
+pub fn basic_montgomery_mod_mul_pr<T>(a: T, b: T, modulus: T) -> Option<T>
 where
     T: Copy
         + num_traits::Zero
@@ -641,13 +775,27 @@ where
         + num_traits::WrappingMul
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
-        + Parity
-        + core::ops::Rem<Output = T>
-        + core::ops::Shr<usize, Output = T>
-        + core::ops::ShrAssign<usize>,
+        + Parity,
 {
-    // All methods use Newton internally, so delegate to the simple version
-    basic_montgomery_mod_exp(base, exponent, modulus)
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
+    let w = type_bit_width::<T>();
+    let n_prime = compute_n_prime_newton(modulus, w);
+    let r_mod_n = compute_r_mod_n(modulus, w);
+    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+    // Convert to Montgomery form via REDC(a * R^2)
+    let (lo, hi) = a.wide_mul(&r2_mod_n);
+    let a_m = wide_redc(lo, hi, modulus, n_prime);
+    let (lo, hi) = b.wide_mul(&r2_mod_n);
+    let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+    // Multiply in Montgomery domain
+    let r_m = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
+
+    // Convert back: REDC(r_m, 0)
+    Some(wide_redc(r_m, T::zero(), modulus, n_prime))
 }
 
 /// Montgomery-based modular exponentiation (Basic): base^exponent mod modulus
@@ -675,6 +823,31 @@ where
     if modulus == T::zero() || modulus.is_even() {
         return None;
     }
+    basic_montgomery_mod_exp_pr(reduce_mod(base, modulus), exponent, modulus)
+}
+
+/// Complete Montgomery modular exponentiation (Basic, pre-reduced): base^exponent mod modulus
+///
+/// Precondition: `base < modulus`. No `Rem` bound. Returns None only if
+/// modulus is even or zero.
+pub fn basic_montgomery_mod_exp_pr<T>(base: T, exponent: T, modulus: T) -> Option<T>
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        + core::ops::ShrAssign<usize>,
+{
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
     let w = type_bit_width::<T>();
     let n_prime = compute_n_prime_newton(modulus, w);
     let r_mod_n = compute_r_mod_n(modulus, w);
@@ -683,9 +856,7 @@ where
     // 1 in Montgomery form = R mod N (since REDC(1 * R²) = 1 * R² * R⁻¹ = R mod N)
     let one_mont = r_mod_n;
 
-    // Reduce base to [0, modulus) before Montgomery conversion
-    let base_red = reduce_mod(base, modulus);
-    let (lo, hi) = base_red.wide_mul(&r2_mod_n);
+    let (lo, hi) = base.wide_mul(&r2_mod_n);
     let mut base_mont = wide_redc(lo, hi, modulus, n_prime);
     let mut result = one_mont;
     let mut exp = exponent;
@@ -701,6 +872,117 @@ where
     }
 
     Some(wide_redc(result, T::zero(), modulus, n_prime))
+}
+
+/// Complete Montgomery modular exponentiation (Basic, CT): base^exponent mod modulus
+///
+/// Reduces `base` modulo `modulus` then dispatches to
+/// [`crate::basic::montgomery::ct::pre_reduced::mod_exp`]. Use this when the
+/// exponent (and possibly the base) is secret — e.g. RSA private-key
+/// operations.
+///
+/// Returns None if modulus is even or zero.
+pub fn basic_montgomery_mod_exp_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        + core::ops::Rem<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::BitAnd<Output = T>
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + subtle::ConstantTimeLess,
+{
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
+    basic_montgomery_mod_exp_pr_ct(reduce_mod(base, modulus), exponent, modulus)
+}
+
+/// Complete Montgomery modular exponentiation (Basic, CT, pre-reduced):
+/// base^exponent mod modulus, constant-time over `exponent` (and `base`).
+///
+/// Precondition: `base < modulus`. No `Rem` bound.
+///
+/// Implements a fixed-iteration constant-time square-and-multiply:
+///   - Iterates over **every** bit position of the exponent type (not just
+///     significant bits), so the loop count does not leak `bit_length(exp)`.
+///   - Performs the squaring and the conditional multiply on **every**
+///     iteration, with `subtle::conditional_select` choosing whether to keep
+///     the multiplied result based on the current exponent bit — so timing
+///     and memory access patterns are independent of the exponent bit
+///     pattern.
+///   - All Montgomery reductions route through [`wide_redc_ct`].
+///
+/// Precomputation (`compute_n_prime_newton`, `compute_r_mod_n`,
+/// `compute_r2_mod_n`) operates only on the modulus, which is public; using
+/// the NCT compute_* helpers there is intentional and does not leak any
+/// secret.
+///
+/// Returns None if modulus is even or zero.
+pub fn basic_montgomery_mod_exp_pr_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
+where
+    T: Copy
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq
+        + PartialOrd
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::BitAnd<Output = T>
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + subtle::ConstantTimeLess,
+{
+    if modulus == T::zero() || modulus.is_even() {
+        return None;
+    }
+    let w = type_bit_width::<T>();
+    let n_prime = compute_n_prime_newton(modulus, w);
+    let r_mod_n = compute_r_mod_n(modulus, w);
+    let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+
+    // 1 in Montgomery form = R mod N
+    let one_mont = r_mod_n;
+
+    // Convert base to Montgomery form via REDC(base * R²)
+    let base_mont = wide_montgomery_mul_ct(base, r2_mod_n, modulus, n_prime);
+
+    let mut result = one_mont;
+
+    // Constant-time square-and-multiply, MSB to LSB, fixed iteration count = w.
+    // Always squares; always computes the multiply; conditionally selects.
+    let one = T::one();
+    for i in (0..w).rev() {
+        // Always square
+        result = wide_montgomery_mul_ct(result, result, modulus, n_prime);
+
+        // Always compute the conditional product
+        let multiplied = wide_montgomery_mul_ct(result, base_mont, modulus, n_prime);
+
+        // Extract bit i of exponent (i is public; the shift amount is the
+        // loop index, not derived from exp). Bit value is secret.
+        let bit_t = (exponent >> i) & one;
+        let choice = bit_t.ct_eq(&one);
+        result = T::conditional_select(&result, &multiplied, choice);
+    }
+
+    // Convert back from Montgomery form: REDC(result, 0)
+    Some(wide_redc_ct(result, T::zero(), modulus, n_prime))
 }
 
 #[cfg(test)]
@@ -1158,8 +1440,33 @@ mod tests {
 
     // -- FixedUInt test ------------------------------------------------------
 
+    /// Sibling of [`test_wide_fixed_bigint_pr`] for the Rem-bound wrappers
+    /// (`basic_mod_mul`, `basic_mod_exp`). Default (Nct-personality)
+    /// FixedUInt provides Rem and so these wrappers are reachable here.
+    /// A Ct-typed FixedUInt would fail to satisfy the Rem bound — which is
+    /// the correct outcome, since reduce-then-multiply is variable-time.
     #[test]
     fn test_wide_fixed_bigint() {
+        use fixed_bigint::FixedUInt;
+        type U128 = FixedUInt<u32, 4>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64); // 2^128 - 59 (odd)
+
+        let a = U128::from(0xDEAD_BEEF_u64);
+        let b = U128::from(0xCAFE_BABE_u64);
+        let expected = crate::mul::basic_mod_mul(a, b, modulus);
+        let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+        assert_eq!(got, expected);
+
+        let base = U128::from(42u64);
+        let exp = U128::from(1000u64);
+        let expected = crate::exp::basic_mod_exp(base, exp, modulus);
+        let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_wide_fixed_bigint_pr() {
         use fixed_bigint::FixedUInt;
         type U128 = FixedUInt<u32, 4>;
 
@@ -1172,23 +1479,25 @@ mod tests {
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
 
+        // All test inputs are tiny (< 2^32) and modulus is ~2^128, so the
+        // pre-reduced precondition is naturally satisfied.
         let a = U128::from(0xDEAD_BEEF_u64);
         let (lo, hi) = a.wide_mul(&r2_mod_n);
         let a_m = wide_redc(lo, hi, modulus, n_prime);
         let back = wide_redc(a_m, U128::from(0u64), modulus, n_prime);
         assert_eq!(back, a);
 
-        // Multiplication test: compare with basic_mod_mul
+        // Multiplication: compare _pr Montgomery against _pr double-and-add.
         let b = U128::from(0xCAFE_BABE_u64);
-        let expected = crate::mul::basic_mod_mul(a, b, modulus);
-        let got = basic_montgomery_mod_mul(a, b, modulus).unwrap();
+        let expected = crate::mul::basic_mod_mul_pr(a, b, modulus);
+        let got = basic_montgomery_mod_mul_pr(a, b, modulus).unwrap();
         assert_eq!(got, expected);
 
-        // Exponentiation test
+        // Exponentiation
         let base = U128::from(42u64);
         let exp = U128::from(1000u64);
-        let expected = crate::exp::basic_mod_exp(base, exp, modulus);
-        let got = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+        let expected = crate::exp::basic_mod_exp_pr(base, exp, modulus);
+        let got = basic_montgomery_mod_exp_pr(base, exp, modulus).unwrap();
         assert_eq!(got, expected);
     }
 
@@ -1237,21 +1546,173 @@ mod tests {
         assert_eq!(got, expected);
     }
 
+    /// wide_redc_ct must produce the same output as wide_redc for all inputs.
+    /// Exhaustive over a small u8 modulus to cover both the "needs subtraction"
+    /// and "doesn't need subtraction" branches plus the extra_bit case.
     #[test]
-    fn test_wide_from_montgomery() {
-        // Test the wide-REDC based from_montgomery function
+    fn test_wide_redc_ct_matches_nct_u8() {
         let modulus = 13u8;
-        let w = type_bit_width::<u8>();
-        let n_prime = compute_n_prime_newton(modulus, w);
-        let r_mod_n = compute_r_mod_n(modulus, w);
-        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+        for t_lo in 0u8..=255 {
+            for t_hi in 0u8..modulus {
+                // Pick an arbitrary odd n_prime — exact value doesn't matter for
+                // comparing the two implementations; they share inputs.
+                let n_prime = 11u8;
+                let nct = wide_redc(t_lo, t_hi, modulus, n_prime);
+                let ct = wide_redc_ct(t_lo, t_hi, modulus, n_prime);
+                assert_eq!(nct, ct, "wide_redc_ct mismatch at t_lo={t_lo} t_hi={t_hi}");
+            }
+        }
+    }
 
-        // Convert to Montgomery form and back for various values
-        for a in 0u8..13 {
-            let (lo, hi) = a.wide_mul(&r2_mod_n);
-            let a_m = wide_redc(lo, hi, modulus, n_prime);
-            let back = wide_from_montgomery(a_m, modulus, n_prime);
-            assert_eq!(back, a, "wide_from_montgomery roundtrip failed for {a}");
+    /// All four `strict_wide_*` functions must produce identical outputs to
+    /// their by-value siblings on Copy types. Same input grid as the
+    /// `wide_redc_ct` equivalence test; local `basic_*` aliases keep the
+    /// comparison readable.
+    #[test]
+    fn test_strict_wide_matches_basic_u8() {
+        // Local aliases for "the by-value (basic-flavor) version" purely so
+        // the asserts read symmetrically.
+        use super::{
+            wide_montgomery_mul as basic_wide_montgomery_mul,
+            wide_montgomery_mul_ct as basic_wide_montgomery_mul_ct, wide_redc as basic_wide_redc,
+            wide_redc_ct as basic_wide_redc_ct,
+        };
+
+        let modulus = 13u8;
+        let n_prime = 11u8;
+        for t_lo in 0u8..=255 {
+            for t_hi in 0u8..modulus {
+                assert_eq!(
+                    basic_wide_redc(t_lo, t_hi, modulus, n_prime),
+                    strict_wide_redc(&t_lo, &t_hi, &modulus, &n_prime),
+                    "strict_wide_redc mismatch at t_lo={t_lo} t_hi={t_hi}"
+                );
+                assert_eq!(
+                    basic_wide_redc_ct(t_lo, t_hi, modulus, n_prime),
+                    strict_wide_redc_ct(&t_lo, &t_hi, &modulus, &n_prime),
+                    "strict_wide_redc_ct mismatch at t_lo={t_lo} t_hi={t_hi}"
+                );
+            }
+        }
+
+        // mul wrappers exercise a different code path (wide_mul + redc).
+        for a in 0u8..modulus {
+            for b in 0u8..modulus {
+                assert_eq!(
+                    basic_wide_montgomery_mul(a, b, modulus, n_prime),
+                    strict_wide_montgomery_mul(&a, &b, &modulus, &n_prime),
+                    "strict_wide_montgomery_mul mismatch at a={a} b={b}"
+                );
+                assert_eq!(
+                    basic_wide_montgomery_mul_ct(a, b, modulus, n_prime),
+                    strict_wide_montgomery_mul_ct(&a, &b, &modulus, &n_prime),
+                    "strict_wide_montgomery_mul_ct mismatch at a={a} b={b}"
+                );
+            }
+        }
+    }
+
+    /// wide_redc_ct matches at FixedUInt sizes.
+    ///
+    /// Under fixed-bigint's personality typestate, `wide_redc_ct`'s
+    /// `ConditionallySelectable`/`ConstantTimeLess` bounds resolve only for
+    /// Ct-typed FixedUInts; the Nct-typed precompute values are bridged via
+    /// the free `.into()` upgrade, and the CT result is brought back via
+    /// `forget_ct()` for cross-personality equality.
+    #[test]
+    fn test_wide_redc_ct_matches_nct_fixed() {
+        use fixed_bigint::{Ct, FixedUInt};
+        type U128 = FixedUInt<u32, 4>;
+        type U128Ct = FixedUInt<u32, 4, Ct>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64);
+        let w = type_bit_width::<U128>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let modulus_ct: U128Ct = modulus.into();
+        let n_prime_ct: U128Ct = n_prime.into();
+
+        // A mix: small values, values near modulus, and full-width-ish values
+        let test_vals = [
+            U128::from(0u64),
+            U128::from(1u64),
+            U128::from(0xDEAD_BEEF_u64),
+            modulus - U128::from(1u64),
+            !U128::from(0u64), // 2^128 - 1 (well above modulus)
+        ];
+        for &t_lo in &test_vals {
+            for &t_hi in &test_vals {
+                let nct = wide_redc(t_lo, t_hi, modulus, n_prime);
+                let t_lo_ct: U128Ct = t_lo.into();
+                let t_hi_ct: U128Ct = t_hi.into();
+                let ct = wide_redc_ct(t_lo_ct, t_hi_ct, modulus_ct, n_prime_ct);
+                assert_eq!(
+                    nct,
+                    ct.forget_ct(),
+                    "wide_redc_ct mismatch at t_lo={t_lo:?} t_hi={t_hi:?}"
+                );
+            }
+        }
+    }
+
+    /// basic_montgomery_mod_exp_ct must produce the same output as the NCT
+    /// version for all inputs, on a primitive type.
+    #[test]
+    fn test_basic_montgomery_mod_exp_ct_matches_nct_u32() {
+        let modulus = 13u32;
+        for base in 0u32..modulus {
+            for exp in 0u32..32 {
+                let nct = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
+                let ct = basic_montgomery_mod_exp_ct(base, exp, modulus).unwrap();
+                assert_eq!(nct, ct, "mod_exp_ct mismatch at base={base} exp={exp}");
+            }
+        }
+    }
+
+    /// basic_montgomery_mod_exp_pr_ct must produce the same output as the NCT
+    /// _pr version for pre-reduced inputs.
+    #[test]
+    fn test_basic_montgomery_mod_exp_pr_ct_matches_nct_u32() {
+        let modulus = 13u32;
+        for base in 0u32..modulus {
+            for exp in 0u32..32 {
+                let nct = basic_montgomery_mod_exp_pr(base, exp, modulus).unwrap();
+                let ct = basic_montgomery_mod_exp_pr_ct(base, exp, modulus).unwrap();
+                assert_eq!(nct, ct, "mod_exp_pr_ct mismatch at base={base} exp={exp}");
+            }
+        }
+    }
+
+    /// CT exp matches NCT exp at FixedUInt sizes.
+    ///
+    /// See [`test_wide_redc_ct_matches_nct_fixed`] for the personality-bridge
+    /// rationale — Ct-typed inputs are required for `_ct` functions.
+    #[test]
+    fn test_basic_montgomery_mod_exp_pr_ct_matches_nct_fixed() {
+        use fixed_bigint::{Ct, FixedUInt};
+        type U128 = FixedUInt<u32, 4>;
+        type U128Ct = FixedUInt<u32, 4, Ct>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64); // 2^128 - 59 (odd prime)
+        let modulus_ct: U128Ct = modulus.into();
+        let bases = [U128::from(2u64), U128::from(0xDEAD_BEEF_u64)];
+        let exps = [
+            U128::from(0u64),
+            U128::from(1u64),
+            U128::from(7u64),
+            U128::from(0xCAFE_BABE_u64),
+        ];
+        for &base in &bases {
+            for &exp in &exps {
+                let nct = basic_montgomery_mod_exp_pr(base, exp, modulus).unwrap();
+                let base_ct: U128Ct = base.into();
+                let exp_ct: U128Ct = exp.into();
+                let ct = basic_montgomery_mod_exp_pr_ct(base_ct, exp_ct, modulus_ct).unwrap();
+                assert_eq!(
+                    nct,
+                    ct.forget_ct(),
+                    "mod_exp_pr_ct mismatch at base={base:?} exp={exp:?}"
+                );
+            }
         }
     }
 }

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -102,9 +102,10 @@ where
         + num_traits::WrappingMul
         + num_traits::ops::overflowing::OverflowingAdd
         + core::ops::Add<Output = T::Word>
-        + subtle::ConstantTimeEq,
+        + subtle::ConstantTimeEq
+        + subtle::ConditionallySelectable,
 {
-    use subtle::{Choice, ConstantTimeEq};
+    use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
     let n = T::word_count();
     let zero = <T::Word as Zero>::zero();
@@ -119,9 +120,8 @@ where
         let carry = T::mul_acc_row(ai, b, &mut acc, zero);
         let (sum, overflow) = acc_hi.overflowing_add(&carry);
         acc_hi = sum;
-        if overflow {
-            acc_hi2 = acc_hi2 + one;
-        }
+        let overflow_word = T::Word::conditional_select(&zero, &one, Choice::from(overflow as u8));
+        acc_hi2 = acc_hi2 + overflow_word;
 
         let m = acc.get_word(0).into_option()?.wrapping_mul(&n_prime_0);
 
@@ -194,7 +194,8 @@ where
         + num_traits::WrappingMul
         + num_traits::ops::overflowing::OverflowingAdd
         + core::ops::Add<Output = T::Word>
-        + subtle::ConstantTimeEq,
+        + subtle::ConstantTimeEq
+        + subtle::ConditionallySelectable,
 {
     #[inline]
     fn cios_mont_mul_ct(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Option<Self> {

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -11,20 +11,30 @@ use fixed_bigint::const_numtraits::ConstBorrowingSub;
 use num_traits::ops::overflowing::OverflowingAdd;
 use num_traits::{One, WrappingMul, Zero};
 
-/// CIOS Montgomery multiplication: `a * b * R⁻¹ mod modulus`.
+// Under fixed-bigint's personality typestate, `MulAccOps::get_word` returns
+// an associated `GetWordOutput`: `Option<Word>` for the Nct impl (O(1) slice
+// index) and `subtle::CtOption<Word>` for the Ct impl (O(N) cond-select
+// scan). CIOS uses indices that are statically valid by construction, so
+// both paths immediately collapse to `Option` via `?` / `.into_option()?`;
+// the CT property of the CT path lives in the body of `get_word`, not in
+// the discriminant handling here.
+
+/// CIOS Montgomery multiplication — variable-time: `a * b * R⁻¹ mod modulus`.
 ///
 /// Both `a` and `b` must be in Montgomery form and in `[0, modulus)`.
 /// `n_prime_0` is the lowest word of `−N⁻¹ mod R`.
 ///
 /// The algorithm fuses multiplication and REDC into a single double-loop,
 /// saving ~25 % of limb multiplies compared to separate wide-mul + REDC.
-pub fn cios_montgomery_mul<T: MulAccOps + PartialOrd + ConstBorrowingSub>(
-    a: &T,
-    b: &T,
-    modulus: &T,
-    n_prime_0: T::Word,
-) -> Option<T>
+///
+/// Final reduction is a predicted branch. Timing leaks operand magnitude.
+/// Use [`cios_montgomery_mul_ct`] in CT-sensitive paths (private-key
+/// operations, secret scalar multiplication). For verify / public-key
+/// paths the branched version is significantly faster — see `wide_redc`
+/// docs for the cost breakdown.
+pub fn cios_montgomery_mul<T>(a: &T, b: &T, modulus: &T, n_prime_0: T::Word) -> Option<T>
 where
+    T: MulAccOps<GetWordOutput = Option<<T as MulAccOps>::Word>> + PartialOrd + ConstBorrowingSub,
     T::Word: num_traits::Zero
         + num_traits::One
         + num_traits::WrappingMul
@@ -57,8 +67,6 @@ where
 
         // Phase 2: [acc, acc_hi] = ([acc, acc_hi] + m * modulus) >> word_bits
         let new_overflow = T::mul_acc_shift_row(m, modulus, &mut acc, acc_hi);
-        // Safety: acc_hi2 ∈ {0,1} (reset each iteration, incremented at most once)
-        // and new_overflow ∈ {0,1} (bool→word from mul_acc_shift_row), so max sum = 2.
         debug_assert!(
             new_overflow == zero || new_overflow == one,
             "mul_acc_shift_row must return 0 or 1"
@@ -75,18 +83,81 @@ where
     Some(acc)
 }
 
-/// Convenience trait: types that support CIOS Montgomery multiplication.
+/// CIOS Montgomery multiplication — constant-time finalize.
+///
+/// Same algorithm as [`cios_montgomery_mul`] but performs the final
+/// conditional subtraction branchlessly via `subtle::ConditionallySelectable`
+/// and `subtle::ConstantTimeEq`, removing the operand-magnitude side-channel.
+///
+/// `acc_hi` is a `T::Word`; we use `ConstantTimeEq` on the word for the
+/// "high half nonzero" test. The "low half ≥ modulus" test is free — the
+/// borrow flag from `borrowing_sub` already encodes `acc < modulus`.
+pub fn cios_montgomery_mul_ct<T>(a: &T, b: &T, modulus: &T, n_prime_0: T::Word) -> Option<T>
+where
+    T: MulAccOps<GetWordOutput = subtle::CtOption<<T as MulAccOps>::Word>>
+        + ConstBorrowingSub
+        + subtle::ConditionallySelectable,
+    T::Word: num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + core::ops::Add<Output = T::Word>
+        + subtle::ConstantTimeEq,
+{
+    use subtle::{Choice, ConstantTimeEq};
+
+    let n = T::word_count();
+    let zero = <T::Word as Zero>::zero();
+    let one = <T::Word as One>::one();
+    let mut acc = T::default();
+    let mut acc_hi = zero;
+    let mut acc_hi2 = zero;
+
+    for i in 0..n {
+        let ai = a.get_word(i).into_option()?;
+
+        let carry = T::mul_acc_row(ai, b, &mut acc, zero);
+        let (sum, overflow) = acc_hi.overflowing_add(&carry);
+        acc_hi = sum;
+        if overflow {
+            acc_hi2 = acc_hi2 + one;
+        }
+
+        let m = acc.get_word(0).into_option()?.wrapping_mul(&n_prime_0);
+
+        let new_overflow = T::mul_acc_shift_row(m, modulus, &mut acc, acc_hi);
+        debug_assert!(
+            new_overflow == zero || new_overflow == one,
+            "mul_acc_shift_row must return 0 or 1"
+        );
+        acc_hi = acc_hi2 + new_overflow;
+        acc_hi2 = zero;
+    }
+
+    // Branchless final reduction:
+    //   needs_sub = (acc_hi != 0) | (acc >= modulus)
+    //             = (acc_hi != 0) | !borrow      (since borrow = acc < modulus)
+    let (sub_result, borrow) = <T as ConstBorrowingSub>::borrowing_sub(acc, *modulus, false);
+    let acc_hi_nonzero = !acc_hi.ct_eq(&zero);
+    let needs_sub = acc_hi_nonzero | !Choice::from(borrow as u8);
+    Some(T::conditional_select(&acc, &sub_result, needs_sub))
+}
+
+/// Convenience trait: types that support variable-time CIOS Montgomery multiplication.
 ///
 /// Implemented automatically for any `T: MulAccOps + PartialOrd + ConstBorrowingSub`
-/// with the required `Word` bounds.  Higher-level code (e.g. `MontgomeryCtx`)
+/// with the required `Word` bounds. Higher-level code (e.g. `MontgomeryCtx`)
 /// can bound on this trait instead of requiring knowledge of `MulAccOps::Word`
-/// or the CIOS call signature.
-pub trait CiosMontMul: MulAccOps + PartialOrd + ConstBorrowingSub {
+/// or the CIOS call signature. For CT-sensitive paths, see [`CiosMontMulCt`].
+pub trait CiosMontMul:
+    MulAccOps<GetWordOutput = Option<<Self as MulAccOps>::Word>> + PartialOrd + ConstBorrowingSub
+{
     fn cios_mont_mul(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Option<Self>;
 }
 
-impl<T: MulAccOps + PartialOrd + ConstBorrowingSub> CiosMontMul for T
+impl<T> CiosMontMul for T
 where
+    T: MulAccOps<GetWordOutput = Option<<T as MulAccOps>::Word>> + PartialOrd + ConstBorrowingSub,
     T::Word: num_traits::Zero
         + num_traits::One
         + num_traits::WrappingMul
@@ -96,6 +167,38 @@ where
     #[inline]
     fn cios_mont_mul(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Option<Self> {
         cios_montgomery_mul(a, b, modulus, n_prime.get_word(0)?)
+    }
+}
+
+/// Constant-time analog of [`CiosMontMul`].
+///
+/// Implemented automatically for any
+/// `T: MulAccOps + ConstBorrowingSub + ConditionallySelectable` with the
+/// required `Word` bounds (including `ConstantTimeEq`). Calls
+/// [`cios_montgomery_mul_ct`] under the hood.
+pub trait CiosMontMulCt:
+    MulAccOps<GetWordOutput = subtle::CtOption<<Self as MulAccOps>::Word>>
+    + ConstBorrowingSub
+    + subtle::ConditionallySelectable
+{
+    fn cios_mont_mul_ct(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Option<Self>;
+}
+
+impl<T> CiosMontMulCt for T
+where
+    T: MulAccOps<GetWordOutput = subtle::CtOption<<T as MulAccOps>::Word>>
+        + ConstBorrowingSub
+        + subtle::ConditionallySelectable,
+    T::Word: num_traits::Zero
+        + num_traits::One
+        + num_traits::WrappingMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + core::ops::Add<Output = T::Word>
+        + subtle::ConstantTimeEq,
+{
+    #[inline]
+    fn cios_mont_mul_ct(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Option<Self> {
+        cios_montgomery_mul_ct(a, b, modulus, n_prime.get_word(0).into_option()?)
     }
 }
 
@@ -210,8 +313,8 @@ mod tests {
         // Convert back
         let result = wide_redc(result_m, U128::from(0u64), modulus, n_prime);
 
-        // Compare with basic_mod_mul
-        let expected = crate::mul::basic_mod_mul(a, b, modulus);
+        // Compare with basic_mod_mul_pr (inputs are tiny vs modulus, so naturally pre-reduced).
+        let expected = crate::mul::basic_mod_mul_pr(a, b, modulus);
         assert_eq!(result, expected);
     }
 
@@ -239,4 +342,88 @@ mod tests {
         let expected = wide_montgomery_mul(a_m, b_m, modulus, n_prime);
         assert_eq!(result, expected);
     }
+
+    /// CT variant must produce the same output as the NCT path for all inputs.
+    ///
+    /// The precompute (Newton's iteration, r/r² mod N) runs on the Nct side
+    /// for speed; the to-Montgomery REDC also runs in Nct. Only the CT CIOS
+    /// call itself requires Ct-typed inputs (its `ConditionallySelectable`
+    /// bound resolves only there). Convert via `.into()` for the CT call and
+    /// `.forget_ct()` to bring the result back for equality.
+    #[test]
+    fn test_cios_ct_matches_nct_u8() {
+        use fixed_bigint::{Ct, FixedUInt};
+        type U16 = FixedUInt<u8, 2>;
+        type U16Ct = FixedUInt<u8, 2, Ct>;
+
+        let modulus = U16::from(13u16);
+        let w = type_bit_width::<U16>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+        let modulus_ct: U16Ct = modulus.into();
+
+        for a_val in 0u16..13 {
+            for b_val in 0u16..13 {
+                let a = U16::from(a_val);
+                let b = U16::from(b_val);
+                let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+                let a_m = wide_redc(lo, hi, modulus, n_prime);
+                let (lo, hi) = crate::WideMul::wide_mul(&b, &r2_mod_n);
+                let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+                let n_prime_0 = n_prime.get_word(0).unwrap();
+                let nct = cios_montgomery_mul(&a_m, &b_m, &modulus, n_prime_0).unwrap();
+                let a_m_ct: U16Ct = a_m.into();
+                let b_m_ct: U16Ct = b_m.into();
+                let ct = cios_montgomery_mul_ct(&a_m_ct, &b_m_ct, &modulus_ct, n_prime_0).unwrap();
+                assert_eq!(
+                    nct,
+                    ct.forget_ct(),
+                    "CIOS CT mismatch for {a_val}*{b_val} mod 13"
+                );
+            }
+        }
+    }
+
+    /// CT variant matches NCT at a larger type (128-bit modulus).
+    #[test]
+    fn test_cios_ct_matches_nct_u32x4() {
+        use fixed_bigint::{Ct, FixedUInt};
+        type U128 = FixedUInt<u32, 4>;
+        type U128Ct = FixedUInt<u32, 4, Ct>;
+
+        let modulus = !U128::from(0u64) - U128::from(58u64);
+        let w = type_bit_width::<U128>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = compute_r_mod_n(modulus, w);
+        let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
+        let modulus_ct: U128Ct = modulus.into();
+
+        let test_vals = [0u64, 1, 2, 42, 0xDEAD_BEEF, 0xCAFE_BABE];
+        for &a_val in &test_vals {
+            for &b_val in &test_vals {
+                let a = U128::from(a_val);
+                let b = U128::from(b_val);
+                let (lo, hi) = crate::WideMul::wide_mul(&a, &r2_mod_n);
+                let a_m = wide_redc(lo, hi, modulus, n_prime);
+                let (lo, hi) = crate::WideMul::wide_mul(&b, &r2_mod_n);
+                let b_m = wide_redc(lo, hi, modulus, n_prime);
+
+                let n_prime_0 = n_prime.get_word(0).unwrap();
+                let nct = cios_montgomery_mul(&a_m, &b_m, &modulus, n_prime_0).unwrap();
+                let a_m_ct: U128Ct = a_m.into();
+                let b_m_ct: U128Ct = b_m.into();
+                let ct = cios_montgomery_mul_ct(&a_m_ct, &b_m_ct, &modulus_ct, n_prime_0).unwrap();
+                assert_eq!(
+                    nct,
+                    ct.forget_ct(),
+                    "CIOS CT mismatch for {a_val:#x}*{b_val:#x}"
+                );
+            }
+        }
+    }
+
+    /// Trait CiosMontMulCt is usable as a bound without constraining T::Word.
+    fn _assert_ct_trait_bound<T: CiosMontMulCt>() {}
 }

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -158,7 +158,7 @@ where
     let n_prime = match method {
         NPrimeMethod::TrialSearch => compute_n_prime_trial_search_constrained(modulus, &r)?,
         // Newton is mapped to ExtendedEuclidean in the constrained path.
-        // This is because constrained/strict paths use legacy R > N semantics
+        // This is because constrained/strict paths use R > N semantics
         // (R = smallest power of 2 exceeding N), not the wide-REDC R = 2^W approach.
         // Newton's method is designed for R = 2^W with wrapping arithmetic, so we
         // fall back to ExtendedEuclidean which computes the same N' = -N^{-1} mod R.
@@ -253,8 +253,8 @@ where
     let m = &product & &mask;
 
     // Step 2: t = (a_mont + m * N) >> r_bits
-    // TODO(Phase 1): m * N can overflow for large moduli (m < R, N < R, so
-    // m*N can reach R²). Needs WideningMul for correctness at key sizes.
+    // Warning: m * N can overflow for large moduli (m < R, N < R, so m*N
+    // can reach R²). For overflow-free reduction, use wide-REDC.
     let m_times_n = m * modulus;
     let temp_sum = a_mont.wrapping_add(&m_times_n);
     let t = temp_sum >> r_bits;
@@ -289,10 +289,10 @@ where
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
 {
-    // TODO(Phase 1): Replace mod_mul + from_montgomery with proper Montgomery
-    // reduction using WideningMul. Current mod_mul is O(k) double-and-add which
-    // defeats the performance purpose of Montgomery, and from_montgomery's
-    // m * N intermediate can overflow at key sizes. See ROADMAP.md Phase 1.
+    // Note: this R>N path uses double-and-add mod_mul (O(k)), which
+    // defeats Montgomery's perf purpose; the m*N intermediate in
+    // from_montgomery can also overflow at key sizes. For overflow-free
+    // multiplication, route through wide-REDC / CIOS instead.
     let product = crate::mul::constrained_mod_mul(a_mont.clone(), b_mont, modulus);
     constrained_from_montgomery(product, modulus, n_prime, r_bits)
 }

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -1,71 +1,62 @@
-// Montgomery form arithmetic module
-// Contains basic and strict implementations organized in submodules
+//! Flavor-neutral Montgomery arithmetic primitives.
+//!
+//! Holds the [`NPrimeMethod`] enum (shared by every flavor's
+//! `*_with_method` siblings), the wide-REDC param helpers
+//! ([`compute_n_prime_newton`], [`compute_r_mod_n`], [`compute_r2_mod_n`],
+//! [`type_bit_width`]), and the [`cios`] submodule with the
+//! interleaved-multiply-and-reduce primitives and their CT siblings.
+//!
+//! The R>N path's per-flavor implementations live in private
+//! `basic_mont` / `constrained_mont` / `strict_mont` submodules that
+//! are surfaced through the
+//! [`modmath::basic::montgomery`](crate::basic::montgomery),
+//! [`modmath::constrained::montgomery`](crate::constrained::montgomery),
+//! and [`modmath::strict::montgomery`](crate::strict::montgomery)
+//! re-export hubs. The flavor-neutral [`cios`] submodule is
+//! exposed publicly because its primitives have no flavor variants —
+//! operands are already by-reference, no `Copy` bound to swap on.
 
-pub mod basic_mont;
+pub(crate) mod basic_mont;
 
-pub mod constrained_mont;
+pub(crate) mod constrained_mont;
 
-pub mod strict_mont;
+pub(crate) mod strict_mont;
 
 #[cfg(feature = "wide-mul")]
 pub mod cios;
 
-// Re-export basic functions for backwards compatibility
+// Flavor-neutral items live at this flat path: the NPrimeMethod enum
+// (shared by every flavor's `*_with_method` siblings), the wide-REDC
+// param helpers (`compute_n_prime_newton` etc., generic over any T:
+// WrappingMul + ...), and `type_bit_width`. Flavor-keyed R>N items are
+// surfaced through `modmath::{basic,constrained,strict}::montgomery::*`
+// and reach into `basic_mont` / `constrained_mont` / `strict_mont` via
+// the submodule paths instead of this flat re-export.
 #[rustfmt::skip]
 pub use basic_mont::{
     NPrimeMethod,
-    basic_compute_montgomery_params,
-    basic_compute_montgomery_params_with_method,
-    basic_from_montgomery,
-    basic_montgomery_mod_exp,
-    basic_montgomery_mod_exp_with_method,
-    basic_montgomery_mod_mul,
-    basic_montgomery_mod_mul_with_method,
-    basic_montgomery_mul,
-    basic_to_montgomery,
-    wide_from_montgomery,
-    // Wide-REDC primitives for precomputed Montgomery contexts
     type_bit_width,
     compute_n_prime_newton,
     compute_r_mod_n,
     compute_r2_mod_n,
-    wide_redc,
-    wide_montgomery_mul,
 };
 
-// Re-export constrained functions
-#[rustfmt::skip]
-pub use constrained_mont::{
-    constrained_compute_montgomery_params,
-    constrained_compute_montgomery_params_with_method,
-    constrained_from_montgomery,
-    constrained_montgomery_mod_exp,
-    constrained_montgomery_mod_exp_with_method,
-    constrained_montgomery_mod_mul,
-    constrained_montgomery_mod_mul_with_method,
-    constrained_montgomery_mul,
-    constrained_to_montgomery,
-};
-
-// Re-export strict functions
-#[rustfmt::skip]
-pub use strict_mont::{
-    strict_compute_montgomery_params,
-    strict_compute_montgomery_params_with_method,
-    strict_from_montgomery,
-    strict_montgomery_mod_exp,
-    strict_montgomery_mod_exp_with_method,
-    strict_montgomery_mod_mul,
-    strict_montgomery_mod_mul_with_method,
-    strict_to_montgomery,
-};
-
-// Re-export CIOS Montgomery multiplication
+// Re-export the CIOS traits as the canonical entry point for consumers.
+// The underlying `cios_montgomery_mul` / `cios_montgomery_mul_ct` free
+// functions remain publicly reachable via `modmath::montgomery::cios::*`
+// for callers who want the raw word-level primitive (the trait method
+// takes the whole `n_prime` and extracts the low word; the free function
+// takes the word directly).
 #[cfg(feature = "wide-mul")]
-pub use cios::{CiosMontMul, cios_montgomery_mul};
+pub use cios::{CiosMontMul, CiosMontMulCt};
 
+// Tests exercise the R > N path and constrained/strict APIs which require
+// `Rem`-able `T`; gated to NCT/non-FixedUInt builds via dev-deps without ct.
 #[cfg(test)]
 mod tests {
+    use super::basic_mont::*;
+    use super::constrained_mont::*;
+    use super::strict_mont::*;
     use super::*;
 
     #[test]
@@ -99,7 +90,7 @@ mod tests {
             basic_compute_montgomery_params_with_method(13u32, NPrimeMethod::TrialSearch).unwrap();
 
         // Both should produce identical results (Newton delegates to ExtendedEuclidean
-        // in the legacy param path, which agrees with TrialSearch)
+        // in the R > N param path, which agrees with TrialSearch)
         assert_eq!(default_result, explicit_trial_result);
 
         // Verify the explicit method call produces correct values
@@ -248,7 +239,6 @@ mod tests {
         // Test with our documented example: N = 13, R = 16
         let (r, _r_inv, _n_prime, _r_bits) = basic_compute_montgomery_params(13u32).unwrap();
 
-        // From EXAMPLE1_COMPUTE_PARAM.md:
         // 7 -> Montgomery: 7 * 16 mod 13 = 112 mod 13 = 8
         // 5 -> Montgomery: 5 * 16 mod 13 = 80 mod 13 = 2
         assert_eq!(basic_to_montgomery(7u32, 13u32, r), 8u32);
@@ -791,6 +781,9 @@ macro_rules! montgomery_test_module {
 
 #[cfg(test)]
 mod bnum_montgomery_tests {
+    use super::basic_mont::*;
+    use super::constrained_mont::*;
+    use super::strict_mont::*;
     use super::*;
 
     montgomery_test_module!(
@@ -879,6 +872,11 @@ mod bnum_montgomery_tests {
         basic: off, // Copy is not implemented, heap allocation
     );
 
+    // Default (Nct-personality) FixedUInt provides Rem; the strict/
+    // constrained/basic Montgomery wrappers are reachable here. The Ct
+    // personality intentionally omits Rem (reduce-then-multiply is
+    // variable-time on operand magnitudes), so a Ct-typed FixedUInt would
+    // be a compile error here, not silent execution.
     montgomery_test_module!(
         fixed_bigint,
         fixed_bigint::FixedUInt,

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -18,9 +18,9 @@ where
     // We need to find N' where modulus * N' ≡ R - 1 (mod R)
     let target = r - &T::one(); // This is -1 mod R
 
-    // Simple trial search for N'
-    // TODO: Replace with Extended Euclidean Algorithm for O(log R) complexity instead of O(R)
-    // Current implementation is fine for small numbers but inefficient for large moduli
+    // Simple O(R) trial search for N'. Adequate for small moduli; the
+    // ExtendedEuclidean and HenselsLifting NPrimeMethod variants offer
+    // O(log R) alternatives for larger moduli.
     let mut n_prime = T::one();
     loop {
         // Check if (modulus * n_prime) % r == target
@@ -242,7 +242,7 @@ where
             strict_compute_n_prime_trial_search(modulus, &r)?
         }
         // Newton is mapped to ExtendedEuclidean in the strict path.
-        // This is because strict/constrained paths use legacy R > N semantics
+        // This is because strict/constrained paths use R > N semantics
         // (R = smallest power of 2 exceeding N), not the wide-REDC R = 2^W approach.
         // Newton's method is designed for R = 2^W with wrapping arithmetic, so we
         // fall back to ExtendedEuclidean which computes the same N' = -N^{-1} mod R.
@@ -279,10 +279,10 @@ where
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::BitAnd<Output = T>,
 {
-    // TODO(Phase 1): Replace mod_mul + from_montgomery with proper Montgomery
-    // reduction using WideningMul. Current mod_mul is O(k) double-and-add which
-    // defeats the performance purpose of Montgomery, and from_montgomery's
-    // m * N intermediate can overflow at key sizes. See ROADMAP.md Phase 1.
+    // Note: this R>N path uses double-and-add mod_mul (O(k)), which
+    // defeats Montgomery's perf purpose; the m*N intermediate in
+    // from_montgomery can also overflow at key sizes. For overflow-free
+    // multiplication, route through wide-REDC / CIOS instead.
     let product = crate::mul::strict_mod_mul(a_mont, b_mont, modulus);
     strict_from_montgomery(product, modulus, n_prime, r_bits)
 }
@@ -330,8 +330,8 @@ where
     let m = &product & &mask;
 
     // Step 2: t = (a_mont + m * N) >> r_bits
-    // TODO(Phase 1): m * N can overflow for large moduli (m < R, N < R, so
-    // m*N can reach R²). Needs WideningMul for correctness at key sizes.
+    // Warning: m * N can overflow for large moduli (m < R, N < R, so m*N
+    // can reach R²). For overflow-free reduction, use wide-REDC.
     let m_times_n = &m * modulus;
     let (sum, _overflow) = a_mont.overflowing_add(&m_times_n);
     let t = sum >> r_bits; // Divide by R = 2^r_bits using bit shift
@@ -422,7 +422,7 @@ where
 ///
 /// This function uses the default NPrimeMethod (Newton) for N' computation.
 /// Note: In the strict path, Newton is mapped to ExtendedEuclidean since these
-/// paths use legacy R > N semantics rather than wide-REDC's R = 2^W.
+/// paths use R > N semantics rather than wide-REDC's R = 2^W.
 /// For performance-critical applications, consider using `strict_montgomery_mod_mul_with_method`
 /// to select the optimal N' computation method for your specific use case.
 ///
@@ -534,7 +534,7 @@ where
 ///
 /// This function uses the default NPrimeMethod (Newton) for N' computation.
 /// Note: In the strict path, Newton is mapped to ExtendedEuclidean since these
-/// paths use legacy R > N semantics rather than wide-REDC's R = 2^W.
+/// paths use R > N semantics rather than wide-REDC's R = 2^W.
 /// For performance-critical applications or specific hardware optimization, consider using
 /// `strict_montgomery_mod_exp_with_method` to select the optimal N' computation method:
 /// - `Newton`: Default, mapped to ExtendedEuclidean in strict path
@@ -762,7 +762,6 @@ mod tests {
         let modulus = 13u32;
         let (r, _r_inv, _n_prime, _r_bits) = strict_compute_montgomery_params(&modulus).unwrap();
 
-        // From EXAMPLE1_COMPUTE_PARAM.md:
         // 7 -> Montgomery: 7 * 16 mod 13 = 112 mod 13 = 8
         // 5 -> Montgomery: 5 * 16 mod 13 = 80 mod 13 = 2
         assert_eq!(strict_to_montgomery(7u32, &modulus, &r), 8u32);

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -66,8 +66,26 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>,
 {
-    let mut a = a % m;
-    let mut b = b % m;
+    basic_mod_mul_pr(a % m, b % m, m)
+}
+
+/// # Modular Multiplication (Basic, pre-reduced)
+/// Precondition: `a < m` and `b < m`. No `Rem` bound.
+///
+/// Note: this only removes the division side-channel from the signature.
+/// The double-and-add loop still leaks `bit_length(b)`; for constant-time
+/// multiplication, use the Montgomery wide-REDC path.
+pub fn basic_mod_mul_pr<T>(mut a: T, mut b: T, m: T) -> T
+where
+    T: core::cmp::PartialOrd
+        + Copy
+        + num_traits::Zero
+        + num_traits::One
+        + crate::parity::Parity
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub
+        + core::ops::Shr<usize, Output = T>,
+{
     let m1 = m;
     let mut result = T::zero();
 
@@ -113,8 +131,26 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     a.rem_assign(m);
-    let mut b = b % m;
+    let b = b % m;
+    constrained_mod_mul_pr(a, &b, m)
+}
 
+/// # Modular Multiplication (Constrained, pre-reduced)
+/// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound. See
+/// [`basic_mod_mul_pr`] for the CT caveat.
+pub fn constrained_mod_mul_pr<T>(mut a: T, b: &T, m: &T) -> T
+where
+    T: num_traits::Zero
+        + num_traits::One
+        + crate::parity::Parity
+        + PartialOrd
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub
+        + core::ops::Shr<usize, Output = T>,
+{
+    // Need an owned mutable T for the double-and-add loop's right-shift;
+    // mirror the `exp_pr` convention of cloning via wrapping_add(zero).
+    let mut b = T::zero().wrapping_add(b);
     let mut result = T::zero();
 
     while b > T::zero() {
@@ -159,8 +195,26 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     a.rem_assign(m);
-    let mut b = b % m;
+    let b = b % m;
+    strict_mod_mul_pr(a, &b, m)
+}
 
+/// # Modular Multiplication (Strict, pre-reduced)
+/// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound. See
+/// [`basic_mod_mul_pr`] for the CT caveat.
+pub fn strict_mod_mul_pr<T>(mut a: T, b: &T, m: &T) -> T
+where
+    T: num_traits::Zero
+        + num_traits::One
+        + crate::parity::Parity
+        + PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub
+        + core::ops::Shr<usize, Output = T>,
+{
+    // Need an owned mutable T for the double-and-add loop's right-shift;
+    // mirror the `exp_pr` convention of cloning via overflowing_add(zero).
+    let mut b = T::zero().overflowing_add(b).0;
     let mut result = T::zero();
 
     while b > T::zero() {
@@ -562,12 +616,46 @@ mod bnum_mul_tests {
         basic: off, // Copy cannot be implemented, heap allocation
     );
 
+    // Default (Nct-personality) FixedUInt provides Rem; the wrapper
+    // functions are usable here. The Ct personality intentionally omits
+    // Rem (variable-time on operand magnitudes).
     mul_test_module!(
         fixed_bigint,
         fixed_bigint::FixedUInt,
-        type U256 = FixedUInt<u32, 4>;
+        type U256 = fixed_bigint::FixedUInt<u32, 4>;
         strict: on,
         constrained: on,
         basic: on,
     );
+}
+
+#[cfg(test)]
+mod fixed_bigint_pr_tests {
+    use super::{basic_mod_mul_pr, constrained_mod_mul_pr, strict_mod_mul_pr};
+    type U256 = fixed_bigint::FixedUInt<u32, 4>;
+
+    #[test]
+    fn test_mod_mul_basic_pr() {
+        let m = U256::from(19u8);
+        let a = U256::from(7u8);
+        let b = U256::from(13u8);
+        let expected = U256::from(15u8); // (7 * 13) mod 19 = 91 mod 19 = 15
+
+        assert_eq!(strict_mod_mul_pr(a, &b, &m), expected);
+        let a = U256::from(7u8);
+        assert_eq!(constrained_mod_mul_pr(a, &b, &m), expected);
+        let a = U256::from(7u8);
+        assert_eq!(basic_mod_mul_pr(a, b, m), expected);
+    }
+
+    #[test]
+    fn test_mod_mul_zero_pr() {
+        let m = U256::from(19u8);
+        let zero = U256::from(0u8);
+        let b = U256::from(13u8);
+
+        assert_eq!(strict_mod_mul_pr(zero, &b, &m), zero);
+        assert_eq!(constrained_mod_mul_pr(zero, &b, &m), zero);
+        assert_eq!(basic_mod_mul_pr(zero, b, m), zero);
+    }
 }

--- a/modmath/src/strict/mod.rs
+++ b/modmath/src/strict/mod.rs
@@ -13,10 +13,13 @@
 //!
 //! ## Pre-reduced variants
 //!
-//! [`pre_reduced`] mirrors this module's surface but assumes inputs
-//! are already in `[0, m)`, skipping the `% m` reduction step. Works
-//! for backends without `core::ops::Rem` and is the right entry point
-//! inside loops where reduction is handled separately.
+//! [`pre_reduced`] re-exports `add` / `sub` / `mul` / `exp` siblings that
+//! assume inputs are already in `[0, m)` and skip the `% m` reduction
+//! step. Works for backends without `core::ops::Rem` and is the right
+//! entry point inside loops where reduction is handled separately.
+//! Note: `inv` has no pre-reduced sibling — modular inverse via the
+//! extended Euclidean algorithm inside `inv` performs its own
+//! magnitude-dependent loop, with no useful "pre-reduced" shortcut.
 
 #[doc(inline)]
 pub use crate::add::strict_mod_add as add;

--- a/modmath/src/strict/mod.rs
+++ b/modmath/src/strict/mod.rs
@@ -1,0 +1,45 @@
+//! Schoolbook modular arithmetic with reference-based parameters
+//! throughout — neither `Copy` nor `Clone` on owned `T` is required.
+//!
+//! Uses `OverflowingAdd` / `OverflowingSub` rather than
+//! `WrappingAdd` / `WrappingSub`, the strictest bound profile in the
+//! toolbox. Suitable for backends that don't expose the wrapping
+//! operations on owned values, or when avoiding `Clone` is necessary
+//! for the operand type.
+//!
+//! See [`modmath::basic`](crate::basic) (`Copy`-bound, simplest) and
+//! [`modmath::constrained`](crate::constrained) (`Clone`-bound, mixed
+//! value/reference) for less strict surfaces.
+//!
+//! ## Pre-reduced variants
+//!
+//! [`pre_reduced`] mirrors this module's surface but assumes inputs
+//! are already in `[0, m)`, skipping the `% m` reduction step. Works
+//! for backends without `core::ops::Rem` and is the right entry point
+//! inside loops where reduction is handled separately.
+
+#[doc(inline)]
+pub use crate::add::strict_mod_add as add;
+#[doc(inline)]
+pub use crate::exp::strict_mod_exp as exp;
+#[doc(inline)]
+pub use crate::inv::strict_mod_inv as inv;
+#[doc(inline)]
+pub use crate::mul::strict_mod_mul as mul;
+#[doc(inline)]
+pub use crate::sub::strict_mod_sub as sub;
+
+pub mod montgomery;
+
+/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
+/// no `Rem`-family bound.
+pub mod pre_reduced {
+    #[doc(inline)]
+    pub use crate::add::strict_mod_add_pr as add;
+    #[doc(inline)]
+    pub use crate::exp::strict_mod_exp_pr as exp;
+    #[doc(inline)]
+    pub use crate::mul::strict_mod_mul_pr as mul;
+    #[doc(inline)]
+    pub use crate::sub::strict_mod_sub_pr as sub;
+}

--- a/modmath/src/strict/montgomery.rs
+++ b/modmath/src/strict/montgomery.rs
@@ -1,0 +1,68 @@
+//! R > N Montgomery arithmetic with reference-based parameters
+//! throughout.
+//!
+//! Textbook Montgomery: pick `R` as the smallest power of 2 greater
+//! than the modulus, precompute `R⁻¹ mod N` and `N' = -N⁻¹ mod R`,
+//! transform values into Montgomery form, multiply in the Mont domain,
+//! transform back. Use [`compute_params`] to derive the parameters,
+//! [`to_mont`] / [`from_mont`] for representation transforms, and
+//! [`mul`] for in-Mont multiplication. The full-pipeline operations
+//! [`mod_mul`] and [`mod_exp`] wrap precompute + transform + arith.
+//!
+//! ## Distinction between `mul` and `mod_mul`
+//!
+//! - [`mul`] — takes Mont-form values and Montgomery params; returns
+//!   a Mont-form value. The in-domain multiplication step.
+//! - [`mod_mul`] — takes raw values and the modulus only; internally
+//!   computes Mont params, transforms inputs, multiplies, transforms
+//!   back. The complete `a * b mod m` pipeline.
+//!
+//! ## N' computation method
+//!
+//! [`compute_params`] uses a default algorithm. To pick explicitly
+//! between trial-search / extended-Euclidean / Hensel's lifting, use
+//! [`compute_params_with_method`], [`mod_mul_with_method`], or
+//! [`mod_exp_with_method`] with a [`crate::NPrimeMethod`] choice.
+
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_compute_montgomery_params as compute_params;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_compute_montgomery_params_with_method as compute_params_with_method;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_from_montgomery as from_mont;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_montgomery_mod_exp as mod_exp;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_montgomery_mod_exp_with_method as mod_exp_with_method;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_montgomery_mod_mul as mod_mul;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_montgomery_mod_mul_with_method as mod_mul_with_method;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_montgomery_mul as mul;
+#[doc(inline)]
+pub use crate::montgomery::strict_mont::strict_to_montgomery as to_mont;
+
+/// Wide-REDC primitives at the `R = 2^W` working width — reference-based
+/// operands, no `Copy` bound on `T`. Suitable for non-`Copy` bigint
+/// backends where each by-value pass would clone the operand.
+///
+/// For the by-value variant suitable for `Copy` types (u32,
+/// `FixedUInt`), see [`modmath::basic::montgomery::wide`](crate::basic::montgomery::wide).
+/// Codegen for `Copy` types is identical between the two; the strict
+/// form only matters when `T: !Copy`.
+pub mod wide {
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::strict_wide_montgomery_mul as mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::strict_wide_redc as redc;
+
+    /// Constant-time finalize. Branchless conditional-subtract via
+    /// `subtle::ConditionallySelectable`.
+    pub mod ct {
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::strict_wide_montgomery_mul_ct as mul;
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::strict_wide_redc_ct as redc;
+    }
+}

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -35,8 +35,19 @@ where
         + num_traits::ops::wrapping::WrappingSub
         + core::ops::Rem<Output = T>,
 {
-    let a = a % m;
-    let diff = a.wrapping_sub(&(b % m));
+    basic_mod_sub_pr(a % m, b % m, m)
+}
+
+/// # Modular Subtraction (Basic, pre-reduced)
+/// Precondition: `a < m` and `b < m`. No `Rem` bound.
+pub fn basic_mod_sub_pr<T>(a: T, b: T, m: T) -> T
+where
+    T: core::cmp::PartialOrd
+        + Copy
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub,
+{
+    let diff = a.wrapping_sub(&b);
     if diff > a {
         // If we wrapped around (underflow)
         diff.wrapping_add(&m)
@@ -56,8 +67,20 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     let a_mod = &a % m;
-    let diff = a_mod.wrapping_sub(&(b % m));
-    if diff > a_mod {
+    let b_mod = b % m;
+    constrained_mod_sub_pr(a_mod, &b_mod, m)
+}
+
+/// # Modular Subtraction (Constrained, pre-reduced)
+/// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
+pub fn constrained_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::wrapping::WrappingAdd
+        + num_traits::ops::wrapping::WrappingSub,
+{
+    let diff = a.wrapping_sub(b);
+    if diff > a {
         // If we wrapped around (underflow)
         diff.wrapping_add(m)
     } else {
@@ -77,8 +100,19 @@ where
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     a.rem_assign(m);
-    let (diff, overflow) = a.overflowing_sub(&(b % m));
+    let b_mod = b % m;
+    strict_mod_sub_pr(a, &b_mod, m)
+}
 
+/// # Modular Subtraction (Strict, pre-reduced)
+/// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
+pub fn strict_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
+where
+    T: core::cmp::PartialOrd
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::ops::overflowing::OverflowingSub,
+{
+    let (diff, overflow) = a.overflowing_sub(b);
     if overflow {
         m.overflowing_add(&diff).0
     } else {
@@ -318,12 +352,50 @@ mod bnum_sub_tests {
         basic: off, // Copy cannot be implemented, heap allocation
     );
 
+    // Default (Nct-personality) FixedUInt provides Rem; the wrapper
+    // functions are usable here. The Ct personality intentionally omits
+    // Rem (variable-time on operand magnitudes).
     sub_test_module!(
         fixed_bigint,
         fixed_bigint::FixedUInt,
-        type U256 = FixedUInt<u32, 4>;
+        type U256 = fixed_bigint::FixedUInt<u32, 4>;
         strict: on,
         constrained: on,
         basic: on,
     );
+}
+
+#[cfg(test)]
+mod fixed_bigint_pr_tests {
+    use super::{basic_mod_sub_pr, constrained_mod_sub_pr, strict_mod_sub_pr};
+    type U256 = fixed_bigint::FixedUInt<u32, 4>;
+
+    #[test]
+    fn test_mod_sub_basic_pr() {
+        let m = U256::from(20u8);
+        let a = U256::from(10u8);
+        let b = U256::from(5u8);
+        let expected = U256::from(5u8);
+
+        assert_eq!(strict_mod_sub_pr(a, &b, &m), expected);
+        let a = U256::from(10u8);
+        assert_eq!(constrained_mod_sub_pr(a, &b, &m), expected);
+        let a = U256::from(10u8);
+        assert_eq!(basic_mod_sub_pr(a, b, m), expected);
+    }
+
+    #[test]
+    fn test_mod_sub_underflow_pr() {
+        // a < b: wraps via + m
+        let m = U256::from(20u8);
+        let a = U256::from(3u8);
+        let b = U256::from(7u8);
+        let expected = U256::from(16u8); // 3 - 7 = -4 ≡ 16 (mod 20)
+
+        assert_eq!(strict_mod_sub_pr(a, &b, &m), expected);
+        let a = U256::from(3u8);
+        assert_eq!(constrained_mod_sub_pr(a, &b, &m), expected);
+        let a = U256::from(3u8);
+        assert_eq!(basic_mod_sub_pr(a, b, m), expected);
+    }
 }


### PR DESCRIPTION
…ule reorg

Major changes:

- Adds modmath::Field<T> and modmath::FieldCt<T> with lifetime-branded Residue<'f, T> / ResidueCt<'f, T> as the canonical Montgomery surface.
- Adds CT-finalize siblings throughout the Montgomery stack: wide_redc_ct, cios_montgomery_mul_ct, wide_montgomery_mul_ct, basic_montgomery_mod_exp_ct, plus _pr variants where pre-reduced inputs are assumed.
- Adds CiosMontMulCt convenience trait paralleling CiosMontMul.
- Adds FieldCt::exp_public_exp for the CT-base + NCT-exp shape (RSA encrypt with public e, Curve25519 Fermat inverse with public p-2).
- Reorganizes schoolbook surface: modmath::basic, modmath::constrained, modmath::strict modules replace the basic_*/constrained_*/strict_* function prefixes; backward-compat re-exports preserved.
- Adds _pr (pre-reduced) sibling functions to schoolbook surface so CT-aware code paths can drop the Rem bound.
- wide-mul is now a default feature.
- Subtle dep added (gated by wide-mul which pulls fixed-bigint/ct).

## Summary by Sourcery

Introduce a branded Montgomery field abstraction with CT/NCT personalities, reorganize the public modular arithmetic surface into basic/constrained/strict modules, and extend Montgomery and schoolbook operations with pre-reduced and constant-time variants backed by wide-REDC/CIOS.

New Features:
- Add Field<T, P> / FieldCt / FieldNct Montgomery context types with lifetime-branded Residue values and personality parameter for CT vs non-CT arithmetic.
- Expose basic/constrained/strict module hubs that group the schoolbook add/sub/mul/exp/inv and montgomery APIs, including wide-REDC helpers and CT submodules.
- Provide constant-time wide-REDC primitives (wide_redc_ct, wide_montgomery_mul_ct) and CIOS-based Montgomery multiplication (cios_montgomery_mul_ct) with a CiosMontMulCt trait.
- Add constant-time Montgomery exponentiation helpers in the basic flavor, including pre-reduced and CT-over-exponent variants and FieldCt::exp_public_exp for public exponents.
- Introduce pre-reduced (_pr) variants of add/sub/mul/exp and Montgomery conversion/multiply/exp functions across basic, constrained, and strict surfaces that operate without Rem bounds.

Enhancements:
- Clarify and document NPrimeMethod behavior, R>N vs R=2^W semantics, and wide-REDC usage throughout the Montgomery stack.
- Refactor montgomery module layout to keep flavor-neutral items at modmath::montgomery while routing R>N paths through basic/constrained/strict::montgomery, and remove wide_from_montgomery in favor of wide_redc.
- Tighten and document interaction with fixed-bigint personality typestate so CT paths require Ct-typed integers and Rem/Div are only available on Nct personalities.
- Improve schoolbook modular add/sub/mul/exp implementations by factoring shared logic into pre-reduced helpers, handling modulus==1 in exponentiation, and reducing trait bounds for non-Rem callers.
- Add reference-based wide-REDC helpers (strict_wide_redc, strict_wide_montgomery_mul and their CT siblings) for non-Copy bigint backends and relax Copy constraints where unnecessary.
- Expand and rewrite crate-level and module-level documentation to describe the reorganized API surface, personalities, and CT vs non-CT guarantees.

Build:
- Bump crate version from 0.1.5 to 0.2.0 and update fixed-bigint to 0.3.
- Add subtle as a dependency for constant-time conditional selection and equality, and make wide-mul a default feature with explicit docs.rs feature configuration.

Documentation:
- Update top-level crate docs and Montgomery module docs to describe the new basic/constrained/strict structure, Field/Residue types, wide-REDC/CIOS usage, and CT vs non-CT variants.
- Add extensive inline documentation and examples around fixed-bigint personalities, pre-reduced APIs, and constant-time behavior assumptions.

Tests:
- Add comprehensive tests for pre-reduced add/sub/mul/exp operations over fixed-bigint types.
- Introduce equivalence tests ensuring CT wide-REDC and CIOS variants match their variable-time counterparts across small integers and FixedUInt backends.
- Add tests for Field/Residue behavior, including round-trips, CT vs NCT cross-checks, cswap, exp_public_exp equivalence, branding limitations, and from_precomputed construction.
- Extend existing Montgomery and exponentiation test suites to cover fixed-bigint personalities, pre-reduced paths, and modulus==1 edge cases.

Chores:
- Add or update repository ignore rules and adjust internal comments to reflect the removal of legacy terminology and TODOs around the R>N path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public Montgomery Field/Residue API, new flavor hubs (basic, constrained, strict), pre-reduced entry points, wide/strict Montgomery facades, and constant-time variants.

* **Changes**
  * Crate reorganized and documented, public surface streamlined, default features adjusted (wide-mul enabled), version bumped to 0.2.0.

* **Tests**
  * Expanded coverage for pre-reduced paths, Montgomery/wide-REDC, constant-time equivalence, and bigint/personality cases.

* **Chores**
  * Ignore macOS .DS_Store files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->