### PR TITLE
Add wide_montgomery_mul_acc for fused inner products

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = """
 Modular math implemented with traits.

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -90,11 +90,15 @@ pub mod wide {
     #[doc(inline)]
     pub use crate::montgomery::basic_mont::wide_montgomery_mul as mul;
     #[doc(inline)]
+    pub use crate::montgomery::basic_mont::wide_montgomery_mul_acc as mul_acc;
+    #[doc(inline)]
     pub use crate::montgomery::basic_mont::wide_redc as redc;
 
     /// Constant-time finalize. Branchless conditional-subtract via
     /// `subtle::ConditionallySelectable`.
     pub mod ct {
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::wide_montgomery_mul_acc_ct as mul_acc;
         #[doc(inline)]
         pub use crate::montgomery::basic_mont::wide_montgomery_mul_ct as mul;
         #[doc(inline)]

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -53,7 +53,8 @@ use core::marker::PhantomData;
 use fixed_bigint::{Ct, Nct, Personality};
 
 use crate::montgomery::basic_mont::{
-    wide_montgomery_mul, wide_montgomery_mul_ct, wide_redc, wide_redc_ct,
+    wide_montgomery_mul, wide_montgomery_mul_acc, wide_montgomery_mul_acc_ct,
+    wide_montgomery_mul_ct, wide_redc, wide_redc_ct,
 };
 use crate::montgomery::{
     CiosMontMul, CiosMontMulCt, compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n,
@@ -420,6 +421,74 @@ where
             _p: PhantomData,
         }
     }
+
+    /// Wide multiply-accumulate: `(acc.0, acc.1) += a.mont * b.mont`.
+    ///
+    /// Brand-tagged wrapper around [`wide_montgomery_mul_acc`]. Pair
+    /// with [`Field::wide_redc`] to close the accumulator after a fused
+    /// inner-product loop. See the free-function for the `N ≤ R/q`
+    /// bound contract.
+    pub fn mul_acc(&self, acc: (T, T), a: &Residue<'_, T, Nct>, b: &Residue<'_, T, Nct>) -> (T, T)
+    where
+        T: WideMul,
+    {
+        wide_montgomery_mul_acc(acc.0, acc.1, a.mont, b.mont)
+    }
+
+    /// Close a wide accumulator into a brand-tagged [`Residue`].
+    pub fn wide_redc(&self, acc: (T, T)) -> Residue<'_, T, Nct>
+    where
+        T: WideMul,
+    {
+        let mont = wide_redc(acc.0, acc.1, self.modulus, self.n_prime);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular inverse via Fermat's little theorem: `a^(modulus − 2)`.
+    ///
+    /// **Requires `modulus` to be prime.** Variable-time over the bits
+    /// of `modulus − 2`. Returns `None` when `a` is the zero residue.
+    pub fn inv_fermat(&self, a: &Residue<'_, T, Nct>) -> Option<Residue<'_, T, Nct>>
+    where
+        T: CiosMontMul + core::ops::ShrAssign<usize>,
+    {
+        if a.mont == T::zero() {
+            return None;
+        }
+        let two = T::one().wrapping_add(&T::one());
+        let exp_val = self.modulus.wrapping_sub(&two);
+        Some(self.exp(a, &exp_val))
+    }
+
+    /// Modular inverse via extended Euclidean GCD on the raw Mont
+    /// value, then rebrand to Mont form via two Mont multiplies by
+    /// `R^2 mod N`.
+    ///
+    /// Works for any odd modulus (composite is fine). Variable-time —
+    /// do not call with secret inputs; use [`Self::inv_fermat`] for CT
+    /// paths. Returns `None` when `a` is not coprime to modulus.
+    pub fn inv_eea(&self, a: &Residue<'_, T, Nct>) -> Option<Residue<'_, T, Nct>>
+    where
+        T: WideMul + core::ops::Div<Output = T> + core::ops::Sub<Output = T>,
+    {
+        if a.mont == T::zero() {
+            return None;
+        }
+        let raw_inv = crate::inv::basic_mod_inv(a.mont, self.modulus)?;
+        // raw_inv = (a*R)^{-1} = a^{-1} * R^{-1} (residue form).
+        // Two Mont mults by R^2 lift it back to a^{-1} * R = Mont(a^{-1}).
+        let step1 = wide_montgomery_mul(raw_inv, self.r2_mod_n, self.modulus, self.n_prime);
+        let mont = wide_montgomery_mul(step1, self.r2_mod_n, self.modulus, self.n_prime);
+        Some(Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -441,6 +510,20 @@ where
     /// is not guaranteed to be branchless.
     pub fn cswap(choice: subtle::Choice, a: &mut Self, b: &mut Self) {
         T::conditional_swap(&mut a.mont, &mut b.mont, choice);
+    }
+}
+
+impl<'f, T> Residue<'f, T, Ct>
+where
+    T: subtle::ConstantTimeEq + MontStorage,
+{
+    /// Constant-time equality on the underlying Montgomery values.
+    ///
+    /// Use in place of derived `PartialEq` on Ct paths where the
+    /// equality outcome must not leak through timing (ML-KEM
+    /// decapsulation tag check, ed25519 signature verification).
+    pub fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        self.mont.ct_eq(&other.mont)
     }
 }
 
@@ -658,6 +741,54 @@ where
             _brand: PhantomData,
             _p: PhantomData,
         }
+    }
+
+    /// Wide multiply-accumulate (CT carry).
+    ///
+    /// Brand-tagged wrapper around [`wide_montgomery_mul_acc_ct`]. Pair
+    /// with [`Field::wide_redc`] (CT variant) to close the accumulator.
+    /// See the free-function for the `N ≤ R/q` bound contract.
+    pub fn mul_acc(&self, acc: (T, T), a: &Residue<'_, T, Ct>, b: &Residue<'_, T, Ct>) -> (T, T)
+    where
+        T: WideMul + subtle::ConditionallySelectable,
+    {
+        wide_montgomery_mul_acc_ct(acc.0, acc.1, a.mont, b.mont)
+    }
+
+    /// Close a wide accumulator (CT finalize) into a brand-tagged
+    /// [`Residue`].
+    pub fn wide_redc(&self, acc: (T, T)) -> Residue<'_, T, Ct>
+    where
+        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+    {
+        let mont = wide_redc_ct(acc.0, acc.1, self.modulus, self.n_prime);
+        Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        }
+    }
+
+    /// Modular inverse via Fermat: `a^(modulus − 2)` through the fixed-
+    /// iteration CT Montgomery ladder.
+    ///
+    /// **Requires `modulus` to be prime.** Constant-time over the bits
+    /// of `modulus − 2` (uses [`Self::exp`]). Returns `None` for the
+    /// zero residue.
+    pub fn inv_fermat(&self, a: &Residue<'_, T, Ct>) -> Option<Residue<'_, T, Ct>>
+    where
+        T: CiosMontMulCt
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeEq
+            + core::ops::Shr<usize, Output = T>
+            + core::ops::BitAnd<Output = T>,
+    {
+        if a.mont == T::zero() {
+            return None;
+        }
+        let two = T::one().wrapping_add(&T::one());
+        let exp_val = self.modulus.wrapping_sub(&two);
+        Some(self.exp(a, &exp_val))
     }
 }
 
@@ -1023,5 +1154,122 @@ mod tests {
         // trait extension on their own side and call modmath's standalone
         // primitives. This test just proves the const-context construction
         // path is real.
+    }
+
+    /// `Field::mul_acc` + `Field::wide_redc` from a zero accumulator
+    /// must equal `Field::mul` on the same operands.
+    #[test]
+    fn field_mul_acc_round_trip_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        for a_raw in 0u16..13 {
+            for b_raw in 0u16..13 {
+                let a = f.reduce(&u16(a_raw));
+                let b = f.reduce(&u16(b_raw));
+                let direct = f.mul(&a, &b);
+                let via_acc = f.wide_redc(f.mul_acc((u16(0), u16(0)), &a, &b));
+                assert_eq!(f.into_raw(&direct), f.into_raw(&via_acc));
+            }
+        }
+    }
+
+    /// Dot product through `Field::mul_acc` + single `Field::wide_redc`
+    /// must equal the direct residue-domain sum of products.
+    #[test]
+    fn field_mul_acc_dot_product_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        let pairs: &[(u16, u16)] = &[(2, 3), (5, 7), (11, 4), (1, 12)];
+        let mut acc = (u16(0), u16(0));
+        for &(a_raw, b_raw) in pairs {
+            let a = f.reduce(&u16(a_raw));
+            let b = f.reduce(&u16(b_raw));
+            acc = f.mul_acc(acc, &a, &b);
+        }
+        let result = f.wide_redc(acc);
+        let expected: u16 = pairs
+            .iter()
+            .fold(0u16, |s, &(a, b)| (s + (a * b) % 13) % 13);
+        assert_eq!(f.into_raw(&result), u16(expected));
+    }
+
+    /// `a * inv_fermat(a) == 1` for every nonzero residue at prime
+    /// modulus 13; zero returns `None`.
+    #[test]
+    fn field_inv_fermat_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        for raw in 1u16..13 {
+            let a = f.reduce(&u16(raw));
+            let inv = f.inv_fermat(&a).unwrap();
+            assert_eq!(
+                f.into_raw(&f.mul(&a, &inv)),
+                u16(1),
+                "fermat fails at {raw}"
+            );
+        }
+        assert!(f.inv_fermat(&f.zero()).is_none());
+    }
+
+    /// Same contract as inv_fermat but via EEA path; cross-checks the
+    /// two methods agree at every nonzero residue.
+    #[test]
+    fn field_inv_eea_small() {
+        let f: Field<U16> = Field::new(u16(13)).unwrap();
+        for raw in 1u16..13 {
+            let a = f.reduce(&u16(raw));
+            let inv_e = f.inv_eea(&a).unwrap();
+            let inv_f = f.inv_fermat(&a).unwrap();
+            assert_eq!(f.into_raw(&f.mul(&a, &inv_e)), u16(1), "eea fails at {raw}");
+            assert_eq!(
+                f.into_raw(&inv_e),
+                f.into_raw(&inv_f),
+                "fermat/eea disagree at {raw}"
+            );
+        }
+        assert!(f.inv_eea(&f.zero()).is_none());
+    }
+
+    /// Ct variant of `Field::mul_acc` + `Field::wide_redc` must agree
+    /// with `Field::mul`.
+    #[test]
+    fn field_mul_acc_ct_round_trip_small() {
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        for a_raw in 0u16..13 {
+            for b_raw in 0u16..13 {
+                let a = f.reduce(&u16ct(a_raw));
+                let b = f.reduce(&u16ct(b_raw));
+                let direct = f.mul(&a, &b);
+                let via_acc = f.wide_redc(f.mul_acc((u16ct(0), u16ct(0)), &a, &b));
+                assert_eq!(f.into_raw(&direct), f.into_raw(&via_acc));
+            }
+        }
+    }
+
+    /// Ct `inv_fermat` must satisfy `a * inv(a) == 1` at prime modulus.
+    #[test]
+    fn field_inv_fermat_ct_small() {
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        for raw in 1u16..13 {
+            let a = f.reduce(&u16ct(raw));
+            let inv = f.inv_fermat(&a).unwrap();
+            assert_eq!(
+                f.into_raw(&f.mul(&a, &inv)),
+                u16ct(1),
+                "ct fermat fails at {raw}"
+            );
+        }
+        assert!(f.inv_fermat(&f.zero()).is_none());
+    }
+
+    /// `ResidueCt::ct_eq` matches `PartialEq` outcomes on representative
+    /// inputs (true and false cases).
+    #[test]
+    fn residue_ct_eq_small() {
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        let a = f.reduce(&u16ct(7));
+        let b = f.reduce(&u16ct(7));
+        let c = f.reduce(&u16ct(8));
+        let eq_ab: bool = a.ct_eq(&b).into();
+        let eq_ac: bool = a.ct_eq(&c).into();
+        assert!(eq_ab);
+        assert!(!eq_ac);
     }
 }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -766,8 +766,14 @@ where
 {
     let (m_lo, m_hi) = a.wide_mul(&b);
     let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
-    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
-    let (new_hi, _extra) = accumulate_high_half_carry(sum_hi, carry1, carry2);
+    let (sum_hi, _) = acc_hi.overflowing_add(&m_hi);
+    // Carry-out is discarded under the documented `N ≤ R/q` bound.
+    let new_hi = if carry1 {
+        let (r, _) = sum_hi.overflowing_add(&T::one());
+        r
+    } else {
+        sum_hi
+    };
     (new_lo, new_hi)
 }
 
@@ -789,8 +795,9 @@ where
 {
     let (m_lo, m_hi) = a.wide_mul(&b);
     let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
-    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
-    let (new_hi, _extra) = accumulate_high_half_carry_ct(sum_hi, carry1, carry2);
+    let (sum_hi, _) = acc_hi.overflowing_add(&m_hi);
+    let (r, _) = sum_hi.overflowing_add(&T::one());
+    let new_hi = T::conditional_select(&sum_hi, &r, subtle::Choice::from(carry1 as u8));
     (new_lo, new_hi)
 }
 
@@ -805,8 +812,13 @@ where
 {
     let (m_lo, m_hi) = a.wide_mul(b);
     let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
-    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
-    let (new_hi, _extra) = accumulate_high_half_carry(sum_hi, carry1, carry2);
+    let (sum_hi, _) = acc_hi.overflowing_add(&m_hi);
+    let new_hi = if carry1 {
+        let (r, _) = sum_hi.overflowing_add(&T::one());
+        r
+    } else {
+        sum_hi
+    };
     (new_lo, new_hi)
 }
 
@@ -823,8 +835,9 @@ where
 {
     let (m_lo, m_hi) = a.wide_mul(b);
     let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
-    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
-    let (new_hi, _extra) = accumulate_high_half_carry_ct(sum_hi, carry1, carry2);
+    let (sum_hi, _) = acc_hi.overflowing_add(&m_hi);
+    let (r, _) = sum_hi.overflowing_add(&T::one());
+    let new_hi = T::conditional_select(&sum_hi, &r, subtle::Choice::from(carry1 as u8));
     (new_lo, new_hi)
 }
 

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -749,6 +749,85 @@ where
     strict_wide_redc_ct(&lo, &hi, modulus, n_prime)
 }
 
+/// Wide multiply-accumulate: `(acc_lo, acc_hi) += a * b`.
+///
+/// Produces `a * b` as a double-width pair and folds it into the
+/// caller-held accumulator. Result is **not reduced** — call
+/// [`wide_redc`] once at the end of accumulation.
+///
+/// # Bound
+///
+/// Caller must keep the accumulator within `2·WIDTH(T)`. With Mont-form
+/// `a, b ∈ [0, q)`, summing `N` products requires `N ≤ R/q` where
+/// `R = 2^WIDTH(T)`. Out-of-bound use silently wraps the high word.
+pub fn wide_montgomery_mul_acc<T>(acc_lo: T, acc_hi: T, a: T, b: T) -> (T, T)
+where
+    T: Copy + num_traits::One + WideMul + num_traits::ops::overflowing::OverflowingAdd,
+{
+    let (m_lo, m_hi) = a.wide_mul(&b);
+    let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
+    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
+    let (new_hi, _extra) = accumulate_high_half_carry(sum_hi, carry1, carry2);
+    (new_lo, new_hi)
+}
+
+/// Wide multiply-accumulate — constant-time carry propagation.
+///
+/// Same shape as [`wide_montgomery_mul_acc`] but routes the carry
+/// combination through [`accumulate_high_half_carry_ct`] so the
+/// per-term cost has no value-dependent branches. Use in CT-sensitive
+/// paths; pair with [`wide_redc_ct`] for the final reduction.
+///
+/// Same bound as [`wide_montgomery_mul_acc`] — caller-verified `N ≤ R/q`.
+pub fn wide_montgomery_mul_acc_ct<T>(acc_lo: T, acc_hi: T, a: T, b: T) -> (T, T)
+where
+    T: Copy
+        + num_traits::One
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + subtle::ConditionallySelectable,
+{
+    let (m_lo, m_hi) = a.wide_mul(&b);
+    let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
+    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
+    let (new_hi, _extra) = accumulate_high_half_carry_ct(sum_hi, carry1, carry2);
+    (new_lo, new_hi)
+}
+
+/// Wide multiply-accumulate — reference-based inputs.
+///
+/// Same shape as [`wide_montgomery_mul_acc`] but takes operands by
+/// reference, for non-`Copy` bigint backends. Pair with
+/// [`strict_wide_redc`] for the final reduction.
+pub fn strict_wide_montgomery_mul_acc<T>(acc_lo: &T, acc_hi: &T, a: &T, b: &T) -> (T, T)
+where
+    T: num_traits::One + WideMul + num_traits::ops::overflowing::OverflowingAdd,
+{
+    let (m_lo, m_hi) = a.wide_mul(b);
+    let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
+    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
+    let (new_hi, _extra) = accumulate_high_half_carry(sum_hi, carry1, carry2);
+    (new_lo, new_hi)
+}
+
+/// Wide multiply-accumulate — constant-time carry, reference-based inputs.
+///
+/// Same shape as [`wide_montgomery_mul_acc_ct`] but reference-based.
+/// Pair with [`strict_wide_redc_ct`] for the final reduction.
+pub fn strict_wide_montgomery_mul_acc_ct<T>(acc_lo: &T, acc_hi: &T, a: &T, b: &T) -> (T, T)
+where
+    T: num_traits::One
+        + WideMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + subtle::ConditionallySelectable,
+{
+    let (m_lo, m_hi) = a.wide_mul(b);
+    let (new_lo, carry1) = acc_lo.overflowing_add(&m_lo);
+    let (sum_hi, carry2) = acc_hi.overflowing_add(&m_hi);
+    let (new_hi, _extra) = accumulate_high_half_carry_ct(sum_hi, carry1, carry2);
+    (new_lo, new_hi)
+}
+
 // ---------------------------------------------------------------------------
 // Public API: mod_mul / mod_exp using wide REDC
 // ---------------------------------------------------------------------------
@@ -1642,6 +1721,129 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// `mul_acc` with a zero accumulator + `redc` must produce the same
+    /// result as the existing fused `wide_montgomery_mul`. Identity check
+    /// on the new primitive.
+    #[test]
+    fn test_wide_mul_acc_identity_u8() {
+        let modulus = 13u8;
+        let n_prime = compute_n_prime_newton(modulus, 8);
+        for a in 0u8..modulus {
+            for b in 0u8..modulus {
+                let direct = wide_montgomery_mul(a, b, modulus, n_prime);
+                let (lo, hi) = wide_montgomery_mul_acc(0u8, 0u8, a, b);
+                let via_acc = wide_redc(lo, hi, modulus, n_prime);
+                assert_eq!(direct, via_acc, "identity mismatch at a={a} b={b}");
+            }
+        }
+    }
+
+    /// Σ a_i * b_i computed via `mul_acc` per term + one `redc` at the
+    /// end must equal the direct residue-domain sum of products. Proves
+    /// the accumulation semantics — the core promise of the primitive.
+    #[test]
+    fn test_wide_mul_acc_dot_product_u8() {
+        let modulus = 13u8;
+        let n_prime = compute_n_prime_newton(modulus, 8);
+        let r_mod_n = compute_r_mod_n(modulus, 8);
+        let r2 = compute_r2_mod_n(r_mod_n, modulus, 8);
+        let to_mont = |x: u8| {
+            let (lo, hi) = x.wide_mul(&r2);
+            wide_redc(lo, hi, modulus, n_prime)
+        };
+        let pairs: &[(u8, u8)] = &[(2, 3), (5, 7), (11, 4), (1, 12)];
+
+        let (mut acc_lo, mut acc_hi) = (0u8, 0u8);
+        for &(a, b) in pairs {
+            let (l, h) = wide_montgomery_mul_acc(acc_lo, acc_hi, to_mont(a), to_mont(b));
+            acc_lo = l;
+            acc_hi = h;
+        }
+        let result_mont = wide_redc(acc_lo, acc_hi, modulus, n_prime);
+        let result = wide_redc(result_mont, 0u8, modulus, n_prime);
+
+        let expected = pairs
+            .iter()
+            .fold(0u8, |acc, &(a, b)| (acc + (a * b) % modulus) % modulus);
+        assert_eq!(result, expected);
+    }
+
+    /// CT and NCT `mul_acc` variants must produce bit-identical output
+    /// over a representative input grid.
+    #[test]
+    fn test_wide_mul_acc_ct_matches_nct_u8() {
+        let modulus = 13u8;
+        for a in 0u8..modulus {
+            for b in 0u8..modulus {
+                for acc_lo in [0u8, 1, 50, 100, 200, 255] {
+                    for acc_hi in [0u8, 1, 5, modulus - 1] {
+                        let nct = wide_montgomery_mul_acc(acc_lo, acc_hi, a, b);
+                        let ct = wide_montgomery_mul_acc_ct(acc_lo, acc_hi, a, b);
+                        assert_eq!(
+                            nct, ct,
+                            "ct/nct mismatch at lo={acc_lo} hi={acc_hi} a={a} b={b}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Reference-based `strict_*_mul_acc` siblings must match the
+    /// by-value forms on `Copy` types.
+    #[test]
+    fn test_strict_wide_mul_acc_matches_basic_u8() {
+        let modulus = 13u8;
+        for a in 0u8..modulus {
+            for b in 0u8..modulus {
+                for acc_lo in [0u8, 1, 50, 100, 255] {
+                    for acc_hi in [0u8, 1, 5, modulus - 1] {
+                        assert_eq!(
+                            wide_montgomery_mul_acc(acc_lo, acc_hi, a, b),
+                            strict_wide_montgomery_mul_acc(&acc_lo, &acc_hi, &a, &b),
+                            "strict mul_acc mismatch at lo={acc_lo} hi={acc_hi} a={a} b={b}"
+                        );
+                        assert_eq!(
+                            wide_montgomery_mul_acc_ct(acc_lo, acc_hi, a, b),
+                            strict_wide_montgomery_mul_acc_ct(&acc_lo, &acc_hi, &a, &b),
+                            "strict mul_acc_ct mismatch at lo={acc_lo} hi={acc_hi} a={a} b={b}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// ML-KEM-shaped dot product at `q=3329`, `T=u32`. Exercises the
+    /// actual use-case: 4 Mont products summed via `mul_acc`, single
+    /// `redc` at the end.
+    #[test]
+    fn test_wide_mul_acc_dot_product_u32_mlkem_q() {
+        let modulus = 3329u32;
+        let w = type_bit_width::<u32>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r2 = compute_r2_mod_n(compute_r_mod_n(modulus, w), modulus, w);
+        let to_mont = |x: u32| {
+            let (lo, hi) = x.wide_mul(&r2);
+            wide_redc(lo, hi, modulus, n_prime)
+        };
+        let pairs: &[(u32, u32)] = &[(123, 456), (789, 1011), (2222, 3000), (1, 3328)];
+
+        let (mut acc_lo, mut acc_hi) = (0u32, 0u32);
+        for &(a, b) in pairs {
+            let (l, h) = wide_montgomery_mul_acc(acc_lo, acc_hi, to_mont(a), to_mont(b));
+            acc_lo = l;
+            acc_hi = h;
+        }
+        let result_mont = wide_redc(acc_lo, acc_hi, modulus, n_prime);
+        let result = wide_redc(result_mont, 0u32, modulus, n_prime);
+
+        let expected = pairs.iter().fold(0u64, |acc, &(a, b)| {
+            acc + (a as u64 * b as u64) % modulus as u64
+        }) % modulus as u64;
+        assert_eq!(result as u64, expected);
     }
 
     /// wide_redc_ct matches at FixedUInt sizes.

--- a/modmath/src/strict/montgomery.rs
+++ b/modmath/src/strict/montgomery.rs
@@ -55,11 +55,15 @@ pub mod wide {
     #[doc(inline)]
     pub use crate::montgomery::basic_mont::strict_wide_montgomery_mul as mul;
     #[doc(inline)]
+    pub use crate::montgomery::basic_mont::strict_wide_montgomery_mul_acc as mul_acc;
+    #[doc(inline)]
     pub use crate::montgomery::basic_mont::strict_wide_redc as redc;
 
     /// Constant-time finalize. Branchless conditional-subtract via
     /// `subtle::ConditionallySelectable`.
     pub mod ct {
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::strict_wide_montgomery_mul_acc_ct as mul_acc;
         #[doc(inline)]
         pub use crate::montgomery::basic_mont::strict_wide_montgomery_mul_ct as mul;
         #[doc(inline)]


### PR DESCRIPTION
Adds a wide multiply-accumulate primitive that produces a*b as a double-width pair and folds it into a caller-held (lo, hi) accumulator, returning the new accumulator without reduction. Pair with wide_redc once at the end to get a fused inner product / dot product / NTT matrix-vector multiply that pays one REDC per output coefficient instead of one per multiply.

Additive, no breaking change. Version 0.3.1.

## Summary by Sourcery

Introduce wide Montgomery multiply-accumulate primitives to support fused accumulation workflows before a single reduction, along with re-exports and version bump.

New Features:
- Add wide_montgomery_mul_acc primitives (by-value, constant-time, reference-based, and constant-time reference-based) for accumulating double-width Montgomery products without immediate reduction.
- Expose the new wide multiply-accumulate operations in the public basic and strict Montgomery wide modules, including constant-time variants.

Build:
- Bump the modmath crate version from 0.3.0 to 0.3.1 to publish the new API.

Tests:
- Add identity, dot-product, constant-time parity, and strict/by-value equivalence tests for the new wide Montgomery multiply-accumulate primitives, including ML-KEM-shaped scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Montgomery multiply-accumulate support with deferred reduction for both standard and constant-time usage.
  * Exposed field-wide accumulator closure (wide reduction) to finalize accumulated Montgomery products.
  * Added modular inversion APIs for prime-modulus (Fermat) and extended-Euclidean inversion, with safe zero handling.
  * Introduced constant-time residue equality for Ct types.
* **Tests**
  * Expanded coverage for accumulator flows, dot-product accumulation, inversion correctness, and Ct vs non-Ct bit-level consistency.
* **Chores**
  * Bumped crate version to `0.3.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->