### PR TITLE
Add optional zeroize feature; drop Copy from Residue

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = """
 Modular math implemented with traits.
@@ -59,4 +59,4 @@ zeroize = ["dep:zeroize", "fixed-bigint?/zeroize"]
 # would build with default features only and the wide-mul-gated public
 # API could become invisible.
 [package.metadata.docs.rs]
-features = ["wide-mul"]
+features = ["wide-mul", "zeroize"]

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = """
 Modular math implemented with traits.
@@ -18,6 +18,7 @@ num-integer = { version = "0.1", default-features = false, optional = true }
 c0nst = { version = "0.2", optional = true }
 fixed-bigint = { version = "0.3", optional = true, default-features = false }
 subtle = { version = "2.6", default-features = false }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 fixed-bigint = { version = "0.3" }
@@ -50,6 +51,7 @@ strict = []
 num-integer = ["dep:num-integer"]
 wide-mul = ["dep:fixed-bigint"]
 nightly = ["dep:c0nst", "c0nst/nightly", "dep:fixed-bigint", "fixed-bigint/nightly"]
+zeroize = ["dep:zeroize", "fixed-bigint?/zeroize"]
 
 # docs.rs (published documentation) builds with `wide-mul` explicitly
 # enabled as defense-in-depth — covers the case where someone publishes

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -158,15 +158,15 @@ pub type ResidueCt<'f, T> = Residue<'f, T, Ct>;
 // Shared impls (any P)
 // ---------------------------------------------------------------------------
 
-impl<T: Copy + MontStorage, P: Personality> Residue<'_, T, P> {
-    /// Returns a copy of the underlying Montgomery-form value.
+impl<T: MontStorage, P: Personality> Residue<'_, T, P> {
+    /// Returns a reference to the underlying Montgomery-form value.
     ///
     /// **Escape hatch.** Intended for downstream specialization layers
     /// (e.g. `Curve25519Field`) that implement fast paths reading the raw
     /// limbs. General consumers should not call this — use the methods on
     /// [`Field`] instead.
-    pub fn mont_value(&self) -> T {
-        self.mont
+    pub fn mont_value(&self) -> &T {
+        &self.mont
     }
 }
 
