### PR TITLE
Carry detection via ct_lt across the CT wide-REDC path

### DIFF
--- a/ct-verify/README.md
+++ b/ct-verify/README.md
@@ -36,11 +36,11 @@ Three members:
   `divsteps_total` steps) compile to branchful-but-CT-safe counter
   loops that static pattern-matching can't classify; those helpers are
   allowlisted per symbol in `ct-driver/src/target.rs` with the
-  source-semantic justification inline. The riscv32 extras list is
-  different in kind — it documents **known secret-dependent branches**
-  (`overflowing_add`'s u64 carry flag lowers to an equality-branch
-  chain on an ISA with no flags register) deferred to a library
-  follow-up; bare-u64 CT carriers on rv32 are unsupported until then.
+  source-semantic justification inline. Carry detection throughout the
+  CT wide-REDC path uses the `sum.ct_lt(&a)` idiom rather than
+  `overflowing_add` — the overflow flag's materialization lowers to
+  equality-branch chains on ISAs without a flags register (riscv32),
+  which is how this gate caught the original findings there.
 
 Which inputs are tainted mirrors each entry's documented secrecy
 contract, not a blanket "everything is secret": the wide-mul/REDC and

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -98,7 +98,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::RISCV_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
-        extra_allowed_helpers: RISCV32_EXTRA_HELPERS,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     TargetSpec {
@@ -110,7 +110,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::RISCV_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
-        extra_allowed_helpers: RISCV32_EXTRA_HELPERS,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     // Priority 4: 8-bit AVR (nightly-only, needs build-std + target-cpu).
@@ -407,32 +407,6 @@ const THUMBV6M_EXTRA_HELPERS: &[&str] = &[
     r"^__clz[sd]i2$",
     r"^__udivmodsi4$",
     r"^__aeabi_l?ls[lr]$",
-];
-
-/// riscv32-specific extras — unlike everything in `HELPER_ALLOWLIST`,
-/// these are NOT public-loop classifications. They are **known
-/// secret-dependent branches**, documented here so the gate stays
-/// honest instead of silently green.
-///
-/// Root cause: `overflowing_add`'s carry flag on u64 carriers. rv32
-/// has no flags register, so LLVM lowers the 64-bit carry-out as an
-/// equality-branch chain (`beq hi', hi` tie-breaking the `sltu`) on
-/// values derived from the operands — which are secret in these
-/// functions' contracts. ARM (adds/adcs) and x86_64/aarch64 (flags)
-/// lower the same source branchlessly, so only rv32 is affected, and
-/// only the primitive-u64-carrier instantiations — the multi-limb
-/// rv32 deployment carrier (`FixedUInt<u32, N, Ct>`) does native
-/// 32-bit arithmetic and is unaffected.
-///
-/// Tracked follow-up: rewrite the wide-REDC carry discipline onto the
-/// `sum.ct_lt(&a)` idiom already used by safegcd's `se_add` and
-/// `Field::add` (pure arithmetic, branchless on every ISA), then
-/// delete this list. Until then, deploying a bare-u64 CT carrier on
-/// rv32 is unsupported.
-const RISCV32_EXTRA_HELPERS: &[&str] = &[
-    r"modmath10montgomery10basic_mont12wide_redc_ct",
-    r"modmath10montgomery10basic_mont13mod_double_ct",
-    r"\$LT\$u64\$u20\$as\$u20\$modmath_cios\.\.CiosRowOps\$GT\$",
 ];
 
 pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -275,7 +275,7 @@ where
     /// [`new_odd`]: Self::new_odd
     pub fn new_odd_ct(modulus: Odd<T>) -> Self
     where
-        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess + const_num_traits::CtIsZero,
     {
         let modulus = modulus.get();
         let w = type_bit_width::<T>();
@@ -635,7 +635,10 @@ where
     /// [`CtParity`]: const_num_traits::CtParity
     pub fn try_new_odd_ct(modulus: T) -> subtle::CtOption<Self>
     where
-        T: const_num_traits::CtParity + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: const_num_traits::CtParity
+            + const_num_traits::CtIsZero
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess,
     {
         // Mask the parity check (no branch on the secret modulus). The
         // precompute below uses the CT path ([`Self::new_odd_ct`]) so
@@ -656,7 +659,10 @@ where
     /// Convert a raw value to Montgomery form. Constant-time finalize.
     pub fn reduce(&self, raw: &T) -> Residue<'_, T, Ct>
     where
-        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: WideMul
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess
+            + const_num_traits::CtIsZero,
     {
         let mont = wide_montgomery_mul_ct(*raw, self.r2_mod_n, self.modulus, self.n_prime);
         Residue {
@@ -670,7 +676,10 @@ where
     #[allow(clippy::wrong_self_convention)]
     pub fn into_raw(&self, r: &Residue<'_, T, Ct>) -> T
     where
-        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: WideMul
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess
+            + const_num_traits::CtIsZero,
     {
         wide_redc_ct(r.mont, T::zero(), self.modulus, self.n_prime)
     }
@@ -858,7 +867,7 @@ where
     /// See the free-function for the `N ≤ R/q` bound contract.
     pub fn mul_acc(&self, acc: (T, T), a: &Residue<'_, T, Ct>, b: &Residue<'_, T, Ct>) -> (T, T)
     where
-        T: WideMul + subtle::ConditionallySelectable,
+        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
     {
         wide_montgomery_mul_acc_ct(acc.0, acc.1, a.mont, b.mont)
     }
@@ -867,7 +876,10 @@ where
     /// [`Residue`].
     pub fn wide_redc(&self, acc: (T, T)) -> Residue<'_, T, Ct>
     where
-        T: WideMul + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: WideMul
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess
+            + const_num_traits::CtIsZero,
     {
         let mont = wide_redc_ct(acc.0, acc.1, self.modulus, self.n_prime);
         Residue {

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -430,17 +430,22 @@ where
 fn mod_double_ct<T>(val: T, modulus: T) -> T
 where
     T: Copy
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
-    let (doubled, overflow) = val.overflowing_add(val);
+    let doubled = val.wrapping_add(val);
+    // Wraparound ⇔ sum < operand. subtle's ct_lt is pure mask
+    // arithmetic on every ISA; overflowing_add's carry flag lowers to
+    // an equality-branch chain on targets without a flags register
+    // (riscv32).
+    let overflow = doubled.ct_lt(&val);
     let sub_result = doubled.wrapping_sub(modulus);
     let doubled_ge_modulus = !doubled.ct_lt(&modulus);
-    let needs_sub = Choice::from(overflow as u8) | doubled_ge_modulus;
+    let needs_sub = overflow | doubled_ge_modulus;
     T::conditional_select(&doubled, &sub_result, needs_sub)
 }
 
@@ -509,7 +514,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -553,7 +559,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -589,7 +596,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -631,27 +639,25 @@ where
 /// Same semantics — adds `carry1` to `result` and returns the combined
 /// extra-bit flag — but eliminates the value-dependent branches. The
 /// addition is always performed; the result is selected branchlessly via
-/// `subtle::ConditionallySelectable`. The boolean carry combination uses
-/// bitwise ops (`&`, `|`) on `subtle::Choice` rather than `&&` / `||` so
-/// the new carry computation does not short-circuit on operand value.
+/// `subtle::ConditionallySelectable`. Carries stay `Choice` end to end:
+/// bitwise `&` / `|` never short-circuit, and no `bool` materializes for
+/// the optimizer to re-branch on.
 ///
 /// Called by the CT REDC functions (`wide_redc_ct`, `strict_wide_redc_ct`).
-fn accumulate_high_half_carry_ct<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
+fn accumulate_high_half_carry_ct<T>(result: T, carry1: Choice, carry2: Choice) -> (T, Choice)
 where
     T: const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + core::ops::Add<Output = T>
         + subtle::ConditionallySelectable,
 {
-    let c1 = Choice::from(carry1 as u8);
-    let c2 = Choice::from(carry2 as u8);
-    // Always compute the addition; branchlessly choose whether to keep it.
-    let (r2, carry3) = result.overflowing_add(T::one());
-    let c3 = Choice::from(carry3 as u8);
-    let chosen = T::conditional_select(&result, &r2, c1);
-    // new_carry = carry2 | (carry1 & carry3) — bitwise, no short-circuit.
-    let new_carry: bool = (c2 | (c1 & c3)).into();
-    (chosen, new_carry)
+    // Always compute the addition; branchlessly choose whether to keep
+    // it. `+1` wraps ⇔ the sum is zero — no overflow flag needed.
+    let r2 = result.wrapping_add(T::one());
+    let carry3 = r2.ct_is_zero();
+    let chosen = T::conditional_select(&result, &r2, carry1);
+    (chosen, carry2 | (carry1 & carry3))
 }
 
 /// REDC on a double-width input (t_lo, t_hi) — variable-time.
@@ -756,7 +762,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
@@ -767,14 +774,19 @@ where
 {
     let m = t_lo.wrapping_mul(n_prime);
     let (m_lo, m_hi) = m.wide_mul(&modulus);
-    let (_discard_lo, carry1) = t_lo.overflowing_add(m_lo);
-    let (result, carry2) = t_hi.overflowing_add(m_hi);
+    // Carries via ct_lt (wraparound ⇔ sum < operand): overflowing_add's
+    // flag lowers to an equality-branch chain on targets without a
+    // flags register (riscv32).
+    let sum_lo = t_lo.wrapping_add(m_lo);
+    let carry1 = sum_lo.ct_lt(&t_lo);
+    let result = t_hi.wrapping_add(m_hi);
+    let carry2 = result.ct_lt(&t_hi);
     let (result, extra_bit) = accumulate_high_half_carry_ct(result, carry1, carry2);
 
     // Branchless final reduction: needs_sub = extra_bit | !(result < modulus)
     let sub_result = result.wrapping_sub(modulus);
     let result_lt_modulus = result.ct_lt(&modulus);
-    let needs_sub = Choice::from(extra_bit as u8) | !result_lt_modulus;
+    let needs_sub = extra_bit | !result_lt_modulus;
     T::conditional_select(&result, &sub_result, needs_sub)
 }
 
@@ -789,7 +801,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
@@ -800,13 +813,16 @@ where
 {
     let m = (*t_lo).wrapping_mul(*n_prime);
     let (m_lo, m_hi) = m.wide_mul(modulus);
-    let (_discard_lo, carry1) = (*t_lo).overflowing_add(m_lo);
-    let (result, carry2) = (*t_hi).overflowing_add(m_hi);
+    // Carry idiom rationale in `wide_redc_ct`.
+    let sum_lo = (*t_lo).wrapping_add(m_lo);
+    let carry1 = sum_lo.ct_lt(t_lo);
+    let result = (*t_hi).wrapping_add(m_hi);
+    let carry2 = result.ct_lt(t_hi);
     let (result, extra_bit) = accumulate_high_half_carry_ct(result, carry1, carry2);
 
     let sub_result = result.wrapping_sub(*modulus);
     let result_lt_modulus = result.ct_lt(modulus);
-    let needs_sub = Choice::from(extra_bit as u8) | !result_lt_modulus;
+    let needs_sub = extra_bit | !result_lt_modulus;
     T::conditional_select(&result, &sub_result, needs_sub)
 }
 
@@ -843,7 +859,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
@@ -890,7 +907,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + const_num_traits::CtIsZero
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
@@ -948,15 +966,19 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + subtle::ConstantTimeLess
         + core::ops::Add<Output = T>
         + subtle::ConditionallySelectable,
 {
     let (m_lo, m_hi) = a.wide_mul(&b);
-    let (new_lo, carry1) = acc_lo.overflowing_add(m_lo);
-    let (sum_hi, _) = acc_hi.overflowing_add(m_hi);
-    let (r, _) = sum_hi.overflowing_add(T::one());
-    let new_hi = T::conditional_select(&sum_hi, &r, subtle::Choice::from(carry1 as u8));
+    // Carry idiom rationale in `wide_redc_ct`; the two adds whose
+    // flags were discarded are plain wrapping adds.
+    let new_lo = acc_lo.wrapping_add(m_lo);
+    let carry1 = new_lo.ct_lt(&acc_lo);
+    let sum_hi = acc_hi.wrapping_add(m_hi);
+    let r = sum_hi.wrapping_add(T::one());
+    let new_hi = T::conditional_select(&sum_hi, &r, carry1);
     (new_lo, new_hi)
 }
 
@@ -994,15 +1016,18 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingAdd
+        + subtle::ConstantTimeLess
         + core::ops::Add<Output = T>
         + subtle::ConditionallySelectable,
 {
     let (m_lo, m_hi) = a.wide_mul(b);
-    let (new_lo, carry1) = (*acc_lo).overflowing_add(m_lo);
-    let (sum_hi, _) = (*acc_hi).overflowing_add(m_hi);
-    let (r, _) = sum_hi.overflowing_add(T::one());
-    let new_hi = T::conditional_select(&sum_hi, &r, subtle::Choice::from(carry1 as u8));
+    // Carry idiom rationale in `wide_redc_ct`.
+    let new_lo = (*acc_lo).wrapping_add(m_lo);
+    let carry1 = new_lo.ct_lt(acc_lo);
+    let sum_hi = (*acc_hi).wrapping_add(m_hi);
+    let r = sum_hi.wrapping_add(T::one());
+    let new_hi = T::conditional_select(&sum_hi, &r, carry1);
     (new_lo, new_hi)
 }
 
@@ -1299,9 +1324,9 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::WrappingSub
         + const_num_traits::CtIsZero
         + Parity
@@ -1359,9 +1384,9 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::WrappingMul
         + const_num_traits::WrappingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::WrappingSub
         + const_num_traits::CtIsZero
         + Parity
@@ -2285,7 +2310,12 @@ mod tests {
             for &carry1 in &[false, true] {
                 for &carry2 in &[false, true] {
                     let nct = accumulate_high_half_carry(result, carry1, carry2);
-                    let ct = accumulate_high_half_carry_ct(result, carry1, carry2);
+                    let ct = accumulate_high_half_carry_ct(
+                        result,
+                        Choice::from(carry1 as u8),
+                        Choice::from(carry2 as u8),
+                    );
+                    let ct = (ct.0, bool::from(ct.1));
                     assert_eq!(
                         nct, ct,
                         "mismatch at result={result} carry1={carry1} carry2={carry2}"


### PR DESCRIPTION
Second leg of closing the riscv32 findings from #27, following modmath-cios 0.1.1 (#28).

`overflowing_add`'s carry flag has no branchless materialization on ISAs without a flags register — LLVM lowers the 64-bit carry-out as an equality-branch chain on operand-derived values on riscv32. This sweeps the CT wide-REDC path onto the `sum.ct_lt(&a)` wraparound idiom already used by safegcd's `se_add` and `Field::add`: pure mask arithmetic on every target, and the carry is born a `subtle::Choice`, so the `Choice::from(bool)` laundering at the finalize sites disappears too.

**Swept:** `mod_double_ct`, `wide_redc_ct` / `strict_wide_redc_ct`, `wide_montgomery_mul_acc_ct` / strict variant, and `accumulate_high_half_carry_ct` (now `Choice`-typed; its `+1` overflow test becomes `ct_is_zero`). Bounds shrink from `OverflowingAdd` to `WrappingAdd` (+`CtIsZero`) through the CT call chain — relaxing pub fn bounds is non-breaking. The Nct twins are untouched (variable time is their documented contract), and the `mod_exp_pr_*_ct` entries keep `OverflowingAdd` for their intentionally-NCT public-modulus precompute.

**Acceptance test:** `RISCV32_EXTRA_HELPERS` is deleted outright — with this sweep plus modmath-cios 0.1.1 resolving from the registry, the riscv32 asm-grep rows pass with **zero allowances**. Verified locally on the pinned 1.86: all seven matrix targets green, 437 workspace tests pass, and the ctgrind taint gate re-verified clean (13/13, 3/3) after the rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)