### PR TITLE
Backend-agnostic docs, _odd hub exports, latent warning cleanup

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -31,12 +31,15 @@ jobs:
           components: rustfmt, clippy
     - name: Check formatting
       if: matrix.rust == 'stable'
-      working-directory: modmath
-      run: cargo fmt -- --check
+      run: cargo fmt --all -- --check
     - name: Run clippy
       if: matrix.rust == 'stable'
-      working-directory: modmath
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --workspace --all-targets -- -D warnings
+    - name: Check docs
+      if: matrix.rust == 'stable'
+      run: cargo doc --workspace --no-deps
+      env:
+        RUSTDOCFLAGS: -D warnings
     - name: Build
       working-directory: modmath
       run: cargo build

--- a/README.md
+++ b/README.md
@@ -24,10 +24,3 @@ to work with multiple implementations.
 Note: While `const` traits are not yet stable and commonplace, this cannot
 be very efficient. In almost all real world code you'll want to directly use
 crates that implement big integers with `const` functions.
-
-### Tested with
-
-Tested with built-in integers and [`fixed-bigint`](https://crates.io/crates/fixed-bigint).
-Other backends ([`num-bigint`](https://crates.io/crates/num-bigint), [`crypto-bigint`](https://crates.io/crates/crypto-bigint), [`bnum`](https://crates.io/crates/bnum), [`ibig`](https://crates.io/crates/ibig))
-were exercised on the 0.3.x line; their coverage returns once they
-implement the `const-num-traits` surface.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ The code isn't intended to be fast or efficient, just as generic as possible
 to work with multiple implementations.
 
 Note: While `const` traits are not yet stable and commonplace, this cannot
-be verify efficient. In almost all real world code you'll want to direcyl use
+be very efficient. In almost all real world code you'll want to directly use
 crates that implement big integers with `const` functions.
 
 ### Tested with
 
-Tested with [`num-bigint`](https://crates.io/crates/num-bigint), [`crypto-bigint`](https://crates.io/crates/crypto-bigint), [`bnum`](https://crates.io/crates/bnum), [`ibig`](https://crates.io/crates/ibig)
-and [`fixed-bigint`](https://crates.io/crates/fixed-bigint) crates.
+Tested with built-in integers and [`fixed-bigint`](https://crates.io/crates/fixed-bigint).
+Other backends ([`num-bigint`](https://crates.io/crates/num-bigint), [`crypto-bigint`](https://crates.io/crates/crypto-bigint), [`bnum`](https://crates.io/crates/bnum), [`ibig`](https://crates.io/crates/ibig))
+were exercised on the 0.3.x line; their coverage returns once they
+implement the `const-num-traits` surface.

--- a/modmath-cios/src/lib.rs
+++ b/modmath-cios/src/lib.rs
@@ -1,27 +1,21 @@
 //! Row-op trait surface for CIOS Montgomery multiplication.
 //!
-//! Defines [`CiosRowOps`] — the abstraction the CIOS algorithm body in
-//! `modmath` drives — plus the single-word degenerate impls for
-//! `u8`/`u16`/`u32`/`u64`. Multi-limb backends (e.g. `fixed-bigint`'s
-//! `FixedUInt`) implement the trait on their own type.
+//! [`CiosRowOps`] is the minimal interface a multi-limb integer type
+//! exposes so a CIOS (Coarsely Integrated Operand Scanning) Montgomery
+//! multiplication loop can drive it: limb access plus the two fused
+//! row kernels. The algorithm itself lives with the consumer; bigint
+//! backends implement the trait on their own type.
 //!
-//! This crate is split out of `modmath` so that the trait identity
-//! stays stable across compile units. `modmath` is compiled twice
-//! during `cargo test` (once as a normal library that `fixed-bigint`
-//! links against, once with `--test` for the test binary); rustc
-//! assigns the two compilations distinct metadata hashes, so a trait
-//! defined inside `modmath` becomes two different types and impls in
-//! `fixed-bigint` fail to resolve from the test binary. By living in a
-//! leaf crate that is *not* `--test`-built in the same workspace pass,
-//! [`CiosRowOps`] has exactly one identity that both sides agree on.
+//! Single-word degenerate impls for `u8`/`u16`/`u32`/`u64` are
+//! provided here, treating each primitive as a 1-limb value.
 
 #![no_std]
 
 /// Row-level operations for CIOS Montgomery multiplication.
 ///
 /// Implementors provide infallible limb access and the two CIOS row
-/// kernels. The CIOS algorithm (in `modmath::montgomery::cios`) is
-/// generic over this trait.
+/// kernels; the multiplication loop driving them is generic over this
+/// trait.
 ///
 /// # Preconditions
 ///
@@ -29,9 +23,9 @@
 /// - `i` is a public value (loop counter, constant) — never secret.
 ///
 /// Under these preconditions, an infallible accessor is CT-safe for
-/// both variable-time and constant-time backends. The CIOS algorithm
-/// enforces both — `i` is always a public loop counter
-/// (`0..word_count()`) or the constant `0`.
+/// both variable-time and constant-time backends. A well-formed CIOS
+/// driver upholds both by construction — `i` is only ever a public
+/// loop counter (`0..word_count()`) or the constant `0`.
 pub trait CiosRowOps: Default + Sized {
     type Word: Copy + PartialOrd;
 

--- a/modmath/src/basic/mod.rs
+++ b/modmath/src/basic/mod.rs
@@ -2,8 +2,7 @@
 //!
 //! Use this module when the operand type satisfies `T: Copy + ...` —
 //! primitive integers (`u8`, `u16`, `u32`, `u64`, `u128`) and
-//! `Copy`-impl'ing bigints (`fixed_bigint::FixedUInt`,
-//! `crypto_bigint::Uint`).
+//! stack-allocated bigints that impl `Copy`.
 //!
 //! For backends that don't impl `Copy`, see
 //! [`modmath::constrained`](crate::constrained) (`Clone`-bound,
@@ -49,9 +48,8 @@ pub mod pre_reduced {
 /// Non-zero-modulus variants. Caller provides `m: T::NonZero` (one
 /// boundary-time `m.into_nonzero()?` proof); every `% m` reduction
 /// inside collapses to `rem_nonzero` with no divide-by-zero panic
-/// path. Verified end-to-end against fixed-bigint's
-/// `NonZeroFixedUInt`-driven `DivNonZero` impl (see
-/// fixed-bigint's `ct-verify/panic-free-audit` matrix).
+/// path when the carrier's `DivNonZero` impl elides the underlying
+/// zero-check.
 pub mod nonzero {
     #[doc(inline)]
     pub use crate::add::basic_mod_add_nz as add;

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -81,7 +81,7 @@ pub mod pre_reduced {
 ///   `Field::reduce` on the `Ct` personality, which composes the CT
 ///   wide-REDC reduction), then dispatch to
 ///   [`pre_reduced::mod_exp`](self::ct::pre_reduced::mod_exp); or
-/// - use the high-level [`Field<T, Ct>::exp`](crate::field::Field::exp)
+/// - use the high-level [`Field<T, Ct>::exp`](crate::Field::exp)
 ///   surface, which handles reduction + exponentiation as a single
 ///   end-to-end CT pipeline.
 ///

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -43,7 +43,11 @@ pub use crate::montgomery::basic_mont::basic_to_montgomery as to_mont;
 #[doc(inline)]
 pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp as mod_exp;
 #[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_odd as mod_exp_odd;
+#[doc(inline)]
 pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul as mod_mul;
+#[doc(inline)]
+pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_odd as mod_mul_odd;
 
 /// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
 /// the input `% m` reduction step is skipped.
@@ -51,7 +55,11 @@ pub mod pre_reduced {
     #[doc(inline)]
     pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr as mod_exp;
     #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_odd as mod_exp_odd;
+    #[doc(inline)]
     pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr as mod_mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr_odd as mod_mul_odd;
     #[doc(inline)]
     pub use crate::montgomery::basic_mont::basic_montgomery_mul_pr as mul;
     #[doc(inline)]
@@ -63,7 +71,7 @@ pub mod pre_reduced {
 /// `subtle::ConditionallySelectable`, removing the operand-magnitude
 /// side-channel on the final reduction step.
 ///
-/// **Only the `pre_reduced::mod_exp` entry is exposed.** CT-over-base
+/// **Only pre-reduced entries are exposed.** CT-over-base
 /// requires a CT reduction primitive; `core::ops::Rem` is
 /// hardware-variable on common embedded targets, so any wrapper that
 /// internally reduced via `Rem` would leak the base magnitude.
@@ -86,6 +94,8 @@ pub mod ct {
     pub mod pre_reduced {
         #[doc(inline)]
         pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_ct as mod_exp;
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_odd_ct as mod_exp_odd;
     }
 }
 

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -307,7 +307,7 @@ where
     /// Returns the modulus by reference.
     ///
     /// Returning `&T` rather than `T` avoids a memcpy of the full modulus
-    /// (~256 bytes for 2048-bit FixedUInt) at the call site. Consumers that
+    /// (~256 bytes for a 2048-bit carrier) at the call site. Consumers that
     /// need a `T` by value can copy at the use point.
     pub fn modulus(&self) -> &T {
         &self.modulus
@@ -888,7 +888,7 @@ where
     /// the zero residue.
     ///
     /// Cost: one full ladder over every bit of `T` (e.g. 256
-    /// square-and-multiply iterations for `FixedUInt<u32, 8>` over a
+    /// square-and-multiply iterations for a 256-bit carrier over a
     /// Curve25519 scalar field), regardless of whether `modulus - 2`
     /// occupies the full carrier width. For composite moduli (RSA
     /// `n = p·q`) where Fermat doesn't apply, use
@@ -928,16 +928,17 @@ where
     /// returns `None` regardless of value coprimality — the carrier
     /// is too tight for the algorithm's intermediate sums.
     ///
-    /// **Pick a `T` at least one bit wider than the modulus:**
-    /// `FixedUInt<u32, 65>` for a 2048-bit RSA modulus,
-    /// `FixedUInt<u32, 129>` for a 4096-bit one. Krabipqc / PQC moduli
+    /// **Pick a `T` at least one bit wider than the modulus** — in
+    /// practice one extra limb when the modulus fills a power-of-two
+    /// width (a 2048-bit RSA modulus needs a 2080-bit carrier at
+    /// 32-bit limbs). Krabipqc / PQC moduli
     /// (3329, 8380417, etc.) leave plenty of headroom on any
     /// reasonable carrier and are unaffected.
     ///
     /// Used by RSA private-key blinding, where the modulus is the
     /// composite `n = p·q` and Fermat's little theorem doesn't apply.
-    /// See [`crate::inv::safegcd`] for the algorithm and full
-    /// precondition list.
+    /// See the `inv::safegcd` module source for the algorithm and
+    /// full precondition list.
     ///
     /// [`inv_fermat`]: Self::inv_fermat
     pub fn inv_safegcd_ct(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -43,9 +43,10 @@
 //! `modulus` must fit in `T` with at least one bit of headroom — i.e.
 //! `2 * modulus` does not overflow `T`. The algorithm maintains
 //! `|d|, |e| < modulus` strictly, so intermediate sums `d + e` are
-//! bounded by `2 * modulus`. Practical types (e.g.
-//! `FixedUInt<u32, 64>` for a 2048-bit RSA modulus) leave plenty of
-//! headroom.
+//! bounded by `2 * modulus`. A modulus that fully occupies the
+//! carrier width violates this — pick a carrier at least one limb
+//! wider (a 2048-bit RSA modulus needs a 2080-bit carrier at 32-bit
+//! limbs).
 //!
 //! ## Implementation note
 //!

--- a/modmath/src/inv/signed.rs
+++ b/modmath/src/inv/signed.rs
@@ -317,6 +317,10 @@ where
 }
 
 #[cfg(test)]
+// op_ref allowed: the by-ref arms deliberately exercise the `Add<&T>` /
+// `Mul<&T>` impls; "fixing" `a * &b` to `a * b` would switch which impl
+// is under test.
+#[allow(clippy::op_ref)]
 mod signed_tests {
     use super::Signed;
 
@@ -428,7 +432,7 @@ mod signed_tests {
         // Test From<T> implementation
         let signed_from_42 = Signed::from(42u32);
         assert_eq!(signed_from_42.value, 42u32);
-        assert_eq!(signed_from_42.negative, false);
+        assert!(!signed_from_42.negative);
 
         // Test into_inner() method
         let signed_value = Signed::new(123u32, true);
@@ -440,20 +444,20 @@ mod signed_tests {
         // Test that new() automatically canonicalizes zero to positive
         let zero_positive = Signed::new(0u32, false);
         assert_eq!(zero_positive.value, 0u32);
-        assert_eq!(zero_positive.negative, false);
+        assert!(!zero_positive.negative);
 
         let zero_negative_input = Signed::new(0u32, true);
         assert_eq!(zero_negative_input.value, 0u32);
-        assert_eq!(zero_negative_input.negative, false); // Should be canonicalized to positive
+        assert!(!zero_negative_input.negative); // Should be canonicalized to positive
 
         // Test with non-zero values - should preserve the sign
         let positive_five = Signed::new(5u32, false);
         assert_eq!(positive_five.value, 5u32);
-        assert_eq!(positive_five.negative, false);
+        assert!(!positive_five.negative);
 
         let negative_three = Signed::new(3u32, true);
         assert_eq!(negative_three.value, 3u32);
-        assert_eq!(negative_three.negative, true); // Should preserve negative for non-zero
+        assert!(negative_three.negative); // Should preserve negative for non-zero
     }
 
     #[test]
@@ -463,35 +467,35 @@ mod signed_tests {
         let b = Signed::new(3u32, true); // -3
         let result = a + &b; // +5 + (-3) = +2
         assert_eq!(result.value, 2u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
 
         // Test case where other > self in mixed signs
         let a = Signed::new(2u32, false); // +2
         let b = Signed::new(5u32, true); // -5
         let result = a + &b; // +2 + (-5) = -3
         assert_eq!(result.value, 3u32);
-        assert_eq!(result.negative, true);
+        assert!(result.negative);
 
         // Test both negative
         let a = Signed::new(4u32, true); // -4
         let b = Signed::new(6u32, true); // -6
         let result = a + &b; // -4 + (-6) = -10
         assert_eq!(result.value, 10u32);
-        assert_eq!(result.negative, true);
+        assert!(result.negative);
 
         // Test zero canonicalization: positive + negative with equal magnitude
         let a = Signed::new(5u32, false); // +5
         let b = Signed::new(5u32, true); // -5
         let result = a + &b; // +5 + (-5) = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Fixed: zero should be canonicalized to positive
+        assert!(!result.negative); // Fixed: zero should be canonicalized to positive
 
         // Test zero canonicalization: negative + positive with equal magnitude
         let a = Signed::new(7u32, true); // -7
         let b = Signed::new(7u32, false); // +7
         let result = a + &b; // -7 + 7 = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Fixed: zero should be canonicalized to positive
+        assert!(!result.negative); // Fixed: zero should be canonicalized to positive
 
         // Additional zero canonicalization test cases for Add<&Signed<T>>
 
@@ -500,35 +504,35 @@ mod signed_tests {
         let b = Signed::new(12u32, true); // -12
         let result = a + &b; // +12 + (-12) = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Zero should be canonicalized to positive
+        assert!(!result.negative); // Zero should be canonicalized to positive
 
         // Test zero canonicalization with different values: -25 + (+25) = 0
         let a = Signed::new(25u32, true); // -25
         let b = Signed::new(25u32, false); // +25
         let result = a + &b; // -25 + 25 = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Zero should be canonicalized to positive
+        assert!(!result.negative); // Zero should be canonicalized to positive
 
         // Test zero canonicalization with larger values: +100 + (-100) = 0
         let a = Signed::new(100u32, false); // +100
         let b = Signed::new(100u32, true); // -100
         let result = a + &b; // +100 + (-100) = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Zero should be canonicalized to positive
+        assert!(!result.negative); // Zero should be canonicalized to positive
 
         // Test zero canonicalization with edge case: +1 + (-1) = 0
         let a = Signed::new(1u32, false); // +1
         let b = Signed::new(1u32, true); // -1
         let result = a + &b; // +1 + (-1) = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Zero should be canonicalized to positive
+        assert!(!result.negative); // Zero should be canonicalized to positive
 
         // Test zero canonicalization with maximum value: +u32::MAX + (-u32::MAX) = 0
         let a = Signed::new(u32::MAX, false); // +u32::MAX
         let b = Signed::new(u32::MAX, true); // -u32::MAX
         let result = a + &b; // +u32::MAX + (-u32::MAX) = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Zero should be canonicalized to positive
+        assert!(!result.negative); // Zero should be canonicalized to positive
     }
 
     #[test]
@@ -537,19 +541,19 @@ mod signed_tests {
         let a = Signed::new(7u32, false); // +7
         let result = a + &3u32; // +7 + 3 = +10
         assert_eq!(result.value, 10u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
 
         // Test negative Signed + T where |signed| >= T
         let a = Signed::new(8u32, true); // -8
         let result = a + &3u32; // -8 + 3 = -5
         assert_eq!(result.value, 5u32);
-        assert_eq!(result.negative, true);
+        assert!(result.negative);
 
         // Test negative Signed + T where |signed| < T (should flip sign)
         let a = Signed::new(2u32, true); // -2
         let result = a + &5u32; // -2 + 5 = +3
         assert_eq!(result.value, 3u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
     }
 
     #[test]
@@ -558,37 +562,37 @@ mod signed_tests {
         let mut a = Signed::new(10u32, false); // +10
         a += &3u32; // +10 += 3 = +13
         assert_eq!(a.value, 13u32);
-        assert_eq!(a.negative, false);
+        assert!(!a.negative);
 
         // Test AddAssign<&T> with negative Signed
         let mut a = Signed::new(15u32, true); // -15
         a += &5u32; // -15 += 5 = -10 (subtracts for negative)
         assert_eq!(a.value, 10u32);
-        assert_eq!(a.negative, true);
+        assert!(a.negative);
 
         // Test exact cancellation case (this should work without underflow)
         let mut a = Signed::new(7u32, true); // -7
         a += &7u32; // -7 += 7 = 0 (7 - 7 = 0)
         assert_eq!(a.value, 0u32);
-        assert_eq!(a.negative, false); // Fixed: zero is canonicalized to positive
+        assert!(!a.negative); // Fixed: zero is canonicalized to positive
 
         // Test another valid case where subtraction doesn't underflow
         let mut a = Signed::new(20u32, true); // -20
         a += &15u32; // -20 += 15 = -5 (20 - 15 = 5, stays negative)
         assert_eq!(a.value, 5u32);
-        assert_eq!(a.negative, true);
+        assert!(a.negative);
 
         // Test with zero addition to positive
         let mut a = Signed::new(5u32, false); // +5
         a += &0u32; // +5 += 0 = +5
         assert_eq!(a.value, 5u32);
-        assert_eq!(a.negative, false);
+        assert!(!a.negative);
 
         // Test with zero addition to negative
         let mut a = Signed::new(8u32, true); // -8
         a += &0u32; // -8 += 0 = -8 (8 - 0 = 8, stays negative)
         assert_eq!(a.value, 8u32);
-        assert_eq!(a.negative, true);
+        assert!(a.negative);
 
         // Extended test cases for sign flips and zero canonicalization:
 
@@ -600,41 +604,41 @@ mod signed_tests {
         let mut zero_case = Signed::new(5u32, true); // -5
         zero_case += &5u32; // -5 + 5 should be +0 (canonicalized)
         assert_eq!(zero_case.value, 0u32);
-        assert_eq!(zero_case.negative, false); // Fixed: zero is canonicalized to positive
+        assert!(!zero_case.negative); // Fixed: zero is canonicalized to positive
 
         // Test case: Multiple operations that should result in zero
         let mut multiple_zero = Signed::new(3u32, true); // -3
         multiple_zero += &3u32; // -3 + 3 = 0
         assert_eq!(multiple_zero.value, 0u32);
-        assert_eq!(multiple_zero.negative, false); // Fixed: zero is canonicalized to positive
+        assert!(!multiple_zero.negative); // Fixed: zero is canonicalized to positive
 
         // Test case: Large exact cancellation
         let mut large_cancel = Signed::new(100u32, true); // -100
         large_cancel += &100u32; // -100 + 100 = 0
         assert_eq!(large_cancel.value, 0u32);
-        assert_eq!(large_cancel.negative, false); // Fixed: zero is canonicalized to positive
+        assert!(!large_cancel.negative); // Fixed: zero is canonicalized to positive
 
         // Additional edge cases with zero
         let mut zero_to_zero = Signed::new(0u32, true); // -0 (invalid state)
         zero_to_zero += &0u32; // -0 + 0 = 0
         assert_eq!(zero_to_zero.value, 0u32);
-        assert_eq!(zero_to_zero.negative, false); // Fixed: zero is canonicalized to positive
+        assert!(!zero_to_zero.negative); // Fixed: zero is canonicalized to positive
 
         // Test cases that should now work: sign flips from negative to positive
         let mut sign_flip1 = Signed::new(8u32, true); // -8
         sign_flip1 += &12u32; // -8 + 12 = +4
         assert_eq!(sign_flip1.value, 4u32);
-        assert_eq!(sign_flip1.negative, false); // Should become positive
+        assert!(!sign_flip1.negative); // Should become positive
 
         let mut sign_flip2 = Signed::new(3u32, true); // -3
         sign_flip2 += &7u32; // -3 + 7 = +4
         assert_eq!(sign_flip2.value, 4u32);
-        assert_eq!(sign_flip2.negative, false); // Should become positive
+        assert!(!sign_flip2.negative); // Should become positive
 
         let mut sign_flip3 = Signed::new(1u32, true); // -1
         sign_flip3 += &10u32; // -1 + 10 = +9
         assert_eq!(sign_flip3.value, 9u32);
-        assert_eq!(sign_flip3.negative, false); // Should become positive
+        assert!(!sign_flip3.negative); // Should become positive
     }
 
     #[test]
@@ -644,7 +648,7 @@ mod signed_tests {
         let mut a = Signed::new(8u32, true); // -8
         a += &12u32; // -8 + 12 = +4
         assert_eq!(a.value, 4u32);
-        assert_eq!(a.negative, false); // Should be positive
+        assert!(!a.negative); // Should be positive
     }
 
     #[test]
@@ -654,7 +658,7 @@ mod signed_tests {
         let mut a = Signed::new(3u32, true); // -3
         a += &7u32; // Should become +4
         assert_eq!(a.value, 4u32);
-        assert_eq!(a.negative, false); // Should be positive
+        assert!(!a.negative); // Should be positive
     }
 
     #[test]
@@ -664,7 +668,7 @@ mod signed_tests {
         let mut a = Signed::new(1u32, true); // -1
         a += &10u32; // Should become +9
         assert_eq!(a.value, 9u32);
-        assert_eq!(a.negative, false); // Should be positive
+        assert!(!a.negative); // Should be positive
     }
 
     #[test]
@@ -674,7 +678,7 @@ mod signed_tests {
         let mut a = Signed::new(1u32, true); // -1
         a += &u32::MAX; // Should become +(u32::MAX - 1)
         assert_eq!(a.value, u32::MAX - 1);
-        assert_eq!(a.negative, false); // Should be positive
+        assert!(!a.negative); // Should be positive
     }
 
     #[test]
@@ -686,37 +690,37 @@ mod signed_tests {
         let a = Signed::new(8u32, true); // -8
         let result = a + &12u32; // This works with Add<&T>
         assert_eq!(result.value, 4u32);
-        assert_eq!(result.negative, false); // Correctly becomes positive
+        assert!(!result.negative); // Correctly becomes positive
 
         // Case 2: -3 + 7 should equal +4
         let a = Signed::new(3u32, true); // -3
         let result = a + &7u32;
         assert_eq!(result.value, 4u32);
-        assert_eq!(result.negative, false); // Correctly becomes positive
+        assert!(!result.negative); // Correctly becomes positive
 
         // Case 3: -1 + 10 should equal +9
         let a = Signed::new(1u32, true); // -1
         let result = a + &10u32;
         assert_eq!(result.value, 9u32);
-        assert_eq!(result.negative, false); // Correctly becomes positive
+        assert!(!result.negative); // Correctly becomes positive
 
         // Case 4: Zero canonicalization should work correctly now
         let a = Signed::new(5u32, true); // -5
         let result = a + &5u32;
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Fixed: zero is now canonicalized to positive
+        assert!(!result.negative); // Fixed: zero is now canonicalized to positive
 
         // Case 5: Test edge case where negative value equals the addend
         let a = Signed::new(7u32, true); // -7
         let result = a + &7u32; // -7 + 7 = 0
         assert_eq!(result.value, 0u32);
-        assert_eq!(result.negative, false); // Fixed: zero is now canonicalized to positive
+        assert!(!result.negative); // Fixed: zero is now canonicalized to positive
 
         // Case 6: Show that positive + positive works correctly
         let a = Signed::new(3u32, false); // +3
         let result = a + &5u32; // +3 + 5 = +8
         assert_eq!(result.value, 8u32);
-        assert_eq!(result.negative, false); // Correctly positive
+        assert!(!result.negative); // Correctly positive
     }
 
     #[test]
@@ -726,45 +730,45 @@ mod signed_tests {
         let b = Signed::new(3u32, false); // +3
         let result = a * b; // +4 * +3 = +12
         assert_eq!(result.value, 12u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
 
         // Test Mul<Self> - positive * negative
         let a = Signed::new(5u32, false); // +5
         let b = Signed::new(2u32, true); // -2
         let result = a * b; // +5 * -2 = -10
         assert_eq!(result.value, 10u32);
-        assert_eq!(result.negative, true);
+        assert!(result.negative);
 
         // Test Mul<Self> - negative * negative
         let a = Signed::new(6u32, true); // -6
         let b = Signed::new(4u32, true); // -4
         let result = a * b; // -6 * -4 = +24
         assert_eq!(result.value, 24u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
 
         // Test Mul<T> - positive Signed * T
         let a = Signed::new(7u32, false); // +7
         let result = a * 2u32; // +7 * 2 = +14
         assert_eq!(result.value, 14u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
 
         // Test Mul<T> - negative Signed * T
         let a = Signed::new(3u32, true); // -3
         let result = a * 5u32; // -3 * 5 = -15
         assert_eq!(result.value, 15u32);
-        assert_eq!(result.negative, true);
+        assert!(result.negative);
 
         // Test Mul<&T> - positive Signed * &T
         let a = Signed::new(8u32, false); // +8
         let result = a * &3u32; // +8 * 3 = +24
         assert_eq!(result.value, 24u32);
-        assert_eq!(result.negative, false);
+        assert!(!result.negative);
 
         // Test Mul<&T> - negative Signed * &T
         let a = Signed::new(9u32, true); // -9
         let result = a * &2u32; // -9 * 2 = -18
         assert_eq!(result.value, 18u32);
-        assert_eq!(result.negative, true);
+        assert!(result.negative);
     }
 
     #[test]

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -26,18 +26,13 @@
 //! alongside their non-CT siblings ([`FieldCt`], `Field<T, Ct>`, `_ct`
 //! function suffixes, `<flavor>::montgomery::wide::ct::*`).
 //!
-//! Tested against built-in integers, [`num-bigint`], [`crypto-bigint`],
-//! [`bnum`], [`ibig`], and [`fixed-bigint`]. The `basic` flavor's `Copy`
-//! bound rules out heap-allocated backends (`num-bigint`, `ibig`); those
-//! use `constrained` or `strict`.
+//! Backend-agnostic: any integer type implementing the required traits
+//! works — built-in integers or third-party bigints. The `basic`
+//! flavor's `Copy` bound rules out heap-allocated backends; those use
+//! `constrained` or `strict`.
 //!
 //! [`Overflowing`]: https://docs.rs/num-traits/latest/num_traits/ops/overflowing
 //! [`subtle`]: https://crates.io/crates/subtle
-//! [`num-bigint`]: https://crates.io/crates/num-bigint
-//! [`crypto-bigint`]: https://crates.io/crates/crypto-bigint
-//! [`bnum`]: https://crates.io/crates/bnum
-//! [`ibig`]: https://crates.io/crates/ibig
-//! [`fixed-bigint`]: https://crates.io/crates/fixed-bigint
 
 mod add;
 mod exp;

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -393,7 +393,7 @@ where
 // Wide-REDC private helpers (R = 2^W, full type width)
 // ---------------------------------------------------------------------------
 
-/// Bit width of type T (e.g. 32 for u32, 128 for FixedUInt<u32,4>).
+/// Bit width of type T (e.g. 32 for u32, 128 for a 4×32-limb bigint).
 pub const fn type_bit_width<T>() -> usize {
     core::mem::size_of::<T>() * 8
 }
@@ -426,7 +426,7 @@ where
 /// selects via `subtle::Choice`.
 ///
 /// Used by [`compute_r_mod_n_ct`] / [`compute_r2_mod_n_ct`] for the Ct
-/// precompute path called from [`Field::new_odd_ct`].
+/// precompute path called from [`Field::new_odd_ct`](crate::field::Field::new_odd_ct).
 fn mod_double_ct<T>(val: T, modulus: T) -> T
 where
     T: Copy
@@ -527,9 +527,9 @@ where
 
 /// Compute R mod N = 2^W mod N via W modular doublings starting from 1.
 ///
-/// **Variable-time.** Used by [`Field::new_odd`] for the Nct precompute
+/// **Variable-time.** Used by [`Field::new_odd`](crate::field::Field::new_odd) for the Nct precompute
 /// path (public modulus); the CT sibling [`compute_r_mod_n_ct`] is
-/// used by [`Field::new_odd_ct`] when the modulus is secret.
+/// used by [`Field::new_odd_ct`](crate::field::Field::new_odd_ct) when the modulus is secret.
 pub fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
 where
     T: Copy
@@ -546,7 +546,7 @@ where
 }
 
 /// CT version of [`compute_r_mod_n`]: `2^W mod modulus` with no
-/// value-dependent branches. Used by [`Field::new_odd_ct`] for the
+/// value-dependent branches. Used by [`Field::new_odd_ct`](crate::field::Field::new_odd_ct) for the
 /// secret-modulus precompute path.
 pub fn compute_r_mod_n_ct<T>(modulus: T, w: usize) -> T
 where
@@ -611,7 +611,7 @@ where
 ///
 /// This is the variable-time path: branches on `carry1` and on `carry3`
 /// via `||` short-circuit. Used by the NCT REDC functions. For the CT
-/// REDC path, see [`accumulate_high_half_carry_ct`].
+/// REDC path, see `accumulate_high_half_carry_ct`.
 fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
 where
     T: const_num_traits::One
@@ -707,9 +707,9 @@ where
 /// REDC on a double-width input — variable-time, reference-based inputs.
 ///
 /// Same algorithm as [`wide_redc`] but takes all operands by reference,
-/// avoiding the per-call value copy. For `Copy` types (`u32`, `FixedUInt`)
-/// the compiler register-passes either way; the by-ref form matters for
-/// non-Copy bigint backends where each value pass would clone.
+/// avoiding the per-call value copy. For `Copy` types the compiler
+/// register-passes either way; the by-ref form matters for non-`Copy`
+/// bigint backends where each value pass would clone.
 ///
 /// Drops the `Copy` bound — usable with backends that don't impl it.
 pub fn strict_wide_redc<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
@@ -938,7 +938,7 @@ where
 /// Wide multiply-accumulate — constant-time carry propagation.
 ///
 /// Same shape as [`wide_montgomery_mul_acc`] but routes the carry
-/// combination through [`accumulate_high_half_carry_ct`] so the
+/// combination through `accumulate_high_half_carry_ct` so the
 /// per-term cost has no value-dependent branches. Use in CT-sensitive
 /// paths; pair with [`wide_redc_ct`] for the final reduction.
 ///

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -426,7 +426,7 @@ where
 /// selects via `subtle::Choice`.
 ///
 /// Used by [`compute_r_mod_n_ct`] / [`compute_r2_mod_n_ct`] for the Ct
-/// precompute path called from [`Field::new_odd_ct`](crate::field::Field::new_odd_ct).
+/// precompute path called from [`Field::new_odd_ct`](crate::Field::new_odd_ct).
 fn mod_double_ct<T>(val: T, modulus: T) -> T
 where
     T: Copy
@@ -527,9 +527,9 @@ where
 
 /// Compute R mod N = 2^W mod N via W modular doublings starting from 1.
 ///
-/// **Variable-time.** Used by [`Field::new_odd`](crate::field::Field::new_odd) for the Nct precompute
+/// **Variable-time.** Used by [`Field::new_odd`](crate::Field::new_odd) for the Nct precompute
 /// path (public modulus); the CT sibling [`compute_r_mod_n_ct`] is
-/// used by [`Field::new_odd_ct`](crate::field::Field::new_odd_ct) when the modulus is secret.
+/// used by [`Field::new_odd_ct`](crate::Field::new_odd_ct) when the modulus is secret.
 pub fn compute_r_mod_n<T>(modulus: T, w: usize) -> T
 where
     T: Copy
@@ -546,7 +546,7 @@ where
 }
 
 /// CT version of [`compute_r_mod_n`]: `2^W mod modulus` with no
-/// value-dependent branches. Used by [`Field::new_odd_ct`](crate::field::Field::new_odd_ct) for the
+/// value-dependent branches. Used by [`Field::new_odd_ct`](crate::Field::new_odd_ct) for the
 /// secret-modulus precompute path.
 pub fn compute_r_mod_n_ct<T>(modulus: T, w: usize) -> T
 where

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -211,7 +211,7 @@ mod smoke_tests {
     /// New CIOS via `CiosRowOps` must match the existing wide-REDC
     /// `wide_montgomery_mul` reference for every `(a, b)` modulo a small
     /// prime. Generated per primitive — validates the trait surface
-    /// end-to-end without depending on fixed-bigint catching up.
+    /// end-to-end on the built-in single-word impls alone.
     macro_rules! cios_smoke_test {
         ($name:ident, $t:ty) => {
             #[test]

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -50,14 +50,13 @@ pub use basic_mont::{
 // takes the word directly).
 pub use cios::{CiosMontMul, CiosMontMulCt};
 
-// Tests exercise the R > N path and constrained/strict APIs which require
-// `Rem`-able `T`; gated to NCT/non-FixedUInt builds via dev-deps without ct.
+// Tests exercise the R > N path and constrained/strict APIs, which
+// require `Rem`-able (Nct-personality) operands.
 #[cfg(test)]
 mod tests {
     use super::basic_mont::*;
     use super::constrained_mont::*;
     use super::strict_mont::*;
-    use super::*;
 
     #[test]
     fn test_basic_compute_montgomery_params() {
@@ -780,10 +779,8 @@ macro_rules! montgomery_test_module {
 }
 
 #[cfg(test)]
-mod bnum_montgomery_tests {
+mod backend_montgomery_tests {
     use super::basic_mont::*;
-    use super::constrained_mont::*;
-    use super::strict_mont::*;
     use super::*;
 
     //     montgomery_test_module!(

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -75,13 +75,10 @@ where
 ///
 /// Same body as [`basic_mod_mul`] but the modulus is taken as
 /// `T::NonZero` — every `% m` becomes `rem_nonzero(m)` with no
-/// divide-by-zero branch. **Deletes the `panic_fmt` symbol** that the
-/// runtime modulus-zero check would synthesize from the linked binary
-/// on embedded targets, when the carrier's `DivNonZero` impl elides the
-/// underlying `Div` zero-check (verified end-to-end against
-/// `fixed-bigint`'s `NonZeroFixedUInt`-driven `DivNonZero` via the
-/// `ct-verify/panic-free-audit` matrix — see fixed-bigint's CHANGELOG
-/// for the per-stage `cargo nm` table).
+/// divide-by-zero branch. When the carrier's `DivNonZero` impl elides
+/// the underlying `Div` zero-check, this **deletes the `panic_fmt`
+/// symbol** that the runtime modulus-zero check would otherwise
+/// synthesize into the linked binary on embedded targets.
 ///
 /// Sibling `*_nz` siblings in [`basic_mod_add_nz`](crate::add::basic_mod_add_nz),
 /// [`basic_mod_sub_nz`](crate::sub::basic_mod_sub_nz), and

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -91,7 +91,7 @@ where
 /// Routing note: the `_nz` surface is Nct-aligned because the
 /// underlying `_pr` bodies are operand-magnitude-branching. Secret
 /// (Ct-personality) moduli go through
-/// [`Field::try_new_odd_ct`](crate::field::Field::try_new_odd_ct) and
+/// [`Field::try_new_odd_ct`](crate::Field::try_new_odd_ct) and
 /// the Montgomery path (which doesn't divide), not through `_nz`.
 pub fn basic_mod_mul_nz<T>(a: T, b: T, m: T::NonZero) -> T
 where

--- a/modmath/src/strict/montgomery.rs
+++ b/modmath/src/strict/montgomery.rs
@@ -47,8 +47,8 @@ pub use crate::montgomery::strict_mont::strict_to_montgomery as to_mont;
 /// operands, no `Copy` bound on `T`. Suitable for non-`Copy` bigint
 /// backends where each by-value pass would clone the operand.
 ///
-/// For the by-value variant suitable for `Copy` types (u32,
-/// `FixedUInt`), see [`modmath::basic::montgomery::wide`](crate::basic::montgomery::wide).
+/// For the by-value variant suitable for `Copy` types, see
+/// [`modmath::basic::montgomery::wide`](crate::basic::montgomery::wide).
 /// Codegen for `Copy` types is identical between the two; the strict
 /// form only matters when `T: !Copy`.
 pub mod wide {


### PR DESCRIPTION
Release-prep cleanup ahead of the merge to main.

- **Doc scrub**: public rustdoc no longer narrates fixed-bigint internals (audit matrix, CHANGELOG pointers) or carries the stale five-backend tested-with roster; sizing examples genericized to bit-widths. modmath-cios crate docs now describe its own contract instead of modmath's double-compilation workaround. Fixes a wrong headroom example in safegcd.rs (64 limbs = zero headroom for 2048-bit, not \"plenty\").
- **_odd exports**: the Odd<T> panic-free Montgomery entries were documented as preferred but publicly unreachable; now wired through the basic::montgomery hub.
- **Warning debt + CI**: CI ran clippy lib-only and never built docs. Fixed the accumulated test-code lints and broken doc links; CI now runs workspace-wide fmt/clippy with --all-targets and gates rustdoc with -D warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh documentation and CI to be backend-agnostic and warning-clean while exposing the previously internal Montgomery helpers for odd moduli through the basic Montgomery hub.

New Features:
- Expose panic-free Montgomery exponentiation and multiplication helpers for odd moduli via the basic::montgomery hub, including pre-reduced and CT variants.

Bug Fixes:
- Resolve clippy and doc warning debt in test code and montgomery internals, including explicit allowance for reference-operand arithmetic in Signed tests.
- Correct safegcd and modular inversion documentation around required carrier headroom for RSA-sized moduli.

Enhancements:
- Clarify and generalize crate- and module-level docs to describe backend-agnostic traits, CIOS row-op contracts, and carrier sizing without relying on a fixed roster of bigint backends.
- Simplify and rename certain backend Montgomery test modules to reflect generic backend coverage rather than specific implementations.

Build:
- Tighten CI to run workspace-wide rustfmt and clippy with all targets and to gate rustdoc builds on warnings, ensuring docs and linting stay clean across the workspace.

Documentation:
- Update README and rustdoc to describe tested backends in terms of capabilities, retire stale backend lists, and align examples and cross-references with the current trait and module surfaces.

Tests:
- Adjust Signed arithmetic tests and Montgomery backend tests for clearer intent and compatibility with stricter lint settings, including reference-based operation coverage and generic backend naming.