@@ -907,11 +907,13 @@ mod tests {
     #[test]
     fn residue_zeroize_wipes_mont_small() {
         use zeroize::Zeroize;
+        fn assert_zeroize_on_drop<T: zeroize::ZeroizeOnDrop>(_: &T) {}
         let f = FieldCt::new(u16ct(13)).unwrap();
         let mut r = f.reduce(&u16ct(7));
-        assert_ne!(r.mont_value(), u16ct(0));
+        assert_zeroize_on_drop(&r);
+        assert_ne!(*r.mont_value(), u16ct(0));
         r.zeroize();
-        assert_eq!(r.mont_value(), u16ct(0));
+        assert_eq!(*r.mont_value(), u16ct(0));
     }
 
     #[test]
@@ -920,7 +922,7 @@ mod tests {
         let f: Field<U16> = Field::new(u16(13)).unwrap();
         for raw in 0u16..13 {
             let r = f.reduce(&u16(raw));
-            let mont = r.mont_value();
+            let mont = *r.mont_value();
             let r2 = f.residue_from_mont(mont);
             assert_eq!(f.into_raw(&r2), u16(raw));
         }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -62,6 +62,18 @@ use crate::montgomery::{
 use crate::parity::Parity;
 use crate::wide_mul::WideMul;
 
+/// Bound on the value stored in a [`Residue`]. With the `zeroize`
+/// feature this requires `T: Zeroize`; otherwise it's vacuous.
+#[cfg(feature = "zeroize")]
+pub trait MontStorage: zeroize::Zeroize {}
+#[cfg(feature = "zeroize")]
+impl<T: zeroize::Zeroize> MontStorage for T {}
+
+#[cfg(not(feature = "zeroize"))]
+pub trait MontStorage {}
+#[cfg(not(feature = "zeroize"))]
+impl<T> MontStorage for T {}
+
 // ---------------------------------------------------------------------------
 // Field<T, P>
 // ---------------------------------------------------------------------------
@@ -110,12 +122,29 @@ pub type FieldCt<T> = Field<T, Ct>;
 /// borrow checker rejects code that uses a residue after its `Field` is
 /// dropped, or that mixes residues across personalities. See module docs
 /// for the covariance caveat.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Residue<'f, T, P: Personality = Nct> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Residue<'f, T: MontStorage, P: Personality = Nct> {
     mont: T,
     _brand: PhantomData<&'f ()>,
     _p: PhantomData<fn() -> P>,
 }
+
+#[cfg(feature = "zeroize")]
+impl<'f, T: MontStorage, P: Personality> zeroize::Zeroize for Residue<'f, T, P> {
+    fn zeroize(&mut self) {
+        self.mont.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<'f, T: MontStorage, P: Personality> Drop for Residue<'f, T, P> {
+    fn drop(&mut self) {
+        self.mont.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<'f, T: MontStorage, P: Personality> zeroize::ZeroizeOnDrop for Residue<'f, T, P> {}
 
 /// Alias for the Nct variant of [`Residue`]. Equivalent to
 /// `Residue<'f, T, Nct>`. Symmetric with [`ResidueCt`].
@@ -129,14 +158,14 @@ pub type ResidueCt<'f, T> = Residue<'f, T, Ct>;
 // Shared impls (any P)
 // ---------------------------------------------------------------------------
 
-impl<T: Copy, P: Personality> Residue<'_, T, P> {
-    /// Returns the underlying Montgomery-form value.
+impl<T: Copy + MontStorage, P: Personality> Residue<'_, T, P> {
+    /// Returns a copy of the underlying Montgomery-form value.
     ///
     /// **Escape hatch.** Intended for downstream specialization layers
     /// (e.g. `Curve25519Field`) that implement fast paths reading the raw
     /// limbs. General consumers should not call this — use the methods on
     /// [`Field`] instead.
-    pub fn mont_value(self) -> T {
+    pub fn mont_value(&self) -> T {
         self.mont
     }
 }
@@ -189,7 +218,8 @@ where
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
         + num_traits::ops::overflowing::OverflowingAdd
-        + Parity,
+        + Parity
+        + MontStorage,
 {
     /// Construct a new `Field` over the given (odd, nonzero) `modulus`.
     ///
@@ -271,7 +301,8 @@ where
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
         + num_traits::ops::overflowing::OverflowingAdd
-        + Parity,
+        + Parity
+        + MontStorage,
 {
     /// Convert a raw value `< modulus` (or arbitrary value, which is then
     /// reduced) to Montgomery form. Returns a brand-tagged [`Residue`].
@@ -397,7 +428,7 @@ where
 
 impl<'f, T> Residue<'f, T, Ct>
 where
-    T: subtle::ConditionallySelectable,
+    T: subtle::ConditionallySelectable + MontStorage,
 {
     /// Conditionally swap two residues in constant time.
     ///
@@ -424,7 +455,8 @@ where
         + num_traits::WrappingAdd
         + num_traits::WrappingSub
         + num_traits::ops::overflowing::OverflowingAdd
-        + Parity,
+        + Parity
+        + MontStorage,
 {
     /// Convert a raw value to Montgomery form. Constant-time finalize.
     pub fn reduce(&self, raw: &T) -> Residue<'_, T, Ct>
@@ -869,6 +901,17 @@ mod tests {
         let raw = U128Ct::from(0xDEAD_BEEF_u64);
         let r = f.reduce(&raw);
         assert_eq!(f.into_raw(&r), raw);
+    }
+
+    #[cfg(feature = "zeroize")]
+    #[test]
+    fn residue_zeroize_wipes_mont_small() {
+        use zeroize::Zeroize;
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        let mut r = f.reduce(&u16ct(7));
+        assert_ne!(r.mont_value(), u16ct(0));
+        r.zeroize();
+        assert_eq!(r.mont_value(), u16ct(0));
     }
 
     #[test]

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -60,7 +60,7 @@ pub mod constrained;
 pub mod strict;
 
 #[cfg(feature = "wide-mul")]
-pub use field::{Field, FieldCt, FieldNct, Residue, ResidueCt, ResidueNct};
+pub use field::{Field, FieldCt, FieldNct, MontStorage, Residue, ResidueCt, ResidueNct};
 pub use parity::Parity;
 pub use wide_mul::WideMul;
 


### PR DESCRIPTION
Plugs the secret-derived stack residue left behind by Montgomery ladders. Adds a zeroize optional feature; with it enabled, Residue auto-wipes its Montgomery value on drop via Zeroize + ZeroizeOnDrop.

Residue no longer derives Copy — every implicit copy of a Ct residue produced a fresh stack location holding secret-derived bytes that nothing would ever wipe, the exact leak vector the feature is designed to plug. Nct residues also lose Copy for typestate symmetry; callers that previously relied on Copy pass by reference or .clone() instead.

## Summary by Sourcery

Introduce optional zeroization of Montgomery residues and tighten Residue’s type and trait bounds to avoid leaking secret-derived data.

New Features:
- Add an optional `zeroize` feature that zeroizes Residue’s Montgomery value via Zeroize and ZeroizeOnDrop on drop.
- Introduce the MontStorage marker trait to gate types usable as Montgomery storage, integrating with zeroize when enabled.

Enhancements:
- Remove Copy from Residue and adjust APIs to return references/copies as needed, reducing inadvertent duplication of secret-derived data.
- Extend Field and Residue bounds to require MontStorage where appropriate, ensuring consistent constraints across constant-time operations.

Build:
- Add the zeroize dependency and feature wiring in Cargo.toml and bump the crate version to 0.2.1.

Tests:
- Add a zeroize-enabled test verifying that Residue.zeroize wipes the underlying Montgomery value when the feature is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "zeroize" feature to securely wipe internal numeric representations when enabled.

* **Documentation**
  * Published docs now build with the zeroize feature enabled.

* **Breaking Changes**
  * Certain numeric residue types no longer implement Copy (still Clone).
  * An access method now returns a reference instead of consuming the value.

* **Chores**
  * Crate version bumped to 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->