### PR TITLE
modmath-cios 0.1.1: drop impossible carry from primitive mul_acc_shift_row

### DIFF
--- a/modmath-cios/Cargo.toml
+++ b/modmath-cios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath-cios"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Row-op trait surface for CIOS Montgomery multiplication."
 repository = "https://github.com/kaidokert/modmath-rs"

--- a/modmath-cios/src/lib.rs
+++ b/modmath-cios/src/lib.rs
@@ -91,9 +91,16 @@ macro_rules! impl_cios_row_ops_primitive {
                 let product = (scalar as $wide) * (*multiplicand as $wide);
                 let total = (*acc as $wide) + product;
                 let total_hi = total >> $bits;
-                let (sum, carry) = total_hi.overflowing_add(acc_hi as $wide);
+                // No carry handling: by the operand types, product is at
+                // most (2^b-1)^2, so total <= 2^2b - 2^b and total_hi <=
+                // 2^b - 1; adding acc_hi (<= 2^b - 1) stays below 2^(b+1),
+                // which cannot wrap the $wide type. The overflowing_add
+                // this replaces guarded an impossible case, and its carry
+                // flag lowered to a data-dependent branch on targets
+                // without a flags register (riscv32).
+                let sum = total_hi + (acc_hi as $wide);
                 *acc = sum as $narrow;
-                ((sum >> $bits) as $narrow) + if carry { 1 } else { 0 }
+                (sum >> $bits) as $narrow
             }
         }
     };


### PR DESCRIPTION
First leg of closing the riscv32 findings documented in ct-driver's `RISCV32_EXTRA_HELPERS` (from #27). Implementation-only — no API or behavior change, so 0.1.1 is semver-invisible and modmath's `^0.1` picks it up on the next resolve.

The primitive `mul_acc_shift_row` carried an `overflowing_add` whose carry is **provably impossible** by the operand types: `product ≤ (2^b−1)²`, so `total ≤ 2^2b − 2^b` and `total_hi ≤ 2^b − 1`; adding `acc_hi` (`≤ 2^b − 1`) stays below `2^(b+1)`, nowhere near wrapping the double-wide type. The proof now lives as a comment where the carry handling used to be.

The dead guard wasn't free: LLVM materialized the carry flag as data-dependent equality-branch chains on riscv32 (no flags register) — the `<u64 as CiosRowOps>` finding the asm-grep gate flagged. Verified via a local path override: with this change, both u64 row-op symbols disassemble **branch-free** on riscv32imc.

Sequencing: the extras-list entry deletion and the companion modmath sweep (`mod_double_ct` / `wide_redc_ct` off `overflowing_add` onto the `ct_lt` carry idiom) follow in a separate PR once 0.1.1 is published — this workspace deliberately consumes modmath-cios from the registry, so the rv32 CI rows can only see the fix after publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of core arithmetic operations for supported operand sizes.
  * Reduced the risk of incorrect results in edge cases during multiplication and accumulation.
* **Chores**
  * Bumped the crate version to `0.1.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->