### PR TITLE
Close the coordinated patch window: crates.io deps only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,5 @@ members = ["modmath", "modmath-cios"]
 # Path-pin sibling crates during the coordinated experimental window.
 # Revert before publishing.
 [patch.crates-io]
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.8" }
-modmath-cios = { path = "modmath-cios" }
-
-# fixed-bigint (alpha.8) takes modmath-cios as a git dep pinned to the
-# v0.4.0-alpha.0 tag; redirect that source to the local path too, or
-# the workspace gets two CiosRowOps identities.
-[patch."https://github.com/kaidokert/modmath-rs"]
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.9" }
 modmath-cios = { path = "modmath-cios" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,3 @@
 resolver="2"
 
 members = ["modmath", "modmath-cios"]
-
-# Path-pin sibling crates during the coordinated experimental window.
-# Revert before publishing.
-[patch.crates-io]
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs", tag = "v0.4.0-alpha.9" }
-modmath-cios = { path = "modmath-cios" }

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -21,7 +21,10 @@ const-num-traits = { version = "0.1.1", default-features = false, features = ["c
 # across compile units (the `--test` rebuild of modmath would otherwise
 # define a second, distinct `CiosRowOps` that fixed-bigint's impl can't
 # satisfy from the test binary).
-modmath-cios = { version = "0.1", path = "../modmath-cios" }
+# Version-only (no path): fixed-bigint's dev-dep also pulls modmath-cios
+# from the registry, and mixing a path copy with the registry copy would
+# split the trait identity into two incompatible `CiosRowOps`.
+modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
 fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] }

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -17,13 +17,9 @@ c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 const-num-traits = { version = "0.1.1", default-features = false, features = ["ct"] }
-# CiosRowOps lives in a leaf crate so the trait identity stays stable
-# across compile units (the `--test` rebuild of modmath would otherwise
-# define a second, distinct `CiosRowOps` that fixed-bigint's impl can't
-# satisfy from the test binary).
-# Version-only (no path): fixed-bigint's dev-dep also pulls modmath-cios
-# from the registry, and mixing a path copy with the registry copy would
-# split the trait identity into two incompatible `CiosRowOps`.
+# Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
+# identity everywhere — modmath, its test binaries, and fixed-bigint's
+# dev-dep all resolve the same copy.
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
Final step of the 0.4.0 release chain, in two commits (previously pushed to main directly — reverted and re-landed here for review):

- **Track fixed-bigint v0.4.0-alpha.9** — alpha.9 switched its modmath-cios dep back to crates.io, making the git-URL patch section obsolete.
- **Drop `[patch.crates-io]` entirely** — fixed-bigint 0.4.0 and modmath-cios 0.1.0 are published. modmath's modmath-cios dep goes version-only (no path): fixed-bigint's dev-dep pulls the registry copy, and mixing it with a path copy splits the `CiosRowOps` trait identity. The workspace now builds exactly what consumers resolve.

`cargo publish --dry-run -p modmath` verifies against pure crates.io deps. After merge: publish modmath 0.4.0 and tag v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency consistency to prevent duplicate crate identities during builds and tests.
  * Updated one dependency to use a registry-only source instead of a local override to keep trait behavior consistent across the project.
  * Removed workspace-level custom dependency redirections so normal registry configuration is used by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->