### PR TITLE
Experiment/safegcd sketch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage data
         working-directory: modmath
         run: |
-          cargo llvm-cov --features wide-mul --lcov --output-path lcov.info
+          cargo llvm-cov --lcov --output-path lcov.info
 
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.85", stable, nightly]
+        rust: ["1.86", stable, nightly]
     continue-on-error: ${{ matrix.rust == 'nightly' }}
 
     steps:
@@ -37,19 +37,12 @@ jobs:
       if: matrix.rust == 'stable'
       working-directory: modmath
       run: cargo clippy -- -D warnings
-    - name: Run clippy (wide-mul)
-      if: matrix.rust == 'stable'
-      working-directory: modmath
-      run: cargo clippy --features wide-mul -- -D warnings
     - name: Build
       working-directory: modmath
       run: cargo build
     - name: Run tests
       working-directory: modmath
       run: cargo test --verbose
-    - name: Run tests (wide-mul)
-      working-directory: modmath
-      run: cargo test --verbose --features wide-mul
     - name: Run tests with nightly feature
       if: matrix.rust == 'nightly'
       working-directory: modmath

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ members = ["modmath", "modmath-cios"]
 # Path-pin sibling crates during the coordinated experimental window.
 # Revert before publishing.
 [patch.crates-io]
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.1" }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.4" }
 modmath-cios = { path = "modmath-cios" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ members = ["modmath", "modmath-cios"]
 # Path-pin sibling crates during the coordinated experimental window.
 # Revert before publishing.
 [patch.crates-io]
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.4" }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.6" }
 modmath-cios = { path = "modmath-cios" }

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -26,6 +26,11 @@ const-num-traits = { git = "https://github.com/kaidokert/num-traits", tag = "v0.
 # define a second, distinct `CiosRowOps` that fixed-bigint's impl can't
 # satisfy from the test binary).
 modmath-cios = { version = "0.1", path = "../modmath-cios" }
+# Optional regular dep — gates the `NonCt` impl for `FixedUInt<W, N,
+# Nct>`. Default-on because most modmath consumers do use FixedUInt;
+# turning it off keeps modmath fixed-bigint-free for consumers that
+# only operate on primitives.
+fixed-bigint = { version = "0.4", default-features = false, features = ["cios"], optional = true }
 
 [dev-dependencies]
 fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] }
@@ -44,10 +49,14 @@ fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] 
 paste = "1"
 
 [features]
-default = []
+default = ["fixed-bigint"]
 constrained = []
 basic = []
 strict = []
+# Gates the NonCt impl for fixed_bigint::FixedUInt<W, N, Nct>. On by
+# default; consumers operating only on primitives can disable it to
+# drop the fixed-bigint dep.
+fixed-bigint = ["dep:fixed-bigint"]
 nightly = ["dep:c0nst", "c0nst/nightly"]
 zeroize = ["dep:zeroize"]
 

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,11 +16,7 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-# Direct dep on the const-friendly num-traits fork, pinned to the
-# v0.1.0-alpha.0 prerelease tag. Package name now matches the dep alias
-# (the fork was renamed `num-traits` → `const-num-traits` directly at
-# the source), so no `package =` rename is needed any more.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits", tag = "v0.1.0-alpha.0", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.1.0", default-features = false, features = ["ct"] }
 # CiosRowOps lives in a leaf crate so the trait identity stays stable
 # across compile units (the `--test` rebuild of modmath would otherwise
 # define a second, distinct `CiosRowOps` that fixed-bigint's impl can't
@@ -57,7 +53,7 @@ strict = []
 # default; consumers operating only on primitives can disable it to
 # drop the fixed-bigint dep.
 fixed-bigint = ["dep:fixed-bigint"]
-nightly = ["dep:c0nst", "c0nst/nightly"]
+nightly = ["dep:c0nst", "c0nst/nightly", "const-num-traits/nightly", "fixed-bigint?/nightly"]
 zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -36,7 +36,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Rem<Output = T>,
+        + core::ops::Rem<Output = T>
+        + crate::NonCt,
 {
     basic_mod_add_pr(a % m, b % m, m)
 }
@@ -57,7 +58,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     basic_mod_add_pr(a.rem_nonzero(m), b.rem_nonzero(m), m_raw)
@@ -72,7 +74,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let sum = a.wrapping_add(b);
     if sum >= m || sum < a {
@@ -92,7 +95,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     let a_mod = &a % m;
@@ -113,7 +117,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = (*b).rem_nonzero(m);
@@ -130,7 +135,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let sum = a.wrapping_add(*b);
     if &sum >= m || sum < a {
@@ -150,7 +156,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -173,7 +180,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = (*b).rem_nonzero(m);
@@ -190,7 +198,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let (sum, overflow) = a.overflowing_add(*b);
     if &sum >= m || overflow {

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -63,15 +63,27 @@ pub mod pre_reduced {
 /// `subtle::ConditionallySelectable`, removing the operand-magnitude
 /// side-channel on the final reduction step.
 ///
-/// Only `mod_exp` has both NCT and CT siblings here today; there is no
-/// `mod_mul_ct` because the underlying source crate hasn't published
-/// one (the CIOS path is the canonical CT-mul entry point — see
-/// [`modmath::montgomery::cios::cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)).
+/// **Only the `pre_reduced::mod_exp` entry is exposed.** The
+/// internal-reduce wrapper (`basic_montgomery_mod_exp_ct`) was
+/// removed in the CT_GET_WELL_PLAN Tier 1.3 cut — its docstring
+/// claimed CT over base, but the `core::ops::Rem` it used for the
+/// initial reduction is hardware-variable on common embedded targets.
+/// Callers needing CT-over-base should:
+///
+/// - reduce the base externally via a CT primitive (e.g.
+///   `Field::reduce` on the `Ct` personality, which composes the CT
+///   wide-REDC reduction), then dispatch to
+///   [`pre_reduced::mod_exp`](self::ct::pre_reduced::mod_exp); or
+/// - use the high-level [`Field<T, Ct>::exp`](crate::field::Field::exp)
+///   surface, which handles reduction + exponentiation as a single
+///   end-to-end CT pipeline.
+///
+/// There is no `mod_mul_ct` here because the underlying source crate
+/// hasn't published one (the CIOS path is the canonical CT-mul entry
+/// point — see
+/// [`cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)).
 pub mod ct {
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_ct as mod_exp;
-
-    /// Pre-reduced CT variants.
+    /// Pre-reduced CT variants. Precondition: `base < modulus`.
     pub mod pre_reduced {
         #[doc(inline)]
         pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_ct as mod_exp;

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -63,11 +63,10 @@ pub mod pre_reduced {
 /// `subtle::ConditionallySelectable`, removing the operand-magnitude
 /// side-channel on the final reduction step.
 ///
-/// **Only the `pre_reduced::mod_exp` entry is exposed.** The
-/// internal-reduce wrapper (`basic_montgomery_mod_exp_ct`) was
-/// removed in the CT_GET_WELL_PLAN Tier 1.3 cut — its docstring
-/// claimed CT over base, but the `core::ops::Rem` it used for the
-/// initial reduction is hardware-variable on common embedded targets.
+/// **Only the `pre_reduced::mod_exp` entry is exposed.** CT-over-base
+/// requires a CT reduction primitive; `core::ops::Rem` is
+/// hardware-variable on common embedded targets, so any wrapper that
+/// internally reduced via `Rem` would leak the base magnitude.
 /// Callers needing CT-over-base should:
 ///
 /// - reduce the base externally via a CT primitive (e.g.

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -60,7 +60,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
-        + Copy,
+        + Copy
+        + crate::NonCt,
 {
     if modulus == T::one() {
         return T::zero();
@@ -86,7 +87,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
-        + Copy,
+        + Copy
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(modulus);
     if m_raw == T::one() {
@@ -114,7 +116,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
-        + Copy,
+        + Copy
+        + crate::NonCt,
 {
     // x mod 1 == 0 for every x, including 1. The square-and-multiply loop
     // below starts with `result = T::one()` and would return 1 in that case.
@@ -152,7 +155,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::DivAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>,
@@ -180,7 +184,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(modulus);
     if m_raw == T::one() {
@@ -204,7 +209,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     // See `basic_mod_exp_pr` for the modulus==1 rationale.
     if modulus == &T::one() {
@@ -243,7 +249,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::DivAssign<&'a T>
         + core::ops::ShrAssign<usize>
@@ -271,7 +278,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::ShrAssign<usize>,
 {
     let m_raw = T::nonzero_get(modulus);
@@ -295,7 +303,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::ShrAssign<usize>,
 {
     // See `basic_mod_exp_pr` for the modulus==1 rationale.

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -999,8 +999,6 @@ where
             _brand: PhantomData,
             _p: PhantomData,
         };
-        // Combined predicate: inverse exists AND modulus has headroom.
-        // If either fails, the CtOption is None-masked.
         subtle::CtOption::new(residue, inv_exists & modulus_has_headroom)
     }
 }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -366,6 +366,7 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + Parity
+        + crate::NonCt
         + MontStorage,
 {
     /// Convert a raw value `< modulus` (or arbitrary value, which is then

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -879,6 +879,7 @@ where
             + WideMul
             + subtle::ConditionallySelectable
             + subtle::ConstantTimeLess
+            + const_num_traits::CtIsZero
             + modmath_cios::CiosRowOps
             + core::ops::Shr<usize, Output = T>
             + core::ops::Shl<usize, Output = T>
@@ -886,6 +887,7 @@ where
         <T as modmath_cios::CiosRowOps>::Word: Copy
             + subtle::ConditionallySelectable
             + subtle::ConstantTimeEq
+            + const_num_traits::CtParity
             + const_num_traits::One
             + const_num_traits::Zero
             + core::ops::BitAnd<Output = <T as modmath_cios::CiosRowOps>::Word>

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -842,22 +842,29 @@ where
     /// iteration CT Montgomery ladder.
     ///
     /// **Requires `modulus` to be prime.** Constant-time over the bits
-    /// of `modulus − 2` (uses [`Self::exp`]). Returns `None` for the
-    /// zero residue.
-    pub fn inv_fermat(&self, a: &Residue<'_, T, Ct>) -> Option<Residue<'_, T, Ct>>
+    /// of `modulus − 2` (uses [`Self::exp`]) and over the zero check on
+    /// `a`. Returns `CtOption::None`-masked for the zero residue.
+    ///
+    /// Audit note: the prior `Option`-returning version had an
+    /// `if a.mont == T::zero() { return None }` early branch — variable
+    /// time on the residue's zero-ness, which silently broke the Ct
+    /// contract. This version uses `CtIsZero` for the masked check and
+    /// `CtOption` for the masked return; the exponentiation runs
+    /// unconditionally and the result is masked.
+    pub fn inv_fermat(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>
     where
         T: CiosMontMulCt
+            + const_num_traits::CtIsZero
             + subtle::ConditionallySelectable
             + subtle::ConstantTimeEq
             + core::ops::Shr<usize, Output = T>
             + core::ops::BitAnd<Output = T>,
     {
-        if a.mont == T::zero() {
-            return None;
-        }
+        let a_is_nonzero = !a.mont.ct_is_zero();
         let two = T::one().wrapping_add(T::one());
         let exp_val = self.modulus.wrapping_sub(two);
-        Some(self.exp(a, &exp_val))
+        let result = self.exp(a, &exp_val);
+        subtle::CtOption::new(result, a_is_nonzero)
     }
 
     /// Constant-time modular inverse via Bernstein-Yang divsteps.
@@ -1539,14 +1546,14 @@ mod tests {
         let f = FieldCt::new(u16ct(13)).unwrap();
         for raw in 1u16..13 {
             let a = f.reduce(&u16ct(raw));
-            let inv = f.inv_fermat(&a).unwrap();
+            let inv = f.inv_fermat(&a).into_option().unwrap();
             assert_eq!(
                 f.into_raw(&f.mul(&a, &inv)),
                 u16ct(1),
                 "ct fermat fails at {raw}"
             );
         }
-        assert!(f.inv_fermat(&f.zero()).is_none());
+        assert!(f.inv_fermat(&f.zero()).into_option().is_none());
     }
 
     /// `ResidueCt::ct_eq` matches `PartialEq` outcomes on representative

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -881,9 +881,19 @@ where
     /// Modular inverse via Fermat: `a^(modulus − 2)` through the fixed-
     /// iteration CT Montgomery ladder.
     ///
-    /// **Requires `modulus` to be prime.** Constant-time over the bits
-    /// of `modulus − 2` (uses [`Self::exp`]) and over the zero check on
-    /// `a`. Returns `CtOption::None`-masked for the zero residue.
+    /// **Requires `modulus` to be prime.** Constant-time over `a`'s
+    /// bits and zero-ness via the fixed `T::BITS`-iteration Montgomery
+    /// ladder in [`Self::exp`]. The loop count depends only on the
+    /// carrier type's bit width, not on `modulus - 2`'s significant
+    /// bit count or `a`'s value. Returns `CtOption::None`-masked for
+    /// the zero residue.
+    ///
+    /// Cost: one full ladder over every bit of `T` (e.g. 256
+    /// square-and-multiply iterations for `FixedUInt<u32, 8>` over a
+    /// Curve25519 scalar field), regardless of whether `modulus - 2`
+    /// occupies the full carrier width. For composite moduli (RSA
+    /// `n = p·q`) where Fermat doesn't apply, use
+    /// [`Self::inv_safegcd_ct`] instead.
     ///
     /// Audit note: the prior `Option`-returning version had an
     /// `if a.mont == T::zero() { return None }` early branch — variable
@@ -915,9 +925,27 @@ where
     /// (no inverse exists). Failure timing is independent of input
     /// magnitudes.
     ///
+    /// ## Carrier headroom precondition
+    ///
+    /// Also returns `CtOption::None` masked when the carrier `T`
+    /// lacks **one bit of headroom over `modulus`** (the safegcd
+    /// `2·modulus ≤ T::MAX` precondition). The check is folded into
+    /// the returned mask at no value-dependent cost (one MSB
+    /// extraction on the cached modulus per call). When the modulus
+    /// occupies the full carrier width (MSB set in `T`), this method
+    /// returns `None` regardless of value coprimality — the carrier
+    /// is too tight for the algorithm's intermediate sums.
+    ///
+    /// **Pick a `T` at least one bit wider than the modulus:**
+    /// `FixedUInt<u32, 65>` for a 2048-bit RSA modulus,
+    /// `FixedUInt<u32, 129>` for a 4096-bit one. Krabipqc / PQC moduli
+    /// (3329, 8380417, etc.) leave plenty of headroom on any
+    /// reasonable carrier and are unaffected.
+    ///
     /// Used by RSA private-key blinding, where the modulus is the
     /// composite `n = p·q` and Fermat's little theorem doesn't apply.
-    /// See [`crate::inv::safegcd`] for the algorithm and preconditions.
+    /// See [`crate::inv::safegcd`] for the algorithm and full
+    /// precondition list.
     ///
     /// [`inv_fermat`]: Self::inv_fermat
     pub fn inv_safegcd_ct(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>
@@ -934,6 +962,7 @@ where
         <T as modmath_cios::CiosRowOps>::Word: Copy
             + subtle::ConditionallySelectable
             + subtle::ConstantTimeEq
+            + const_num_traits::CtIsZero
             + const_num_traits::CtParity
             + const_num_traits::One
             + const_num_traits::Zero

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -259,9 +259,9 @@ where
     ///
     /// Same precompute as [`new_odd`] (Newton's iteration for `N'`,
     /// repeated modular doublings for `R mod N` and `R² mod N`), but
-    /// the doubling-and-reduction loop uses
-    /// [`mod_double_ct`](crate::montgomery::compute_r_mod_n_ct)
-    /// internally — no value-dependent branches on the modulus.
+    /// the doubling-and-reduction loop in
+    /// [`compute_r_mod_n_ct`](crate::montgomery::compute_r_mod_n_ct)
+    /// avoids value-dependent branches on the modulus.
     ///
     /// Use this when `modulus` is secret (e.g. RSA-CRT private primes
     /// `p`, `q`). For public moduli (ed25519 / Curve25519 / krabipqc),
@@ -761,9 +761,7 @@ where
             // Always compute the conditional product.
             let multiplied =
                 CiosMontMulCt::cios_mont_mul_ct(&result, &base.mont, &self.modulus, &self.n_prime);
-            // Select based on bit i of exp. Delegates to CtIsZero
-            // rather than ct_eq(&one); semantics identical for a value
-            // already known to be 0 or 1.
+            // Select based on bit i of exp.
             let bit_t = (*exp >> i) & one;
             let choice = !bit_t.ct_is_zero();
             result = T::conditional_select(&result, &multiplied, choice);
@@ -895,13 +893,6 @@ where
     /// occupies the full carrier width. For composite moduli (RSA
     /// `n = p·q`) where Fermat doesn't apply, use
     /// [`Self::inv_safegcd_ct`] instead.
-    ///
-    /// Audit note: the prior `Option`-returning version had an
-    /// `if a.mont == T::zero() { return None }` early branch — variable
-    /// time on the residue's zero-ness, which silently broke the Ct
-    /// contract. This version uses `CtIsZero` for the masked check and
-    /// `CtOption` for the masked return; the exponentiation runs
-    /// unconditionally and the result is masked.
     pub fn inv_fermat(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>
     where
         T: CiosMontMulCt
@@ -1407,9 +1398,9 @@ mod tests {
     /// check inv * value ≡ 1).
     #[test]
     fn inv_safegcd_ct_composite_modulus_u128() {
-        // n = 2^31 - 1 (Mersenne prime, but treat as "composite-shape"
-        // for the test — what matters is that safegcd doesn't assume
-        // primality). Result still works for any coprime value.
+        // n = (2^32 + 7) · (2^24 + 7) — RSA-CRT-shape two-prime
+        // composite, ~52 bits. safegcd handles composites; the result
+        // works for any coprime value.
         let n_raw: u64 = 0x1_0000_0007 * 0x100_0007u64; // = 4503599644606465
         let modulus = U128Ct::from(n_raw);
         let f = FieldCt::new(modulus).unwrap();

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -254,6 +254,43 @@ where
         }
     }
 
+    /// Construct a new `Field` from an already-proven-odd modulus,
+    /// using the **constant-time** precompute path.
+    ///
+    /// Same precompute as [`new_odd`] (Newton's iteration for `N'`,
+    /// repeated modular doublings for `R mod N` and `R² mod N`), but
+    /// the doubling-and-reduction loop uses
+    /// [`mod_double_ct`](crate::montgomery::compute_r_mod_n_ct)
+    /// internally — no value-dependent branches on the modulus.
+    ///
+    /// Use this when `modulus` is secret (e.g. RSA-CRT private primes
+    /// `p`, `q`). For public moduli (ed25519 / Curve25519 / krabipqc),
+    /// [`new_odd`] is faster and equivalent.
+    ///
+    /// Cost vs [`new_odd`]: one extra `wrapping_sub` and one
+    /// `conditional_select` per modular doubling step (`w` per
+    /// precompute call). Negligible against the subsequent field
+    /// operations the precompute amortizes.
+    ///
+    /// [`new_odd`]: Self::new_odd
+    pub fn new_odd_ct(modulus: Odd<T>) -> Self
+    where
+        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+    {
+        let modulus = modulus.get();
+        let w = type_bit_width::<T>();
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r_mod_n = crate::montgomery::compute_r_mod_n_ct(modulus, w);
+        let r2_mod_n = crate::montgomery::compute_r2_mod_n_ct(r_mod_n, modulus, w);
+        Self {
+            modulus,
+            n_prime,
+            r_mod_n,
+            r2_mod_n,
+            _p: PhantomData,
+        }
+    }
+
     /// Construct a new `Field` over the given (odd, nonzero) `modulus`.
     ///
     /// Returns `None` if `modulus` is zero or even (Montgomery requires odd N).
@@ -597,21 +634,21 @@ where
     /// [`CtParity`]: const_num_traits::CtParity
     pub fn try_new_odd_ct(modulus: T) -> subtle::CtOption<Self>
     where
-        T: const_num_traits::CtParity,
+        T: const_num_traits::CtParity + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
     {
-        // Mask the parity check (no branch on the secret modulus); the
-        // precompute below runs unconditionally on the modulus value and is
-        // branch-free over the trait surface (wrapping/overflowing word
-        // arithmetic). When `is_odd` is unset the precompute output is
-        // meaningless — `CtOption::new(_, choice)` discards it via the
-        // standard masked-`Some` pattern.
+        // Mask the parity check (no branch on the secret modulus). The
+        // precompute below uses the CT path ([`Self::new_odd_ct`]) so
+        // no value-dependent branches on the modulus value either —
+        // every step is `subtle::Choice`-masked. `CtOption::new(_,
+        // choice)` discards the result via the standard masked-`Some`
+        // pattern if the modulus turned out to be even.
         let is_odd = modulus.ct_is_odd();
         // SAFETY: when `is_odd` is unset the wrapped `Odd` proof carries a
         // false predicate, but the resulting `Field` is unreachable through
         // the `CtOption` mask. No body downstream consumes the proof except
         // via the masked output.
         let proof = unsafe { Odd::new_unchecked(modulus) };
-        let field = Self::new_odd(proof);
+        let field = Self::new_odd_ct(proof);
         subtle::CtOption::new(field, is_odd)
     }
 
@@ -1040,6 +1077,41 @@ mod tests {
         // Same precompute as the infallible boundary constructor:
         let baseline = Field::<u32, Ct>::new_odd(Odd::new(13u32).unwrap());
         assert_eq!(field.modulus(), baseline.modulus());
+    }
+
+    /// `Field::new_odd_ct` (the CT precompute path) must produce
+    /// identical precompute values to `Field::new_odd` (the
+    /// variable-time path) for every modulus. Pins the contract that
+    /// `mod_double_ct` / `mod_exp2_ct` are CT-equivalent, not just
+    /// "CT but different output."
+    #[test]
+    fn new_odd_ct_precompute_matches_new_odd() {
+        for m in [3u32, 5, 7, 11, 13, 97, 65521, 0x7FFF_FFE7] {
+            let modulus = Odd::new(m).unwrap();
+            let f_nct = Field::<u32, Ct>::new_odd(modulus);
+            let f_ct = Field::<u32, Ct>::new_odd_ct(modulus);
+            assert_eq!(f_nct.modulus(), f_ct.modulus(), "modulus mismatch at m={m}");
+            assert_eq!(f_nct.n_prime, f_ct.n_prime, "n_prime mismatch at m={m}");
+            assert_eq!(f_nct.r_mod_n, f_ct.r_mod_n, "r_mod_n mismatch at m={m}");
+            assert_eq!(f_nct.r2_mod_n, f_ct.r2_mod_n, "r2_mod_n mismatch at m={m}");
+        }
+    }
+
+    /// CT precompute on multi-limb FixedUInt produces identical
+    /// output to the variable-time precompute. The actual RSA-CRT
+    /// shape — the precompute is what would silently produce
+    /// wrong results if `mod_double_ct` had a bug.
+    #[test]
+    fn new_odd_ct_precompute_matches_new_odd_fixed_bigint() {
+        // 128-bit odd modulus (composite, RSA-CRT-shape)
+        let m = U128Ct::from(0xFFFF_FFFF_FFFF_FFE7u64);
+        let modulus = Odd::new(m).unwrap();
+        let f_nct = Field::<U128Ct, Ct>::new_odd(modulus);
+        let f_ct = Field::<U128Ct, Ct>::new_odd_ct(modulus);
+        assert_eq!(f_nct.modulus(), f_ct.modulus());
+        assert_eq!(f_nct.n_prime, f_ct.n_prime);
+        assert_eq!(f_nct.r_mod_n, f_ct.r_mod_n);
+        assert_eq!(f_nct.r2_mod_n, f_ct.r2_mod_n);
     }
 
     #[test]

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -706,6 +706,7 @@ where
     pub fn exp(&self, base: &Residue<'_, T, Ct>, exp: &T) -> Residue<'_, T, Ct>
     where
         T: CiosMontMulCt
+            + const_num_traits::CtIsZero
             + subtle::ConditionallySelectable
             + subtle::ConstantTimeEq
             + core::ops::Shr<usize, Output = T>
@@ -722,9 +723,11 @@ where
             // Always compute the conditional product.
             let multiplied =
                 CiosMontMulCt::cios_mont_mul_ct(&result, &base.mont, &self.modulus, &self.n_prime);
-            // Select based on bit i of exp.
+            // Select based on bit i of exp. Delegates to CtIsZero
+            // rather than ct_eq(&one); semantics identical for a value
+            // already known to be 0 or 1.
             let bit_t = (*exp >> i) & one;
-            let choice = bit_t.ct_eq(&one);
+            let choice = !bit_t.ct_is_zero();
             result = T::conditional_select(&result, &multiplied, choice);
         }
         Residue {

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -859,6 +859,80 @@ where
         let exp_val = self.modulus.wrapping_sub(two);
         Some(self.exp(a, &exp_val))
     }
+
+    /// Constant-time modular inverse via Bernstein-Yang divsteps.
+    /// **Works for any modulus** — composite (RSA `n = p·q`) or prime —
+    /// unlike [`inv_fermat`] which assumes a prime modulus.
+    ///
+    /// Returns `CtOption::None` masked when `gcd(value, modulus) != 1`
+    /// (no inverse exists). Failure timing is independent of input
+    /// magnitudes.
+    ///
+    /// Used by RSA private-key blinding, where the modulus is the
+    /// composite `n = p·q` and Fermat's little theorem doesn't apply.
+    /// See [`crate::inv::safegcd`] for the algorithm and preconditions.
+    ///
+    /// [`inv_fermat`]: Self::inv_fermat
+    pub fn inv_safegcd_ct(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>
+    where
+        T: CiosMontMulCt
+            + WideMul
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess
+            + modmath_cios::CiosRowOps
+            + core::ops::Shr<usize, Output = T>
+            + core::ops::Shl<usize, Output = T>
+            + core::ops::BitOr<Output = T>,
+        <T as modmath_cios::CiosRowOps>::Word: Copy
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeEq
+            + const_num_traits::One
+            + const_num_traits::Zero
+            + core::ops::BitAnd<Output = <T as modmath_cios::CiosRowOps>::Word>
+            + core::ops::Shl<usize, Output = <T as modmath_cios::CiosRowOps>::Word>,
+    {
+        // The value in the Residue is in Montgomery form. To get the
+        // Montgomery form of the inverse:
+        //   a.mont           = value · R mod n
+        //   raw_inv          = safegcd(a.mont, n) = a.mont⁻¹ mod n
+        //                    = (value · R)⁻¹ mod n
+        //                    = value⁻¹ · R⁻¹ mod n
+        //   wanted: inv.mont = value⁻¹ · R mod n
+        //                    = raw_inv · R² mod n
+        // Computing raw_inv · R² mod n via Mont multiplications requires
+        // **two** multiplications by R², not one:
+        //   m1 = REDC(raw_inv · R²) = raw_inv · R mod n  (= value⁻¹ raw)
+        //   m2 = REDC(m1 · R²)      = m1 · R mod n       (= value⁻¹ · R = inv.mont)
+        // The first multiplication "converts raw_inv into something that
+        // multiplied by R again gives the desired Mont form". The
+        // second multiplication does that final · R step. Equivalent
+        // to one multiplication by R³, but we only have R² cached.
+        //
+        // Headroom precondition: safegcd needs `2 * self.modulus` not
+        // to overflow `T` (i.e. modulus's MSB clear). We fold that
+        // check into the returned CtOption rather than asserting at
+        // entry — `None`-masked when the carrier was sized too tightly
+        // for the modulus. Cost is one MSB extraction on the cached
+        // modulus per call, invisible against the safegcd loop.
+        let modulus_has_headroom = !crate::inv::safegcd::ct_msb_set(&self.modulus);
+        let inv_raw = crate::inv::safegcd::safegcd_inv_ct(&a.mont, &self.modulus);
+        // Extract the raw inverse, defaulting to zero when safegcd
+        // reports `None`. The two REDCs run unconditionally on the
+        // extracted value — under the CtOption mask any garbage they
+        // produce on the failure path is discarded.
+        let inv_exists = inv_raw.is_some();
+        let raw_inv = inv_raw.unwrap_or(T::zero());
+        let m1 = wide_montgomery_mul_ct(raw_inv, self.r2_mod_n, self.modulus, self.n_prime);
+        let mont = wide_montgomery_mul_ct(m1, self.r2_mod_n, self.modulus, self.n_prime);
+        let residue = Residue {
+            mont,
+            _brand: PhantomData,
+            _p: PhantomData,
+        };
+        // Combined predicate: inverse exists AND modulus has headroom.
+        // If either fails, the CtOption is None-masked.
+        subtle::CtOption::new(residue, inv_exists & modulus_has_headroom)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1128,6 +1202,125 @@ mod tests {
         let raw = U128Ct::from(0xDEAD_BEEF_u64);
         let r = f.reduce(&raw);
         assert_eq!(f.into_raw(&r), raw);
+    }
+
+    /// `inv_safegcd_ct` round-trip on a prime modulus. The CT
+    /// composite-modulus inverse is the load-bearing primitive for RSA
+    /// blinding; here we test on a prime (smaller test surface) and
+    /// verify `inv * value ≡ 1 mod modulus`.
+    #[test]
+    fn inv_safegcd_ct_round_trip_prime_modulus() {
+        let f = FieldCt::new(u16ct(13)).unwrap();
+        for raw_val in 1u16..13 {
+            let r = f.reduce(&u16ct(raw_val));
+            let inv = f.inv_safegcd_ct(&r);
+            assert_eq!(
+                inv.is_some().unwrap_u8(),
+                1,
+                "expected inverse for {raw_val} mod 13"
+            );
+            let inv_residue = inv.unwrap();
+            let product = f.mul(&r, &inv_residue);
+            assert_eq!(
+                f.into_raw(&product),
+                u16ct(1),
+                "{raw_val} * inv != 1 mod 13"
+            );
+        }
+    }
+
+    /// `inv_safegcd_ct` on a composite modulus — the RSA blinding case.
+    /// Confirms the algorithm works when the modulus is `p·q`, not
+    /// prime, where Fermat inversion would fail.
+    #[test]
+    fn inv_safegcd_ct_composite_modulus() {
+        // n = 3 * 5 = 15. Coprime values: 1, 2, 4, 7, 8, 11, 13, 14.
+        let f = FieldCt::new(u16ct(15)).unwrap();
+        for &raw_val in &[1u16, 2, 4, 7, 8, 11, 13, 14] {
+            let r = f.reduce(&u16ct(raw_val));
+            let inv = f.inv_safegcd_ct(&r);
+            assert_eq!(
+                inv.is_some().unwrap_u8(),
+                1,
+                "expected inverse for {raw_val} mod 15"
+            );
+            let product = f.mul(&r, &inv.unwrap());
+            assert_eq!(
+                f.into_raw(&product),
+                u16ct(1),
+                "{raw_val} * inv != 1 mod 15"
+            );
+        }
+        // Non-coprime values: safegcd returns None.
+        for &raw_val in &[3u16, 5, 6, 9, 10, 12] {
+            let r = f.reduce(&u16ct(raw_val));
+            let inv = f.inv_safegcd_ct(&r);
+            assert_eq!(
+                inv.is_some().unwrap_u8(),
+                0,
+                "expected None for non-coprime {raw_val} mod 15"
+            );
+        }
+    }
+
+    /// `inv_safegcd_ct` masks the result when the carrier doesn't have
+    /// one bit of headroom over the modulus (the safegcd
+    /// `2·modulus ≤ T::MAX` precondition). Field is constructed with a
+    /// modulus whose MSB is set; the returned CtOption is `None`
+    /// regardless of whether the value is mathematically invertible.
+    #[test]
+    fn inv_safegcd_ct_masks_when_modulus_lacks_headroom() {
+        // U16Ct = FixedUInt<u8, 2, Ct> — 16-bit carrier. Pick a 16-bit
+        // odd modulus with MSB set (e.g. 0xFFFD, an odd value > 2^15).
+        // 2 * 0xFFFD overflows u16 → safegcd's invariants break →
+        // headroom check returns None.
+        let modulus = u16ct(0xFFFD);
+        let f = FieldCt::new(modulus).unwrap();
+        let r = f.reduce(&u16ct(7));
+        let inv = f.inv_safegcd_ct(&r);
+        assert_eq!(
+            inv.is_some().unwrap_u8(),
+            0,
+            "expected None for modulus 0xFFFD (no headroom)"
+        );
+    }
+
+    /// `inv_safegcd_ct` on a larger RSA-CRT-shaped composite modulus.
+    /// n = p · q with small primes p, q. Confirms the algorithm runs
+    /// correctly on a multi-limb FixedUInt and at sizes more
+    /// representative of the RSA blinding workload than the toy
+    /// `mod 15` case (still small enough that we can exhaustively
+    /// check inv * value ≡ 1).
+    #[test]
+    fn inv_safegcd_ct_composite_modulus_u128() {
+        // n = 2^31 - 1 (Mersenne prime, but treat as "composite-shape"
+        // for the test — what matters is that safegcd doesn't assume
+        // primality). Result still works for any coprime value.
+        let n_raw: u64 = 0x1_0000_0007 * 0x100_0007u64; // = 4503599644606465
+        let modulus = U128Ct::from(n_raw);
+        let f = FieldCt::new(modulus).unwrap();
+
+        // A handful of values coprime to n. (0xDEAD_BEEF deliberately
+        // omitted — it shares factor 11 with this n.)
+        let test_vals = [
+            U128Ct::from(1u64),
+            U128Ct::from(2u64),
+            U128Ct::from(3u64),
+            U128Ct::from(0xCAFE_BABEu64),
+            U128Ct::from(0xFEED_FACEu64),
+        ];
+        for v in test_vals {
+            let r = f.reduce(&v);
+            let inv = f.inv_safegcd_ct(&r);
+            assert_eq!(
+                inv.is_some().unwrap_u8(),
+                1,
+                "expected inverse to exist for v={:?}",
+                v
+            );
+            let product = f.mul(&r, &inv.unwrap());
+            assert_eq!(f.into_raw(&product), U128Ct::from(1u64));
+        }
     }
 
     #[cfg(feature = "zeroize")]

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -1,3 +1,4 @@
+pub mod safegcd;
 mod signed;
 use signed::Signed;
 

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -1,3 +1,8 @@
+// Clippy's `clone_on_copy` / `op_ref` lints misfire on generic code that
+// uses `.clone()` or `&x + &T::zero()` as portable "produce owned T"
+// idioms across trait-bound flavors where T may or may not be Copy.
+#![allow(clippy::clone_on_copy, clippy::op_ref)]
+
 //! Bernstein-Yang constant-time modular inverse via "safegcd" divsteps.
 //!
 //! Computes `a⁻¹ mod n` in constant time over the value being inverted,

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -457,11 +457,9 @@ mod tests {
         }
     }
 
-    /// u64 composite modulus, only coprime test values.
-    /// (0xDEAD_BEEF deliberately omitted — it shares factor 11 with
-    /// the test modulus n = 0x100000707000031; the algorithm correctly
-    /// returns CtOption::None for that case, which exercises the
-    /// non-coprime path on a multi-step trace.)
+    /// u64 composite modulus. Coprime values must invert; 0xDEAD_BEEF
+    /// (shares factor 11 with n = 0x100000707000031) must return
+    /// CtOption::None.
     #[test]
     fn u64_composite_coprime() {
         let n: u64 = 0x1_0000_0007 * 0x100_0007;

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -61,20 +61,12 @@ use const_num_traits::{CtIsZero, CtParity, One, WrappingAdd, WrappingSub, Zero};
 use modmath_cios::CiosRowOps;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption};
 
-// ---------------------------------------------------------------------------
-// Iteration count
-// ---------------------------------------------------------------------------
-
 /// Total number of divsteps for an `n`-bit operand. Per the paper
 /// (Theorem 11.2), `⌈(45·n + 64) / 19⌉` is the proven sufficient count.
 /// A small safety margin is added because the bound is tight.
 pub(crate) const fn divsteps_total(modulus_bits: usize) -> usize {
     (45 * modulus_bits + 64).div_ceil(19) + 4
 }
-
-// ---------------------------------------------------------------------------
-// CT primitives on T
-// ---------------------------------------------------------------------------
 
 /// Returns `Choice::from(1)` iff the low bit of `value` is set.
 ///
@@ -225,10 +217,6 @@ where
     T::conditional_select(&candidate_even, &candidate_odd, x_odd)
 }
 
-// ---------------------------------------------------------------------------
-// Public entry point
-// ---------------------------------------------------------------------------
-
 /// Compute `value⁻¹ mod modulus` in constant time over `value`. Works
 /// for any modulus (composite or prime), provided the modulus is odd
 /// and `2 * modulus` fits in `T`.
@@ -279,15 +267,13 @@ where
     let mut delta: i64 = 1;
 
     for _ in 0..total_steps {
-        // ---- Decide swap ---------------------------------------------------
         let delta_pos = ct_i64_positive(delta);
         let g_odd = ct_low_bit(&g);
         let swap = delta_pos & g_odd;
 
-        // ---- Apply swap (CT) -----------------------------------------------
         // swap_choice: (f, g) ← (g, -f); (d, e) ← (e, -d mod m); delta ← -delta
         let new_f_if_swap = g.clone();
-        let new_g_if_swap = f.clone().wrapping_neg_two_complement(); // helper below
+        let new_g_if_swap = f.clone().wrapping_neg_two_complement();
         let new_d_if_swap = e.clone();
         let new_e_if_swap = neg_mod_ct(&d, modulus);
 
@@ -296,16 +282,14 @@ where
         d = T::conditional_select(&d, &new_d_if_swap, swap);
         e = T::conditional_select(&e, &new_e_if_swap, swap);
 
-        // delta: if swap, negate. Then always +1.
         let neg_delta = (delta as u64).wrapping_neg() as i64;
         delta = i64::conditional_select(&delta, &neg_delta, swap);
         delta = delta.wrapping_add(1);
 
-        // ---- Conditional add (g_odd was determined before swap; after the
-        //      swap+negate, the parity of g equals the parity of the original
-        //      g — both old g and -old_f are odd when the swap fired, since
-        //      old f is always odd by loop invariant; in the non-swap case
-        //      g_odd correctly tracks current g's parity).
+        // g_odd was determined before swap; after swap+negate the parity
+        // of g equals that of the original g (both old g and -old_f are
+        // odd when the swap fired, since old f is odd by loop invariant).
+        // In the non-swap case g_odd tracks current g's parity directly.
         let g_odd_now = g_odd;
         let to_add_to_g = T::conditional_select(&T::zero(), &f, g_odd_now);
         g = g.wrapping_add(to_add_to_g);
@@ -313,7 +297,6 @@ where
         let add_to_e = add_mod_ct(&e, &d, modulus);
         e = T::conditional_select(&e, &add_to_e, g_odd_now);
 
-        // ---- Halve g (arithmetic shr 1) and e (half mod m) -----------------
         g = arithmetic_shr_one(&g);
         e = half_mod_ct(&e, modulus);
     }
@@ -335,16 +318,10 @@ where
     CtOption::new(result, has_inverse)
 }
 
-// ---------------------------------------------------------------------------
-// Trait extension: WrappingNeg-style two's-complement negate on T.
-//
-// Implemented inline here because const-num-traits' WrappingNeg has an
-// `Output` associated type that doesn't necessarily equal T for
-// generic T, and we want a clean `T -> T` two's-complement negate. For
-// any `T: WrappingSub<Output = T> + Zero`, two's-complement negate is
+// Inline WrappingNeg-style two's-complement negate. const-num-traits'
+// WrappingNeg has an `Output` associated type that doesn't necessarily
+// equal T for generic T; this trait gives a clean `T -> T` shape as
 // `0 - x` via wrapping_sub.
-// ---------------------------------------------------------------------------
-
 trait WrappingNegT: Sized {
     fn wrapping_neg_two_complement(self) -> Self;
 }
@@ -358,10 +335,6 @@ where
         T::zero().wrapping_sub(self)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -390,7 +363,6 @@ mod tests {
                             g, w,
                             "value={v} modulus={m}: safegcd gave {g}, basic_mod_inv gave {w}"
                         );
-                        // Sanity: the result really is the inverse
                         assert_eq!((g as u64 * v as u64) % m as u64, 1, "inv check failed");
                     }
                     (Some(_), None) | (None, Some(_)) => {
@@ -418,7 +390,6 @@ mod tests {
                 assert_eq!((inv as u64 * v as u64) % 15, 1);
             }
         }
-        // Non-coprime values must return None
         for &v in &[3u32, 5, 6, 9, 10, 12] {
             assert!(
                 safegcd_inv_ct::<u32>(&v, &m).into_option().is_none(),
@@ -490,7 +461,6 @@ mod tests {
             let want = basic_mod_inv(v, m);
             assert_eq!(got, want, "value={v} modulus={m}: u64 case mismatch");
             if let Some(inv) = got {
-                // Sanity via 128-bit verify
                 let prod = (inv as u128 * v as u128) % m as u128;
                 assert_eq!(prod, 1, "u64 inv * value mod m != 1");
             }

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -100,14 +100,15 @@ where
     T::Word: core::ops::BitAnd<Output = T::Word>
         + core::ops::Shl<usize, Output = T::Word>
         + One
-        + Zero
-        + ConstantTimeEq,
+        + CtIsZero,
 {
     let n = value.word_count();
     let word_bits = core::mem::size_of::<T::Word>() * 8;
     let msb_mask = T::Word::one() << (word_bits - 1);
     let masked = value.word(n - 1) & msb_mask;
-    !masked.ct_eq(&T::Word::zero())
+    // Delegates to cnt's CtIsZero rather than ct_eq(&T::Word::zero()).
+    // Identical semantics; the dedicated trait is cnt-tested upstream.
+    !masked.ct_is_zero()
 }
 
 /// Constant-time `delta > 0` for the i64 state variable.
@@ -138,8 +139,7 @@ where
     T::Word: core::ops::BitAnd<Output = T::Word>
         + core::ops::Shl<usize, Output = T::Word>
         + One
-        + Zero
-        + ConstantTimeEq,
+        + CtIsZero,
 {
     let logical = value.clone() >> 1;
     let msb_set = ct_msb_set(value);
@@ -257,6 +257,7 @@ where
     T::Word: Copy
         + ConditionallySelectable
         + ConstantTimeEq
+        + CtIsZero
         + CtParity
         + One
         + Zero

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -1,0 +1,485 @@
+//! Bernstein-Yang constant-time modular inverse via "safegcd" divsteps.
+//!
+//! Computes `a⁻¹ mod n` in constant time over the value being inverted,
+//! for **any modulus** — composite or prime. Used by RSA private-key
+//! blinding (where `n = p·q` is composite, so Fermat's little theorem
+//! doesn't apply) and anywhere else CT inversion of arbitrary residues
+//! is needed.
+//!
+//! Reference: Bernstein & Yang, *"Fast constant-time gcd computation
+//! and modular inversion"*, IACR ePrint 2019/266
+//! (<https://gcd.cr.yp.to/>).
+//!
+//! ## Algorithm shape
+//!
+//! Operates on:
+//! - `f, g`: signed two's-complement values stored in unsigned `T`.
+//!   `f` starts as `modulus`, `g` starts as `value`. They evolve via
+//!   divsteps until `g == 0` and `f == ±1` (iff `gcd == 1`).
+//! - `d, e`: modular coefficients kept in `[0, modulus)` throughout,
+//!   such that `d * value ≡ f mod modulus` and `e * value ≡ g mod
+//!   modulus`. At convergence, `d` is `±value⁻¹ mod modulus`.
+//! - `delta`: small signed integer that tracks the divsteps state
+//!   machine. Stored as `i64`.
+//!
+//! ## Why this is "signed" without naming a signed bigint type
+//!
+//! The algorithm conceptually operates on signed values `f`, `g` that
+//! range over `(-modulus, modulus)`. **The implementation never types
+//! a signed bigint.** Every "signed" op is two's-complement-on-unsigned:
+//!
+//! - signed `f + g`  ≡ `T::wrapping_add(f, g)`         on unsigned `T`
+//! - signed `-f`     ≡ `T::wrapping_neg(f)`            on unsigned `T`
+//! - signed `f < 0`  ≡ MSB of unsigned `f` is set
+//! - arithmetic shr  ≡ `(x >> 1) | sign_extend_mask`   on unsigned `T`
+//!
+//! ## Bound precondition
+//!
+//! `modulus` must fit in `T` with at least one bit of headroom — i.e.
+//! `2 * modulus` does not overflow `T`. The algorithm maintains
+//! `|d|, |e| < modulus` strictly, so intermediate sums `d + e` are
+//! bounded by `2 * modulus`. Practical types (e.g.
+//! `FixedUInt<u32, 64>` for a 2048-bit RSA modulus) leave plenty of
+//! headroom.
+//!
+//! ## Implementation note
+//!
+//! This is a **per-step (unbatched) implementation**: each divstep
+//! does multi-precision arithmetic on the full `T`. Asymptotically
+//! `O(n²)` for an `n`-bit modulus. The batched ("jumpdivstep")
+//! variant brings this to `O(n²/W)` where `W` is the limb width — a
+//! follow-up optimization. The unbatched version is **correct** and
+//! suitable for cases where the latency budget allows it (RSA blinding
+//! at 2048 bits is dominated by the main exponentiation anyway).
+
+use const_num_traits::{One, WrappingAdd, WrappingSub, Zero};
+use modmath_cios::CiosRowOps;
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption};
+
+// ---------------------------------------------------------------------------
+// Iteration count
+// ---------------------------------------------------------------------------
+
+/// Total number of divsteps for an `n`-bit operand. Per the paper
+/// (Theorem 11.2), `⌈(45·n + 64) / 19⌉` is the proven sufficient count.
+/// A small safety margin is added because the bound is tight.
+pub(crate) const fn divsteps_total(modulus_bits: usize) -> usize {
+    (45 * modulus_bits + 64).div_ceil(19) + 4
+}
+
+// ---------------------------------------------------------------------------
+// CT primitives on T
+// ---------------------------------------------------------------------------
+
+/// Returns `Choice::from(1)` iff the low bit of `value` is set.
+#[inline]
+fn ct_low_bit<T>(value: &T) -> Choice
+where
+    T: CiosRowOps,
+    T::Word: core::ops::BitAnd<Output = T::Word> + One + Zero + ConstantTimeEq,
+{
+    let masked = value.word(0) & T::Word::one();
+    !masked.ct_eq(&T::Word::zero())
+}
+
+/// Returns `Choice::from(1)` iff the most-significant bit of `value`'s
+/// bit pattern is set (i.e. value is "negative" in two's-complement
+/// interpretation).
+///
+/// Exposed at crate visibility so `Field::inv_safegcd_ct` can fold the
+/// "modulus has one bit of headroom" precondition into its CtOption
+/// instead of relying on documentation alone.
+#[inline]
+pub(crate) fn ct_msb_set<T>(value: &T) -> Choice
+where
+    T: CiosRowOps,
+    T::Word: core::ops::BitAnd<Output = T::Word>
+        + core::ops::Shl<usize, Output = T::Word>
+        + One
+        + Zero
+        + ConstantTimeEq,
+{
+    let n = value.word_count();
+    let word_bits = core::mem::size_of::<T::Word>() * 8;
+    let msb_mask = T::Word::one() << (word_bits - 1);
+    let masked = value.word(n - 1) & msb_mask;
+    !masked.ct_eq(&T::Word::zero())
+}
+
+/// Constant-time `delta > 0` for the i64 state variable.
+#[inline]
+fn ct_i64_positive(delta: i64) -> Choice {
+    let delta_u = delta as u64;
+    // nonzero = ((x | -x) >> 63) — top bit set iff x != 0
+    let nonzero_top = (delta_u | delta_u.wrapping_neg()) >> 63;
+    // sign_bit_clear = 1 iff x's high bit is 0 (i.e. x >= 0 as i64)
+    let sign_bit_clear = (!delta_u) >> 63;
+    Choice::from(((nonzero_top & sign_bit_clear) & 1) as u8)
+}
+
+/// Arithmetic right shift by 1 (sign-extending). For T interpreted as
+/// two's-complement, returns `value / 2` with floor rounding for
+/// negative values.
+#[inline]
+fn arithmetic_shr_one<T>(value: &T) -> T
+where
+    T: CiosRowOps
+        + Clone
+        + ConditionallySelectable
+        + One
+        + Zero
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::Shl<usize, Output = T>
+        + core::ops::BitOr<Output = T>,
+    T::Word: core::ops::BitAnd<Output = T::Word>
+        + core::ops::Shl<usize, Output = T::Word>
+        + One
+        + Zero
+        + ConstantTimeEq,
+{
+    let logical = value.clone() >> 1;
+    let msb_set = ct_msb_set(value);
+    let n_bits = value.word_count() * core::mem::size_of::<T::Word>() * 8;
+    let top_bit_mask = T::one() << (n_bits - 1);
+    let with_sign_ext = logical.clone() | top_bit_mask;
+    T::conditional_select(&logical, &with_sign_ext, msb_set)
+}
+
+/// Reduce `sum` to `[0, m)` when `sum` is already in `[0, 2·m)`.
+/// One conditional subtract suffices.
+#[inline]
+fn reduce_lt_2m_ct<T>(sum: T, m: &T) -> T
+where
+    T: Clone + ConditionallySelectable + WrappingSub<Output = T> + ConstantTimeLess,
+{
+    let sum_minus_m = sum.clone().wrapping_sub(m.clone());
+    let need_sub = !sum.ct_lt(m);
+    T::conditional_select(&sum, &sum_minus_m, need_sub)
+}
+
+/// Modular add: `(a + b) mod m`, assuming `a, b ∈ [0, m)` so the sum
+/// is in `[0, 2·m)`. Precondition: `2·m` fits in `T` (one bit of
+/// headroom over `m`).
+#[inline]
+fn add_mod_ct<T>(a: &T, b: &T, m: &T) -> T
+where
+    T: Clone
+        + ConditionallySelectable
+        + WrappingAdd<Output = T>
+        + WrappingSub<Output = T>
+        + ConstantTimeLess,
+{
+    let sum = a.clone().wrapping_add(b.clone());
+    reduce_lt_2m_ct(sum, m)
+}
+
+/// Modular negate: `(m - x) mod m`, preserving the `[0, m)` invariant.
+/// Returns 0 when `x == 0` (since `-0 mod m = 0`).
+#[inline]
+fn neg_mod_ct<T>(x: &T, m: &T) -> T
+where
+    T: Clone + Zero + ConditionallySelectable + WrappingSub<Output = T> + ConstantTimeEq,
+{
+    let zero = T::zero();
+    let x_is_zero = x.ct_eq(&zero);
+    let neg = m.clone().wrapping_sub(x.clone());
+    T::conditional_select(&neg, &zero, x_is_zero)
+}
+
+/// Modular halving: returns `y ∈ [0, m)` such that `2·y ≡ x mod m`.
+/// Precondition: `x ∈ [0, m)`, `m` is odd.
+///
+/// For odd `m`, the inverse of 2 mod `m` is `(m + 1) / 2`; computing
+/// `x / 2 mod m` via the standard branch-free trick:
+/// - if `x` even: result is `x >> 1`.
+/// - if `x` odd: result is `(x + m) >> 1` (since `x + m` is even when
+///   `m` is odd, and the sum is in `[m, 2m)` which fits with one bit
+///   of headroom).
+#[inline]
+fn half_mod_ct<T>(x: &T, m: &T) -> T
+where
+    T: CiosRowOps
+        + Clone
+        + ConditionallySelectable
+        + WrappingAdd<Output = T>
+        + core::ops::Shr<usize, Output = T>,
+    T::Word: core::ops::BitAnd<Output = T::Word> + One + Zero + ConstantTimeEq,
+{
+    let x_odd = ct_low_bit(x);
+    let x_plus_m = x.clone().wrapping_add(m.clone());
+    let candidate_odd = x_plus_m >> 1;
+    let candidate_even = x.clone() >> 1;
+    T::conditional_select(&candidate_even, &candidate_odd, x_odd)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Compute `value⁻¹ mod modulus` in constant time over `value`. Works
+/// for any modulus (composite or prime), provided the modulus is odd
+/// and `2 * modulus` fits in `T`.
+///
+/// Returns `CtOption::Some(inv)` when `gcd(value, modulus) == 1`, or
+/// `CtOption::None` masked when no inverse exists. The failure path
+/// timing is independent of input magnitudes.
+///
+/// # Preconditions
+///
+/// - `modulus` is odd
+/// - `modulus > 1`
+/// - `value < modulus` (caller should reduce first)
+/// - `2 * modulus` fits in `T` without overflow (i.e. `T` is at least
+///   one bit wider than `modulus`)
+pub fn safegcd_inv_ct<T>(value: &T, modulus: &T) -> CtOption<T>
+where
+    T: CiosRowOps
+        + Clone
+        + ConditionallySelectable
+        + ConstantTimeEq
+        + ConstantTimeLess
+        + Zero
+        + One
+        + WrappingAdd<Output = T>
+        + WrappingSub<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::Shl<usize, Output = T>
+        + core::ops::BitOr<Output = T>,
+    T::Word: Copy
+        + ConditionallySelectable
+        + ConstantTimeEq
+        + One
+        + Zero
+        + core::ops::BitAnd<Output = T::Word>
+        + core::ops::Shl<usize, Output = T::Word>,
+{
+    let n_bits = value.word_count() * core::mem::size_of::<T::Word>() * 8;
+    let total_steps = divsteps_total(n_bits);
+
+    let mut f = modulus.clone();
+    let mut g = value.clone();
+    let mut d = T::zero();
+    let mut e = T::one();
+    let mut delta: i64 = 1;
+
+    for _ in 0..total_steps {
+        // ---- Decide swap ---------------------------------------------------
+        let delta_pos = ct_i64_positive(delta);
+        let g_odd = ct_low_bit(&g);
+        let swap = delta_pos & g_odd;
+
+        // ---- Apply swap (CT) -----------------------------------------------
+        // swap_choice: (f, g) ← (g, -f); (d, e) ← (e, -d mod m); delta ← -delta
+        let new_f_if_swap = g.clone();
+        let new_g_if_swap = f.clone().wrapping_neg_two_complement(); // helper below
+        let new_d_if_swap = e.clone();
+        let new_e_if_swap = neg_mod_ct(&d, modulus);
+
+        f = T::conditional_select(&f, &new_f_if_swap, swap);
+        g = T::conditional_select(&g, &new_g_if_swap, swap);
+        d = T::conditional_select(&d, &new_d_if_swap, swap);
+        e = T::conditional_select(&e, &new_e_if_swap, swap);
+
+        // delta: if swap, negate. Then always +1.
+        let neg_delta = (delta as u64).wrapping_neg() as i64;
+        delta = i64::conditional_select(&delta, &neg_delta, swap);
+        delta = delta.wrapping_add(1);
+
+        // ---- Conditional add (g_odd was determined before swap; after the
+        //      swap+negate, the parity of g equals the parity of the original
+        //      g — both old g and -old_f are odd when the swap fired, since
+        //      old f is always odd by loop invariant; in the non-swap case
+        //      g_odd correctly tracks current g's parity).
+        let g_odd_now = g_odd;
+        let to_add_to_g = T::conditional_select(&T::zero(), &f, g_odd_now);
+        g = g.wrapping_add(to_add_to_g);
+
+        let add_to_e = add_mod_ct(&e, &d, modulus);
+        e = T::conditional_select(&e, &add_to_e, g_odd_now);
+
+        // ---- Halve g (arithmetic shr 1) and e (half mod m) -----------------
+        g = arithmetic_shr_one(&g);
+        e = half_mod_ct(&e, modulus);
+    }
+
+    // After total_steps divsteps, g == 0 and f == ±gcd. For the
+    // invertible case (gcd == 1), f is either +1 (bit pattern T::one())
+    // or -1 (bit pattern T::one().wrapping_neg()).
+    let one = T::one();
+    let neg_one_pattern = one.clone().wrapping_neg_two_complement();
+
+    let f_is_one = f.ct_eq(&one);
+    let f_is_neg_one = f.ct_eq(&neg_one_pattern);
+    let has_inverse = f_is_one | f_is_neg_one;
+
+    // Result: d if f == 1; (m - d) = -d mod m if f == -1.
+    let neg_d = neg_mod_ct(&d, modulus);
+    let result = T::conditional_select(&d, &neg_d, f_is_neg_one);
+
+    CtOption::new(result, has_inverse)
+}
+
+// ---------------------------------------------------------------------------
+// Trait extension: WrappingNeg-style two's-complement negate on T.
+//
+// Implemented inline here because const-num-traits' WrappingNeg has an
+// `Output` associated type that doesn't necessarily equal T for
+// generic T, and we want a clean `T -> T` two's-complement negate. For
+// any `T: WrappingSub<Output = T> + Zero`, two's-complement negate is
+// `0 - x` via wrapping_sub.
+// ---------------------------------------------------------------------------
+
+trait WrappingNegT: Sized {
+    fn wrapping_neg_two_complement(self) -> Self;
+}
+
+impl<T> WrappingNegT for T
+where
+    T: Zero + WrappingSub<Output = T>,
+{
+    #[inline]
+    fn wrapping_neg_two_complement(self) -> Self {
+        T::zero().wrapping_sub(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inv::basic_mod_inv;
+
+    #[test]
+    fn divsteps_total_matches_paper_bound() {
+        assert!(divsteps_total(256) >= (45usize * 256 + 64).div_ceil(19));
+        assert!(divsteps_total(2048) >= (45usize * 2048 + 64).div_ceil(19));
+        assert!(divsteps_total(4096) >= (45usize * 4096 + 64).div_ceil(19));
+    }
+
+    /// Exhaustive cross-check against `basic_mod_inv` over a small
+    /// odd-prime modulus. T = u32 gives plenty of headroom for the
+    /// `2 * modulus` precondition.
+    #[test]
+    fn matches_basic_mod_inv_mod_small_primes_u32() {
+        for &m in &[3u32, 5, 7, 11, 13, 17, 19, 23, 29, 31, 97, 251] {
+            for v in 1..m {
+                let got = safegcd_inv_ct::<u32>(&v, &m);
+                let want = basic_mod_inv(v, m);
+                match (got.into_option(), want) {
+                    (Some(g), Some(w)) => {
+                        assert_eq!(
+                            g, w,
+                            "value={v} modulus={m}: safegcd gave {g}, basic_mod_inv gave {w}"
+                        );
+                        // Sanity: the result really is the inverse
+                        assert_eq!((g as u64 * v as u64) % m as u64, 1, "inv check failed");
+                    }
+                    (Some(_), None) | (None, Some(_)) => {
+                        panic!("disagreement on value={v} modulus={m}");
+                    }
+                    (None, None) => {}
+                }
+            }
+        }
+    }
+
+    /// Composite modulus — the load-bearing case for RSA blinding,
+    /// where Fermat's little theorem doesn't apply but safegcd still
+    /// computes the inverse correctly.
+    #[test]
+    fn handles_composite_modulus_u32() {
+        // n = 3 * 5 = 15. Values coprime to 15: 1, 2, 4, 7, 8, 11, 13, 14.
+        let m: u32 = 15;
+        let coprime_values = [1u32, 2, 4, 7, 8, 11, 13, 14];
+        for &v in &coprime_values {
+            let got = safegcd_inv_ct::<u32>(&v, &m).into_option();
+            let want = basic_mod_inv(v, m);
+            assert_eq!(got, want, "value={v} modulus=15: composite case mismatch");
+            if let Some(inv) = got {
+                assert_eq!((inv as u64 * v as u64) % 15, 1);
+            }
+        }
+        // Non-coprime values must return None
+        for &v in &[3u32, 5, 6, 9, 10, 12] {
+            assert!(
+                safegcd_inv_ct::<u32>(&v, &m).into_option().is_none(),
+                "value={v} modulus=15: expected None (not coprime)"
+            );
+        }
+    }
+
+    /// FixedUInt end-to-end test. Confirms the algorithm works for
+    /// multi-limb T as it does for primitive T. This is the
+    /// load-bearing case — RSA uses FixedUInt, not primitives.
+    #[test]
+    fn fixed_bigint_smoke_test() {
+        use const_num_traits::Ct;
+        use fixed_bigint::FixedUInt;
+        type U64Ct = FixedUInt<u32, 2, Ct>;
+        type U64Nct = FixedUInt<u32, 2>;
+
+        let m_raw: u64 = 0x7FFF_FFFF_FFFF_FFE7; // 2^63 - 25, prime
+        let m = U64Ct::from(m_raw);
+        let m_nct = U64Nct::from(m_raw);
+        let test_vals = [1u64, 2, 7, 42, 0xDEAD_BEEF];
+        for &v_raw in &test_vals {
+            let v = U64Ct::from(v_raw);
+            let v_nct = U64Nct::from(v_raw);
+            let got = safegcd_inv_ct(&v, &m).into_option();
+            assert!(got.is_some(), "expected inverse to exist for v={v_raw}");
+            let inv = got.unwrap();
+            // Cross-check by converting Ct → Nct and running basic_mod_inv
+            let baseline = basic_mod_inv(v_nct, m_nct).expect("baseline inv");
+            let inv_nct: U64Nct = inv.forget_ct();
+            assert_eq!(
+                inv_nct, baseline,
+                "FixedUInt v={v_raw}: mismatch with basic_mod_inv"
+            );
+        }
+    }
+
+    /// u64 composite modulus, only coprime test values.
+    /// (0xDEAD_BEEF deliberately omitted — it shares factor 11 with
+    /// the test modulus n = 0x100000707000031; the algorithm correctly
+    /// returns CtOption::None for that case, which exercises the
+    /// non-coprime path on a multi-step trace.)
+    #[test]
+    fn u64_composite_coprime() {
+        let n: u64 = 0x1_0000_0007 * 0x100_0007;
+        for v in [1u64, 2, 3, 0xCAFE_BABE, 0xFEED_FACE] {
+            let got = safegcd_inv_ct::<u64>(&v, &n).into_option();
+            assert!(got.is_some(), "u64 case: v={v} mod {n:#x} expected Some");
+            let inv = got.unwrap();
+            let prod = (inv as u128 * v as u128) % n as u128;
+            assert_eq!(prod, 1, "u64 v={v}: inv*v mod n != 1");
+        }
+        // Non-coprime: 0xDEAD_BEEF shares factor 11 with n
+        assert!(
+            safegcd_inv_ct::<u64>(&0xDEAD_BEEF, &n)
+                .into_option()
+                .is_none()
+        );
+    }
+
+    /// Larger primitive: u64 modulus, sanity check on a handful of pairs.
+    /// Uses a modulus < 2^63 to satisfy the `2 * modulus fits in T`
+    /// precondition.
+    #[test]
+    fn u64_smoke_test() {
+        let m: u64 = 0x7FFF_FFFF_FFFF_FFE7; // 2^63 - 25, a prime
+        let test_vals = [1u64, 2, 7, 0xDEAD_BEEF, 0xCAFE_BABE];
+        for &v in &test_vals {
+            let got = safegcd_inv_ct::<u64>(&v, &m).into_option();
+            let want = basic_mod_inv(v, m);
+            assert_eq!(got, want, "value={v} modulus={m}: u64 case mismatch");
+            if let Some(inv) = got {
+                // Sanity via 128-bit verify
+                let prod = (inv as u128 * v as u128) % m as u128;
+                assert_eq!(prod, 1, "u64 inv * value mod m != 1");
+            }
+        }
+    }
+}

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -52,7 +52,7 @@
 //! suitable for cases where the latency budget allows it (RSA blinding
 //! at 2048 bits is dominated by the main exponentiation anyway).
 
-use const_num_traits::{One, WrappingAdd, WrappingSub, Zero};
+use const_num_traits::{CtIsZero, CtParity, One, WrappingAdd, WrappingSub, Zero};
 use modmath_cios::CiosRowOps;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption};
 
@@ -72,14 +72,18 @@ pub(crate) const fn divsteps_total(modulus_bits: usize) -> usize {
 // ---------------------------------------------------------------------------
 
 /// Returns `Choice::from(1)` iff the low bit of `value` is set.
+///
+/// Delegates to cnt's [`CtParity`] on the low limb. The CT contract
+/// for "is this primitive odd" lives upstream; we compose by
+/// extracting `word(0)` (which is a primitive once the limb level is
+/// reached).
 #[inline]
 fn ct_low_bit<T>(value: &T) -> Choice
 where
     T: CiosRowOps,
-    T::Word: core::ops::BitAnd<Output = T::Word> + One + Zero + ConstantTimeEq,
+    T::Word: CtParity,
 {
-    let masked = value.word(0) & T::Word::one();
-    !masked.ct_eq(&T::Word::zero())
+    value.word(0).ct_is_odd()
 }
 
 /// Returns `Choice::from(1)` iff the most-significant bit of `value`'s
@@ -175,13 +179,17 @@ where
 
 /// Modular negate: `(m - x) mod m`, preserving the `[0, m)` invariant.
 /// Returns 0 when `x == 0` (since `-0 mod m = 0`).
+///
+/// Delegates to cnt's [`CtIsZero`] for the masked zero check rather
+/// than hand-rolling `ct_eq(&T::zero())`. Identical semantically; the
+/// dedicated trait is cnt-tested.
 #[inline]
 fn neg_mod_ct<T>(x: &T, m: &T) -> T
 where
-    T: Clone + Zero + ConditionallySelectable + WrappingSub<Output = T> + ConstantTimeEq,
+    T: Clone + Zero + ConditionallySelectable + WrappingSub<Output = T> + CtIsZero,
 {
     let zero = T::zero();
-    let x_is_zero = x.ct_eq(&zero);
+    let x_is_zero = x.ct_is_zero();
     let neg = m.clone().wrapping_sub(x.clone());
     T::conditional_select(&neg, &zero, x_is_zero)
 }
@@ -203,7 +211,7 @@ where
         + ConditionallySelectable
         + WrappingAdd<Output = T>
         + core::ops::Shr<usize, Output = T>,
-    T::Word: core::ops::BitAnd<Output = T::Word> + One + Zero + ConstantTimeEq,
+    T::Word: CtParity,
 {
     let x_odd = ct_low_bit(x);
     let x_plus_m = x.clone().wrapping_add(m.clone());
@@ -238,6 +246,7 @@ where
         + ConditionallySelectable
         + ConstantTimeEq
         + ConstantTimeLess
+        + CtIsZero
         + Zero
         + One
         + WrappingAdd<Output = T>
@@ -248,6 +257,7 @@ where
     T::Word: Copy
         + ConditionallySelectable
         + ConstantTimeEq
+        + CtParity
         + One
         + Zero
         + core::ops::BitAnd<Output = T::Word>

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -61,11 +61,20 @@ use const_num_traits::{CtIsZero, CtParity, One, WrappingAdd, WrappingSub, Zero};
 use modmath_cios::CiosRowOps;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption};
 
-/// Total number of divsteps for an `n`-bit operand. Per the paper
-/// (Theorem 11.2), `⌈(45·n + 64) / 19⌉` is the proven sufficient count.
-/// A small safety margin is added because the bound is tight.
+/// Total number of divsteps for an `n`-bit operand. Per Theorem 11.2
+/// of the Bernstein-Yang paper, for the *integer* case with δ₀=1 (our
+/// initialization at [`safegcd_inv_ct`]) the proven sufficient count
+/// is `⌊(49·n + 80)/17⌋` for `n < 46` and `⌊(49·n + 57)/17⌋` for
+/// `n ≥ 46`. Under-iterating causes worst-case coprime pairs to exit
+/// divsteps with `g ≠ 0`, silently masking valid inverses to `None`.
+/// (The `(45·n + 64)/19` bound is the *polynomial* case from Section
+/// 7 — not applicable here.)
 pub(crate) const fn divsteps_total(modulus_bits: usize) -> usize {
-    (45 * modulus_bits + 64).div_ceil(19) + 4
+    if modulus_bits < 46 {
+        (49 * modulus_bits + 80) / 17
+    } else {
+        (49 * modulus_bits + 57) / 17
+    }
 }
 
 /// Returns `Choice::from(1)` iff the low bit of `value` is set.
@@ -225,10 +234,13 @@ where
 /// `CtOption::None` masked when no inverse exists. The failure path
 /// timing is independent of input magnitudes.
 ///
+/// The `modulus is odd` and `modulus > 1` preconditions are folded
+/// into the returned mask: passing an even modulus or `1` yields
+/// `CtOption::None`, matching the behavior for "no inverse exists" —
+/// the divsteps loop still runs the full step count in constant time.
+///
 /// # Preconditions
 ///
-/// - `modulus` is odd
-/// - `modulus > 1`
 /// - `value < modulus` (caller should reduce first)
 /// - `2 * modulus` fits in `T` without overflow (i.e. `T` is at least
 ///   one bit wider than `modulus`)
@@ -315,7 +327,16 @@ where
     let neg_d = neg_mod_ct(&d, modulus);
     let result = T::conditional_select(&d, &neg_d, f_is_neg_one);
 
-    CtOption::new(result, has_inverse)
+    // Fold in the modulus preconditions. `half_mod_ct`'s (x + m) >> 1
+    // trick is invalid unless m is odd; modulus = 1 collapses residues
+    // to a single class. Divsteps still ran (constant time), the
+    // resulting `d`/`e` are garbage in those cases, and the mask
+    // discards them.
+    let modulus_is_odd = ct_low_bit(modulus);
+    let modulus_is_one = modulus.ct_eq(&one);
+    let modulus_ok = modulus_is_odd & !modulus_is_one;
+
+    CtOption::new(result, has_inverse & modulus_ok)
 }
 
 // Inline WrappingNeg-style two's-complement negate. const-num-traits'
@@ -464,6 +485,27 @@ mod tests {
                 let prod = (inv as u128 * v as u128) % m as u128;
                 assert_eq!(prod, 1, "u64 inv * value mod m != 1");
             }
+        }
+    }
+
+    /// Even modulus and modulus = 1 violate the algorithm's precondition
+    /// (`half_mod_ct`'s trick assumes odd m; modulus = 1 has a single
+    /// residue class). The mask folds those into CtOption::None.
+    #[test]
+    fn modulus_precondition_masks() {
+        for m in [2u32, 4, 6, 100, 0xFFFF_FFFE] {
+            for v in [1u32, 3, 7, 0xCAFE_BABE] {
+                assert!(
+                    safegcd_inv_ct::<u32>(&v, &m).into_option().is_none(),
+                    "even modulus {m:#x} with value {v:#x}: expected None"
+                );
+            }
+        }
+        for v in [0u32, 1, 7] {
+            assert!(
+                safegcd_inv_ct::<u32>(&v, &1u32).into_option().is_none(),
+                "modulus = 1 with value {v}: expected None"
+            );
         }
     }
 }

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -78,7 +78,9 @@ pub use montgomery::{
     type_bit_width,
     compute_n_prime_newton,
     compute_r_mod_n,
+    compute_r_mod_n_ct,
     compute_r2_mod_n,
+    compute_r2_mod_n_ct,
 };
 pub use montgomery::{CiosMontMul, CiosMontMulCt};
 

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -42,6 +42,7 @@
 mod add;
 mod exp;
 mod mul;
+mod nonct;
 mod parity;
 mod sub;
 mod wide_mul;
@@ -59,6 +60,7 @@ pub mod constrained;
 pub mod strict;
 
 pub use field::{Field, FieldCt, FieldNct, MontStorage, Residue, ResidueCt, ResidueNct};
+pub use nonct::NonCt;
 pub use parity::Parity;
 pub use wide_mul::WideMul;
 

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -439,7 +439,6 @@ where
 {
     let (doubled, overflow) = val.overflowing_add(val);
     let sub_result = doubled.wrapping_sub(modulus);
-    // needs_sub = overflow OR doubled >= modulus
     let doubled_ge_modulus = !doubled.ct_lt(&modulus);
     let needs_sub = Choice::from(overflow as u8) | doubled_ge_modulus;
     T::conditional_select(&doubled, &sub_result, needs_sub)
@@ -522,8 +521,6 @@ where
     for _ in 0..w {
         result = mod_double_ct(result, modulus);
     }
-    // Mask to zero when modulus == 1. CT replacement of the variable-time
-    // early return in `mod_exp2`.
     let m_is_one = modulus.ct_eq(&T::one());
     T::conditional_select(&result, &T::zero(), m_is_one)
 }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -1268,73 +1268,24 @@ where
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd(base, exponent, m))
 }
 
-/// Complete Montgomery modular exponentiation (Basic, CT, proven-odd
-/// modulus). **Infallible.** Same dispatch as
-/// [`basic_montgomery_mod_exp_ct`] but with the modulus parity proof
-/// hoisted into the type.
-pub fn basic_montgomery_mod_exp_odd_ct<T>(base: T, exponent: T, modulus: Odd<T>) -> T
-where
-    T: Copy
-        + const_num_traits::Zero
-        + const_num_traits::One
-        + PartialEq
-        + PartialOrd
-        + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + Parity
-        + const_num_traits::CtIsZero
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::Shr<usize, Output = T>
-        + core::ops::BitAnd<Output = T>
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
-        + subtle::ConstantTimeLess,
-{
-    let m = modulus.get();
-    basic_montgomery_mod_exp_pr_odd_ct(reduce_mod(base, m), exponent, modulus)
-}
-
-/// Complete Montgomery modular exponentiation (Basic, CT): base^exponent mod modulus
-///
-/// Reduces `base` modulo `modulus` then dispatches to
-/// [`crate::basic::montgomery::ct::pre_reduced::mod_exp`]. Use this when the
-/// exponent (and possibly the base) is secret — e.g. RSA private-key
-/// operations.
-///
-/// Returns None if modulus is even or zero. Thin wrapper around
-/// [`basic_montgomery_mod_exp_odd_ct`].
-pub fn basic_montgomery_mod_exp_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
-where
-    T: Copy
-        + const_num_traits::Zero
-        + const_num_traits::One
-        + PartialEq
-        + PartialOrd
-        + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + const_num_traits::CtIsZero
-        + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
-        + core::ops::Shr<usize, Output = T>
-        + core::ops::BitAnd<Output = T>
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
-        + subtle::ConstantTimeLess,
-{
-    Odd::new(modulus).map(|m| basic_montgomery_mod_exp_odd_ct(base, exponent, m))
-}
+// NOTE: `basic_montgomery_mod_exp_odd_ct` and `basic_montgomery_mod_exp_ct`
+// previously lived here as convenience wrappers that reduced `base mod
+// modulus` internally before dispatching to the `_pr` Ct kernel. Both
+// called `reduce_mod(base, m)` which uses `core::ops::Rem` — on
+// primitives that's hardware-variable on common embedded targets
+// (Cortex-M0/M3/M4), leaking the base magnitude. The "CT over base"
+// docstring claim was therefore false on the carriers it actually
+// compiled for (FixedUInt<W, N, Ct> doesn't impl Rem at all, so the
+// functions only compiled for primitive moduli, where they leaked).
+//
+// Removed in the CT_GET_WELL_PLAN Tier 1.3 cut. Callers should
+// pre-reduce externally and dispatch to
+// [`basic_montgomery_mod_exp_pr_odd_ct`] (proven-odd modulus) or
+// [`basic_montgomery_mod_exp_pr_ct`] (runtime parity check). The
+// "external pre-reduce" is a documented precondition on the `_pr`
+// kernel anyway — callers that need CT over base should be using the
+// Field<T, Ct> high-level surface (`Field::reduce`, `Field::exp`)
+// which composes CT-only primitives end to end.
 
 /// Complete Montgomery modular exponentiation (Basic, CT, pre-reduced):
 /// base^exponent mod modulus, constant-time over `exponent` (and `base`).
@@ -2279,16 +2230,22 @@ mod tests {
         }
     }
 
-    /// basic_montgomery_mod_exp_ct must produce the same output as the NCT
-    /// version for all inputs, on a primitive type.
+    /// basic_montgomery_mod_exp_pr_ct must produce the same output as
+    /// the NCT version when the caller pre-reduces base. Replaces the
+    /// prior `basic_montgomery_mod_exp_ct_matches_nct_u32` test
+    /// (deleted with its target function — see Tier 1.3 of the
+    /// CT_GET_WELL_PLAN).
     #[test]
-    fn test_basic_montgomery_mod_exp_ct_matches_nct_u32() {
+    fn test_basic_montgomery_mod_exp_pr_ct_matches_nct_u32_with_external_reduce() {
         let modulus = 13u32;
         for base in 0u32..modulus {
             for exp in 0u32..32 {
                 let nct = basic_montgomery_mod_exp(base, exp, modulus).unwrap();
-                let ct = basic_montgomery_mod_exp_ct(base, exp, modulus).unwrap();
-                assert_eq!(nct, ct, "mod_exp_ct mismatch at base={base} exp={exp}");
+                // External pre-reduction: caller's responsibility on
+                // the CT path. Inputs are already in [0, modulus) for
+                // this test, so the `% modulus` is a no-op observable.
+                let ct = basic_montgomery_mod_exp_pr_ct(base % modulus, exp, modulus).unwrap();
+                assert_eq!(nct, ct, "mod_exp_pr_ct mismatch at base={base} exp={exp}");
             }
         }
     }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -395,6 +395,11 @@ pub const fn type_bit_width<T>() -> usize {
 }
 
 /// Modular doubling: (val + val) mod modulus, handling overflow.
+///
+/// **Variable-time.** Branches on the `overflow || doubled >= modulus`
+/// magnitude check; used by [`compute_r_mod_n`] / [`compute_r2_mod_n`]
+/// for the Nct precompute path where the modulus is public. For the Ct
+/// path (secret modulus), see [`mod_double_ct`].
 fn mod_double<T>(val: T, modulus: T) -> T
 where
     T: Copy
@@ -410,6 +415,30 @@ where
     } else {
         doubled
     }
+}
+
+/// CT modular doubling: `(val + val) mod modulus`, no value-dependent
+/// branches. Always computes both the post-sub and pre-sub candidates,
+/// selects via `subtle::Choice`.
+///
+/// Used by [`compute_r_mod_n_ct`] / [`compute_r2_mod_n_ct`] for the Ct
+/// precompute path called from [`Field::new_odd_ct`].
+fn mod_double_ct<T>(val: T, modulus: T) -> T
+where
+    T: Copy
+        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingSub
+        + core::ops::Add<Output = T>
+        + core::ops::Sub<Output = T>
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+{
+    let (doubled, overflow) = val.overflowing_add(val);
+    let sub_result = doubled.wrapping_sub(modulus);
+    // needs_sub = overflow OR doubled >= modulus
+    let doubled_ge_modulus = !doubled.ct_lt(&modulus);
+    let needs_sub = Choice::from(overflow as u8) | doubled_ge_modulus;
+    T::conditional_select(&doubled, &sub_result, needs_sub)
 }
 
 /// Newton's method for N' = -N^{-1} mod 2^W.
@@ -441,6 +470,9 @@ where
 }
 
 /// Compute (val * 2^w) mod N via w modular doublings.
+///
+/// **Variable-time** (delegates to [`mod_double`]). Used for the Nct
+/// precompute path; for the Ct path see [`mod_exp2_ct`].
 fn mod_exp2<T>(val: T, modulus: T, w: usize) -> T
 where
     T: Copy
@@ -464,7 +496,39 @@ where
     result
 }
 
+/// CT modular doubling iterated `w` times: `val · 2^w mod modulus`.
+/// Constant-time over `val` and `modulus`. The `modulus == 1` edge
+/// case (every value reduces to 0) is handled branchlessly via a
+/// final `conditional_select` rather than the variable-time early
+/// return in [`mod_exp2`].
+fn mod_exp2_ct<T>(val: T, modulus: T, w: usize) -> T
+where
+    T: Copy
+        + const_num_traits::Zero
+        + const_num_traits::One
+        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingSub
+        + core::ops::Add<Output = T>
+        + core::ops::Sub<Output = T>
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + subtle::ConstantTimeLess,
+{
+    let mut result = val;
+    for _ in 0..w {
+        result = mod_double_ct(result, modulus);
+    }
+    // Mask to zero when modulus == 1. CT replacement of the variable-time
+    // early return in `mod_exp2`.
+    let m_is_one = modulus.ct_eq(&T::one());
+    T::conditional_select(&result, &T::zero(), m_is_one)
+}
+
 /// Compute R mod N = 2^W mod N via W modular doublings starting from 1.
+///
+/// **Variable-time.** Used by [`Field::new_odd`] for the Nct precompute
+/// path (public modulus); the CT sibling [`compute_r_mod_n_ct`] is
+/// used by [`Field::new_odd_ct`] when the modulus is secret.
 pub fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
 where
     T: Copy
@@ -480,7 +544,28 @@ where
     mod_exp2(T::one(), modulus, w)
 }
 
+/// CT version of [`compute_r_mod_n`]: `2^W mod modulus` with no
+/// value-dependent branches. Used by [`Field::new_odd_ct`] for the
+/// secret-modulus precompute path.
+pub fn compute_r_mod_n_ct<T>(modulus: T, w: usize) -> T
+where
+    T: Copy
+        + const_num_traits::Zero
+        + const_num_traits::One
+        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingSub
+        + core::ops::Add<Output = T>
+        + core::ops::Sub<Output = T>
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + subtle::ConstantTimeLess,
+{
+    mod_exp2_ct(T::one(), modulus, w)
+}
+
 /// Compute R^2 mod N via W more modular doublings from (R mod N).
+///
+/// **Variable-time.** See [`compute_r2_mod_n_ct`] for the CT sibling.
 pub fn compute_r2_mod_n<T>(r_mod_n: T, modulus: T, w: usize) -> T
 where
     T: Copy
@@ -494,6 +579,24 @@ where
         + core::ops::Sub<Output = T>,
 {
     mod_exp2(r_mod_n, modulus, w)
+}
+
+/// CT version of [`compute_r2_mod_n`]: `R² mod modulus` via W modular
+/// doublings from `R mod N`. No value-dependent branches.
+pub fn compute_r2_mod_n_ct<T>(r_mod_n: T, modulus: T, w: usize) -> T
+where
+    T: Copy
+        + const_num_traits::Zero
+        + const_num_traits::One
+        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingSub
+        + core::ops::Add<Output = T>
+        + core::ops::Sub<Output = T>
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + subtle::ConstantTimeLess,
+{
+    mod_exp2_ct(r_mod_n, modulus, w)
 }
 
 /// Accumulate the high half with carries from low-half addition.

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -1182,6 +1182,7 @@ where
         + const_num_traits::WrappingAdd
         + const_num_traits::WrappingSub
         + Parity
+        + const_num_traits::CtIsZero
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -1217,6 +1218,7 @@ where
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingAdd
         + const_num_traits::WrappingSub
+        + const_num_traits::CtIsZero
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1265,6 +1267,7 @@ where
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingAdd
         + const_num_traits::WrappingSub
+        + const_num_traits::CtIsZero
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1301,8 +1304,10 @@ where
 
         // Extract bit i of exponent (i is public; the shift amount is the
         // loop index, not derived from exp). Bit value is secret.
+        // Delegates to cnt's CtIsZero for the masked "is bit set" check
+        // rather than hand-rolling ct_eq(&one).
         let bit_t = (exponent >> i) & one;
-        let choice = bit_t.ct_eq(&one);
+        let choice = !bit_t.ct_is_zero();
         result = T::conditional_select(&result, &multiplied, choice);
     }
 
@@ -1324,6 +1329,7 @@ where
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingAdd
         + const_num_traits::WrappingSub
+        + const_num_traits::CtIsZero
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -1272,25 +1272,6 @@ where
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd(base, exponent, m))
 }
 
-// NOTE: `basic_montgomery_mod_exp_odd_ct` and `basic_montgomery_mod_exp_ct`
-// previously lived here as convenience wrappers that reduced `base mod
-// modulus` internally before dispatching to the `_pr` Ct kernel. Both
-// called `reduce_mod(base, m)` which uses `core::ops::Rem` — on
-// primitives that's hardware-variable on common embedded targets
-// (Cortex-M0/M3/M4), leaking the base magnitude. The "CT over base"
-// docstring claim was therefore false on the carriers it actually
-// compiled for (FixedUInt<W, N, Ct> doesn't impl Rem at all, so the
-// functions only compiled for primitive moduli, where they leaked).
-//
-// Removed in the CT_GET_WELL_PLAN Tier 1.3 cut. Callers should
-// pre-reduce externally and dispatch to
-// [`basic_montgomery_mod_exp_pr_odd_ct`] (proven-odd modulus) or
-// [`basic_montgomery_mod_exp_pr_ct`] (runtime parity check). The
-// "external pre-reduce" is a documented precondition on the `_pr`
-// kernel anyway — callers that need CT over base should be using the
-// Field<T, Ct> high-level surface (`Field::reduce`, `Field::exp`)
-// which composes CT-only primitives end to end.
-
 /// Complete Montgomery modular exponentiation (Basic, CT, pre-reduced):
 /// base^exponent mod modulus, constant-time over `exponent` (and `base`).
 ///
@@ -1362,8 +1343,6 @@ where
 
         // Extract bit i of exponent (i is public; the shift amount is the
         // loop index, not derived from exp). Bit value is secret.
-        // Delegates to cnt's CtIsZero for the masked "is bit set" check
-        // rather than hand-rolling ct_eq(&one).
         let bit_t = (exponent >> i) & one;
         let choice = !bit_t.ct_is_zero();
         result = T::conditional_select(&result, &multiplied, choice);
@@ -2235,10 +2214,7 @@ mod tests {
     }
 
     /// basic_montgomery_mod_exp_pr_ct must produce the same output as
-    /// the NCT version when the caller pre-reduces base. Replaces the
-    /// prior `basic_montgomery_mod_exp_ct_matches_nct_u32` test
-    /// (deleted with its target function — see Tier 1.3 of the
-    /// CT_GET_WELL_PLAN).
+    /// the NCT version when the caller pre-reduces base.
     #[test]
     fn test_basic_montgomery_mod_exp_pr_ct_matches_nct_u32_with_external_reduce() {
         let modulus = 13u32;

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -249,7 +249,8 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>
-        + crate::parity::Parity,
+        + crate::parity::Parity
+        + crate::NonCt,
 {
     crate::mul::basic_mod_mul(a, r, modulus)
 }
@@ -267,7 +268,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::parity::Parity,
+        + crate::parity::Parity
+        + crate::NonCt,
 {
     crate::mul::basic_mod_mul_pr(a, r, modulus)
 }
@@ -346,7 +348,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + crate::parity::Parity,
+        + crate::parity::Parity
+        + crate::NonCt,
 {
     // Montgomery multiplication algorithm:
     // Input: a_mont, b_mont (both in Montgomery form), modulus N, N', r_bits
@@ -379,7 +382,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + crate::parity::Parity,
+        + crate::parity::Parity
+        + crate::NonCt,
 {
     let product = crate::mul::basic_mod_mul_pr(a_mont, b_mont, modulus);
     basic_from_montgomery(product, modulus, n_prime, r_bits)

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -12,7 +12,7 @@ use const_num_traits::ops::ct::CtIsZero;
 use const_num_traits::ops::overflowing::OverflowingAdd;
 use const_num_traits::{One, WrappingMul, Zero};
 use modmath_cios::CiosRowOps;
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use subtle::{Choice, ConditionallySelectable};
 
 /// CIOS Montgomery multiplication — variable-time: `a * b * R⁻¹ mod modulus`.
 ///

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -8,6 +8,7 @@
 //! two CIOS row kernels. modmath never touches raw limb arrays.
 
 use const_num_traits::BorrowingSub;
+use const_num_traits::ops::ct::CtIsZero;
 use const_num_traits::ops::overflowing::OverflowingAdd;
 use const_num_traits::{One, WrappingMul, Zero};
 use modmath_cios::CiosRowOps;
@@ -97,6 +98,7 @@ where
     T::Word: const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingMul
+        + const_num_traits::CtIsZero
         + const_num_traits::ops::overflowing::OverflowingAdd
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>
@@ -130,8 +132,11 @@ where
         acc_hi2 = zero;
     }
 
+    // Final reduction. Delegates to cnt's CtIsZero on the high word and
+    // subtle's Choice arithmetic; the borrow flag from BorrowingSub already
+    // encodes `acc < modulus` (no separate compare needed).
     let (sub_result, borrow) = <T as BorrowingSub>::borrowing_sub(acc, *modulus, false);
-    let acc_hi_nonzero = !acc_hi.ct_eq(&zero);
+    let acc_hi_nonzero = !acc_hi.ct_is_zero();
     let needs_sub = acc_hi_nonzero | !Choice::from(borrow as u8);
     T::conditional_select(&acc, &sub_result, needs_sub)
 }
@@ -186,6 +191,7 @@ where
     T::Word: const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingMul
+        + const_num_traits::CtIsZero
         + const_num_traits::ops::overflowing::OverflowingAdd
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -132,9 +132,8 @@ where
         acc_hi2 = zero;
     }
 
-    // Final reduction. Delegates to cnt's CtIsZero on the high word and
-    // subtle's Choice arithmetic; the borrow flag from BorrowingSub already
-    // encodes `acc < modulus` (no separate compare needed).
+    // Final reduction: the borrow flag from BorrowingSub already
+    // encodes `acc < modulus` — no separate compare needed.
     let (sub_result, borrow) = <T as BorrowingSub>::borrowing_sub(acc, *modulus, false);
     let acc_hi_nonzero = !acc_hi.ct_is_zero();
     let needs_sub = acc_hi_nonzero | !Choice::from(borrow as u8);

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -224,7 +224,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::parity::Parity,
+        + crate::parity::Parity
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -305,6 +306,7 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::parity::Parity
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
@@ -339,6 +341,7 @@ where
         + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -379,6 +382,7 @@ where
         + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -416,6 +420,7 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Add<&'a T, Output = T>
@@ -479,6 +484,7 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Add<&'a T, Output = T>

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -1,3 +1,7 @@
+// Clippy's `clone_on_copy` / `op_ref` lints misfire on the constrained
+// flavor's generic Clone / Add<&T, Output=T> idioms.
+#![allow(clippy::clone_on_copy, clippy::op_ref)]
+
 // Constrained Montgomery arithmetic functions
 // These work with references to avoid unnecessary copies, following the pattern from exp.rs
 

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -37,7 +37,9 @@ pub use basic_mont::{
     type_bit_width,
     compute_n_prime_newton,
     compute_r_mod_n,
+    compute_r_mod_n_ct,
     compute_r2_mod_n,
+    compute_r2_mod_n_ct,
 };
 
 // Re-export the CIOS traits as the canonical entry point for consumers.

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -288,7 +288,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::RemAssign<&'a T>
         + core::ops::Sub<&'a T, Output = T>,
@@ -373,7 +374,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -403,6 +405,7 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Mul<&'a T, Output = T>
@@ -468,6 +471,7 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
+        + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Mul<&'a T, Output = T>
@@ -510,7 +514,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
@@ -590,7 +595,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -1,3 +1,9 @@
+// Clippy's `op_ref` / `clone_on_copy` lints misfire on the strict
+// flavor's `&x + &T::zero()` "portable clone" and generic `.clone()`
+// idioms — the ref forms are load-bearing when T only impls
+// `Add<&T, Output=T>` / `Clone`, not `Copy`.
+#![allow(clippy::clone_on_copy, clippy::op_ref)]
+
 /// Compute N' using trial search method - O(R) complexity (Strict)
 /// Finds N' such that modulus * N' ≡ -1 (mod R)
 /// Uses reference-based operations to minimize copying of large integers

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -65,7 +65,8 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + core::ops::Rem<Output = T>,
+        + core::ops::Rem<Output = T>
+        + crate::NonCt,
 {
     basic_mod_mul_pr(a % m, b % m, m)
 }
@@ -108,7 +109,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     basic_mod_mul_pr(a.rem_nonzero(m), b.rem_nonzero(m), m_raw)
@@ -131,7 +133,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     let m1 = m;
     let mut result = T::zero();
@@ -176,7 +179,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -199,7 +203,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = (*b).rem_nonzero(m);
@@ -220,7 +225,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     // Need an owned mutable T for the double-and-add loop's right-shift;
     // mirror the `exp_pr` convention of cloning via wrapping_add(zero).
@@ -270,7 +276,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = (*b).rem_nonzero(m);
@@ -288,7 +295,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -311,7 +319,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>,
+        + core::ops::Shr<usize, Output = T>
+        + crate::NonCt,
 {
     // Need an owned mutable T for the double-and-add loop's right-shift;
     // mirror the `exp_pr` convention of cloning via overflowing_add(zero).

--- a/modmath/src/nonct.rs
+++ b/modmath/src/nonct.rs
@@ -74,14 +74,13 @@ mod fixed_bigint_impl {
 #[cfg(test)]
 mod tests {
     use super::NonCt;
-    use const_num_traits::Nct;
-    use fixed_bigint::FixedUInt;
 
-    /// Compile-check: primitives and Nct-personality FixedUInt impl NonCt.
-    /// The Ct-personality non-impl is documented in the module docstring;
-    /// a compile-fail test fixture is the correct place to enforce it.
+    /// Compile-check: primitives impl NonCt. FixedUInt<_, _, Nct> impl
+    /// lives behind the `fixed-bigint` feature; the Ct-personality
+    /// non-impl is documented in the module docstring and belongs in a
+    /// compile-fail fixture.
     #[test]
-    fn nonct_impl_check() {
+    fn nonct_impl_check_primitives() {
         fn assert_nonct<T: NonCt>() {}
         assert_nonct::<u8>();
         assert_nonct::<u16>();
@@ -89,6 +88,14 @@ mod tests {
         assert_nonct::<u64>();
         assert_nonct::<u128>();
         assert_nonct::<usize>();
+    }
+
+    #[cfg(feature = "fixed-bigint")]
+    #[test]
+    fn nonct_impl_check_fixed_bigint() {
+        use const_num_traits::Nct;
+        use fixed_bigint::FixedUInt;
+        fn assert_nonct<T: NonCt>() {}
         assert_nonct::<FixedUInt<u32, 4, Nct>>();
         assert_nonct::<FixedUInt<u32, 8, Nct>>();
     }

--- a/modmath/src/nonct.rs
+++ b/modmath/src/nonct.rs
@@ -69,19 +69,17 @@ mod fixed_bigint_impl {
 
     impl<W: MachineWord, const N: usize> sealed::Sealed for FixedUInt<W, N, Nct> {}
     impl<W: MachineWord, const N: usize> NonCt for FixedUInt<W, N, Nct> {}
-
-    // Deliberately NO impl for FixedUInt<W, N, Ct>. Calling
-    // variable-time algorithms with Ct-personality carriers must be a
-    // compile error.
 }
 
 #[cfg(test)]
 mod tests {
     use super::NonCt;
-    use const_num_traits::{Ct, Nct};
+    use const_num_traits::Nct;
     use fixed_bigint::FixedUInt;
 
     /// Compile-check: primitives and Nct-personality FixedUInt impl NonCt.
+    /// The Ct-personality non-impl is documented in the module docstring;
+    /// a compile-fail test fixture is the correct place to enforce it.
     #[test]
     fn nonct_impl_check() {
         fn assert_nonct<T: NonCt>() {}
@@ -93,9 +91,5 @@ mod tests {
         assert_nonct::<usize>();
         assert_nonct::<FixedUInt<u32, 4, Nct>>();
         assert_nonct::<FixedUInt<u32, 8, Nct>>();
-        // FixedUInt<_, _, Ct> does NOT impl NonCt — uncommenting the
-        // line below must fail to compile.
-        // assert_nonct::<FixedUInt<u32, 4, Ct>>();
-        let _ = core::marker::PhantomData::<Ct>;
     }
 }

--- a/modmath/src/nonct.rs
+++ b/modmath/src/nonct.rs
@@ -1,13 +1,13 @@
 //! Sealed marker for "this type is not the Ct personality" — i.e.
 //! safe to use in variable-time algorithms.
 //!
-//! Closes the gap that the `_pr` schoolbook family had: those entries
-//! don't bound on `Rem` / `Div` (because the precondition is that the
-//! caller pre-reduced), so the missing-`Rem`-impl gate that blocks Ct
-//! on the non-`_pr` surface doesn't apply. The variable-time bodies
-//! (`while b > zero { if b.is_odd() ... ; b >>= 1; }`) silently
-//! accepted Ct operands and leaked through the loop count and per-bit
-//! branch.
+//! Closes the gap in the `_pr` schoolbook family: those entries don't
+//! bound on `Rem` / `Div` (their precondition is that the caller
+//! pre-reduced), so the missing-`Rem`-impl gate that blocks Ct on the
+//! non-`_pr` surface doesn't apply. Without this marker, the
+//! variable-time bodies (`while b > zero { if b.is_odd() ... ; b >>=
+//! 1; }`) would admit Ct operands and leak through the loop count and
+//! per-bit branch.
 //!
 //! `T: NonCt` is the bound that gates those entries. Impl'd for the
 //! primitives (conventionally Nct — variable-time at the hardware
@@ -93,10 +93,8 @@ mod tests {
         assert_nonct::<usize>();
         assert_nonct::<FixedUInt<u32, 4, Nct>>();
         assert_nonct::<FixedUInt<u32, 8, Nct>>();
-        // FixedUInt<_, _, Ct> does NOT impl NonCt — verified by the
-        // compile-fail test in `tests/compile_fail_nonct.rs` (or by
-        // observation: uncommenting the line below should fail to
-        // compile).
+        // FixedUInt<_, _, Ct> does NOT impl NonCt — uncommenting the
+        // line below must fail to compile.
         // assert_nonct::<FixedUInt<u32, 4, Ct>>();
         let _ = core::marker::PhantomData::<Ct>;
     }

--- a/modmath/src/nonct.rs
+++ b/modmath/src/nonct.rs
@@ -1,0 +1,103 @@
+//! Sealed marker for "this type is not the Ct personality" — i.e.
+//! safe to use in variable-time algorithms.
+//!
+//! Closes the gap that the `_pr` schoolbook family had: those entries
+//! don't bound on `Rem` / `Div` (because the precondition is that the
+//! caller pre-reduced), so the missing-`Rem`-impl gate that blocks Ct
+//! on the non-`_pr` surface doesn't apply. The variable-time bodies
+//! (`while b > zero { if b.is_odd() ... ; b >>= 1; }`) silently
+//! accepted Ct operands and leaked through the loop count and per-bit
+//! branch.
+//!
+//! `T: NonCt` is the bound that gates those entries. Impl'd for the
+//! primitives (conventionally Nct — variable-time at the hardware
+//! level on common cores) and for `FixedUInt<W, N, Nct>`. Deliberately
+//! **not** impl'd for `FixedUInt<W, N, Ct>`, so attempts to call
+//! variable-time entries with a `Ct`-personality carrier fail to
+//! compile.
+//!
+//! ## Why a modmath-local marker
+//!
+//! Conceptually adjacent to `const_num_traits::Personality`, but with
+//! a different consumer surface: the personality trait describes the
+//! type's CT shape; `NonCt` gates downstream algorithm choice on it.
+//! Both can coexist — the personality is the *attribute*, `NonCt` is
+//! the *gate that consumes it*.
+//!
+//! Lives in modmath rather than cnt because (a) it's a modmath-
+//! specific gate, (b) the alternative (adding a `HasPersonality`
+//! projection trait to cnt + primitive impls + FB impls) is three
+//! crates' worth of coordination for the same enforcement guarantee,
+//! and (c) if a second consumer crate ever wants the same vocabulary,
+//! we can promote to cnt then. For now, modmath-local.
+
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
+/// Sealed marker for "type is not Ct-personality and is therefore
+/// allowed to flow through variable-time algorithms in modmath."
+///
+/// Implemented for primitives (`u8`/`u16`/`u32`/`u64`/`u128`/`usize`)
+/// and, with the `fixed-bigint` feature enabled (on by default), for
+/// `fixed_bigint::FixedUInt<W, N, Nct>`. Not implemented for
+/// `FixedUInt<W, N, Ct>` — that's the whole point.
+///
+/// Used as a bound on the variable-time `_pr` schoolbook entries in
+/// `add.rs`, `sub.rs`, `mul.rs`, `exp.rs` and on the variable-time
+/// Montgomery `_pr` family in `basic_mont.rs`. The bound is a sealed
+/// trait so downstreams can't bypass it by impl'ing `NonCt` for a Ct
+/// carrier.
+pub trait NonCt: sealed::Sealed {}
+
+macro_rules! impl_nonct_primitive {
+    ($($t:ty),*) => {
+        $(
+            impl sealed::Sealed for $t {}
+            impl NonCt for $t {}
+        )*
+    };
+}
+
+impl_nonct_primitive!(u8, u16, u32, u64, u128, usize);
+
+#[cfg(feature = "fixed-bigint")]
+mod fixed_bigint_impl {
+    use super::{NonCt, sealed};
+    use const_num_traits::Nct;
+    use fixed_bigint::{FixedUInt, MachineWord};
+
+    impl<W: MachineWord, const N: usize> sealed::Sealed for FixedUInt<W, N, Nct> {}
+    impl<W: MachineWord, const N: usize> NonCt for FixedUInt<W, N, Nct> {}
+
+    // Deliberately NO impl for FixedUInt<W, N, Ct>. Calling
+    // variable-time algorithms with Ct-personality carriers must be a
+    // compile error.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NonCt;
+    use const_num_traits::{Ct, Nct};
+    use fixed_bigint::FixedUInt;
+
+    /// Compile-check: primitives and Nct-personality FixedUInt impl NonCt.
+    #[test]
+    fn nonct_impl_check() {
+        fn assert_nonct<T: NonCt>() {}
+        assert_nonct::<u8>();
+        assert_nonct::<u16>();
+        assert_nonct::<u32>();
+        assert_nonct::<u64>();
+        assert_nonct::<u128>();
+        assert_nonct::<usize>();
+        assert_nonct::<FixedUInt<u32, 4, Nct>>();
+        assert_nonct::<FixedUInt<u32, 8, Nct>>();
+        // FixedUInt<_, _, Ct> does NOT impl NonCt — verified by the
+        // compile-fail test in `tests/compile_fail_nonct.rs` (or by
+        // observation: uncommenting the line below should fail to
+        // compile).
+        // assert_nonct::<FixedUInt<u32, 4, Ct>>();
+        let _ = core::marker::PhantomData::<Ct>;
+    }
+}

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -36,7 +36,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Rem<Output = T>,
+        + core::ops::Rem<Output = T>
+        + crate::NonCt,
 {
     basic_mod_sub_pr(a % m, b % m, m)
 }
@@ -51,7 +52,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     basic_mod_sub_pr(a.rem_nonzero(m), b.rem_nonzero(m), m_raw)
@@ -66,7 +68,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let diff = a.wrapping_sub(b);
     if diff > a {
@@ -87,7 +90,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     let a_mod = &a % m;
@@ -105,7 +109,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = (*b).rem_nonzero(m);
@@ -121,7 +126,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd
         + const_num_traits::ops::wrapping::WrappingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let diff = a.wrapping_sub(*b);
     if diff > a {
@@ -142,7 +148,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -161,7 +168,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = (*b).rem_nonzero(m);
@@ -177,7 +185,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::ops::overflowing::OverflowingSub
         + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + crate::NonCt,
 {
     let (diff, overflow) = a.overflowing_sub(*b);
     if overflow {


### PR DESCRIPTION
## Summary by Sourcery

Introduce a constant-time modular inversion and precompute path for secret moduli, tighten constant‑time guarantees across Montgomery and field operations, and add a NonCt marker to prevent misuse of variable‑time APIs with constant‑time personalities.

New Features:
- Add `Field::new_odd_ct` and supporting CT precompute helpers for Montgomery parameters over secret odd moduli.
- Add `Field::inv_safegcd_ct` implementing Bernstein–Yang safegcd modular inversion for arbitrary (including composite) moduli.
- Expose CT variants of `compute_r_mod_n` and `compute_r2_mod_n` for constant‑time Montgomery precomputation.
- Introduce a `NonCt` marker trait (with primitive and FixedUInt Nct implementations) to gate variable‑time arithmetic APIs away from Ct‑personality types.

Bug Fixes:
- Make `Field::inv_fermat` truly constant‑time by removing the early zero check and returning a `CtOption` masked on zero‑ness.
- Fix final reduction in CIOS Montgomery multiplication to use CtIsZero on the high word instead of ConstantTimeEq, maintaining constant‑time behaviour.

Enhancements:
- Update exponentiation routines to rely on `CtIsZero` for masked bit checks, simplifying and clarifying constant‑time semantics.
- Refine `Field::exp` and basic Montgomery CT exponentiation to use carrier bit‑width based ladders and clearer documentation of timing behaviour.
- Remove leaking convenience wrappers for CT Montgomery exponentiation and direct callers to pre‑reduced CT kernels or the high‑level `Field<T, Ct>` APIs.
- Document and enforce modulus headroom requirements (2·modulus ≤ T::MAX) in safegcd‑based inversion and its field wrapper.
- Relax clippy lints in strict and constrained Montgomery modules to support generic Clone/Add idioms without false positives.

Build:
- Move `const-num-traits` from a git dependency to the released `0.1.0` crate and hook its nightly feature into the crate's nightly feature flag.
- Add an optional `fixed-bigint` dependency, enabled by default, to support the `NonCt` implementation for FixedUInt and wire it into the `nightly` feature.
- Update the Rust CI matrix to 1.86 and simplify clippy and test runs by removing the `wide-mul` feature variants.

CI:
- Simplify coverage workflow to run `cargo llvm-cov` without the `wide-mul` feature, aligning it with the streamlined feature set.

Documentation:
- Improve and expand documentation around CT vs NCT Montgomery APIs, field inversion methods, and safegcd’s algorithmic shape and preconditions, including RSA blinding use cases.

Tests:
- Add tests verifying CT precompute (`new_odd_ct`) matches the variable‑time precompute on primitives and FixedUInt carriers.
- Add extensive tests for `inv_safegcd_ct` over prime and composite moduli, including headroom‑failure masking and multi‑limb FixedUInt cases.
- Adjust Fermat‑inverse tests to the new `CtOption` return type and ensure zero residues are correctly masked as non‑invertible.
- Update Montgomery exponentiation tests to validate CT pre‑reduced behaviour against the NCT path under external base reduction.
- Add compile‑time tests confirming `NonCt` is implemented for primitives and FixedUInt Nct but not for Ct‑personality FixedUInt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added constant-time modular inverse support and expanded constant-time field operations.
  * Improved Montgomery math support with new constant-time precompute and exponentiation paths.
  * Added broader support for non-constant-time and constant-time type separation in modular arithmetic APIs.

* **Bug Fixes**
  * Tightened several modular add, sub, mul, and exp operations to use the appropriate type constraints.
  * Updated test and CI coverage to reflect the new behavior and feature set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->