### PR TITLE
Add panic-free audit; make safegcd's top-bit mask panic-proof

### DIFF
--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -88,3 +88,37 @@ jobs:
           name: ct-report-${{ matrix.triple }}
           path: target/ct-report/
           retention-days: 30
+
+  # A reachable panic in CT code is both a DoS edge and a timing oracle
+  # (the formatting path's cost depends on the values being formatted).
+  # Two representative ISAs; the property is codegen-level, not
+  # per-target.
+  panic-audit:
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        triple:
+          - thumbv7m-none-eabi
+          - riscv32imc-unknown-none-elf
+    runs-on: ubuntu-latest
+    name: panic-audit ${{ matrix.triple }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.86"
+          targets: ${{ matrix.triple }}
+          components: llvm-tools-preview
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: panic-audit-${{ matrix.triple }}
+
+      - name: Run panic-free audit
+        run: ./ct-verify/panic-free-audit/check.sh ${{ matrix.triple }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "ct-verify/ct-fixtures",
     "ct-verify/ct-ctgrind",
     "ct-verify/ct-driver",
+    "ct-verify/panic-free-audit",
 ]
 
 # Bare `cargo build` (and the CI cross-compiles to thumb targets) should

--- a/ct-verify/README.md
+++ b/ct-verify/README.md
@@ -10,7 +10,7 @@ where Valgrind does; asm-grep runs on every cross target and catches
 data-dependent branches that only materialize in a particular ISA's
 lowering (no conditional select, no flags register).
 
-Three members:
+Four members:
 
 - **`ct-fixtures`** — one `#[no_mangle] pub extern "C"` symbol per
   (CT entry point, carrier) pair, `core::hint::black_box` at both ends
@@ -41,6 +41,15 @@ Three members:
   `overflowing_add` — the overflow flag's materialization lowers to
   equality-branch chains on ISAs without a flags register (riscv32),
   which is how this gate caught the original findings there.
+- **`panic-free-audit`** — `#[no_mangle]` wrappers over the CT surface
+  shaped like a deployed consumer: no `unwrap`, `Odd::new_unchecked` at
+  the trust boundary, `CtOption` results observed through `black_box`
+  instead of extracted. `check.sh` cross-builds the staticlib and
+  asserts no `core::panicking` machinery was synthesized — for CT code
+  a reachable panic is both a DoS edge and a timing oracle. Its first
+  run caught a live one: safegcd's runtime-amount `one << (n_bits − 1)`
+  kept the multi-limb shift impl's bounds-check panic alive through
+  LTO.
 
 Which inputs are tainted mirrors each entry's documented secrecy
 contract, not a blanket "everything is secret": the wide-mul/REDC and

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "panic-free-audit"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.86"
+publish = false
+description = "Linker-DCE audit: confirm modmath's CT surface synthesizes no panic symbols."
+
+[lib]
+# staticlib so a cross-target build produces a `.a` that llvm-nm can
+# read without needing a linker script or runtime. Same shape as
+# `ct-verify/ct-fixtures`.
+crate-type = ["staticlib"]
+
+[features]
+default = []
+# See lib.rs — enabled by check.sh for the cross-built staticlib.
+panic-handler = []
+
+[dependencies]
+modmath = { path = "../../modmath" }
+# Registry, not path — same trait-identity rationale as ct-fixtures.
+fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] }
+const-num-traits = { version = "0.1.1", default-features = false, features = ["ct"] }
+subtle = { version = "2.6", default-features = false }
+
+# Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,
+# panic=abort) is what makes DCE worth measuring; do not override here.

--- a/ct-verify/panic-free-audit/check.sh
+++ b/ct-verify/panic-free-audit/check.sh
@@ -13,14 +13,16 @@ set -eu
 TARGET="${1:-thumbv7m-none-eabi}"
 HOST="$(rustc -vV | sed -n 's/^host: //p')"
 NM="$(rustc --print sysroot)/lib/rustlib/${HOST}/bin/llvm-nm"
-ARCHIVE="target/${TARGET}/release/libpanic_free_audit.a"
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+ARCHIVE="${TARGET_DIR}/${TARGET}/release/libpanic_free_audit.a"
 
-cargo build --release -p panic-free-audit --features panic-handler --target "$TARGET"
-
+# Tooling check before the build — cargo is the expensive step.
 if [ ! -x "$NM" ]; then
     echo "error: llvm-nm not found at $NM (install the llvm-tools-preview component)" >&2
     exit 2
 fi
+
+cargo build --release -p panic-free-audit --features panic-handler --target "$TARGET"
 
 FOUND="$("$NM" "$ARCHIVE" | grep -E 'core9panicking|panic_fmt|unwrap_failed|expect_failed|panic_bounds_check|slice_(start|end)_index' || true)"
 if [ -n "$FOUND" ]; then

--- a/ct-verify/panic-free-audit/check.sh
+++ b/ct-verify/panic-free-audit/check.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Panic-free audit: cross-build the audit staticlib and assert no panic
+# machinery was synthesized into it. Usage: check.sh [target-triple]
+# (defaults to thumbv7m-none-eabi; requires the rustup target and the
+# llvm-tools-preview component).
+#
+# The grep deliberately excludes the crate's own #[panic_handler]
+# definition (`rust_begin_unwind` is a lang item and always emitted);
+# what must be absent is anything from core::panicking — its presence
+# means some audited path can actually reach a panic.
+set -eu
+
+TARGET="${1:-thumbv7m-none-eabi}"
+HOST="$(rustc -vV | sed -n 's/^host: //p')"
+NM="$(rustc --print sysroot)/lib/rustlib/${HOST}/bin/llvm-nm"
+ARCHIVE="target/${TARGET}/release/libpanic_free_audit.a"
+
+cargo build --release -p panic-free-audit --features panic-handler --target "$TARGET"
+
+if [ ! -x "$NM" ]; then
+    echo "error: llvm-nm not found at $NM (install the llvm-tools-preview component)" >&2
+    exit 2
+fi
+
+FOUND="$("$NM" "$ARCHIVE" | grep -E 'core9panicking|panic_fmt|unwrap_failed|expect_failed|panic_bounds_check|slice_(start|end)_index' || true)"
+if [ -n "$FOUND" ]; then
+    echo "panic machinery found in ${ARCHIVE}:" >&2
+    echo "$FOUND" >&2
+    exit 1
+fi
+echo "OK: no panic symbols in ${ARCHIVE}"

--- a/ct-verify/panic-free-audit/src/lib.rs
+++ b/ct-verify/panic-free-audit/src/lib.rs
@@ -1,0 +1,149 @@
+//! Linker-DCE audit for modmath's CT surface.
+//!
+//! Each `#[no_mangle] pub extern "C"` symbol exercises one CT entry
+//! point the way a deployed consumer would — no `unwrap`, no `expect`,
+//! `Odd::new_unchecked` at the trust boundary, `CtOption` results
+//! observed through `black_box` instead of extracted. After
+//! cross-building with the workspace release profile, `check.sh`
+//! asserts the resulting archive contains no `core::panicking`
+//! machinery: for CT code a reachable panic is both a DoS edge and a
+//! timing oracle (the panic formatting path's cost depends on the
+//! values being formatted).
+//!
+//! `black_box` at every boundary so the optimizer can't fold inputs
+//! through and DCE the body wholesale (same hygiene as ct-fixtures).
+
+// no_std + the local #[panic_handler] only under the `panic-handler`
+// feature (the cross-built audit shape, enabled by check.sh) — host-side
+// workspace builds (clippy, tests) link std, which supplies its own.
+#![cfg_attr(feature = "panic-handler", no_std)]
+#![allow(non_snake_case)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use core::hint::black_box;
+
+use const_num_traits::Ct;
+use fixed_bigint::FixedUInt;
+use modmath::basic::montgomery::ct::pre_reduced as mont_ct_pr;
+use modmath::basic::montgomery::wide::ct as wide_ct;
+use modmath::{CiosMontMulCt, Field};
+
+type Fb256 = FixedUInt<u32, 8, Ct>;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn panic_audit__wide_mont_mul_ct__u64(
+    a: u64,
+    b: u64,
+    m: u64,
+    np: u64,
+    out: *mut u64,
+) {
+    let r = wide_ct::mul(black_box(a), black_box(b), black_box(m) | 1, black_box(np));
+    unsafe { *out = black_box(r) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn panic_audit__wide_redc_ct__u64(
+    t_lo: u64,
+    t_hi: u64,
+    m: u64,
+    np: u64,
+    out: *mut u64,
+) {
+    let r = wide_ct::redc(
+        black_box(t_lo),
+        black_box(t_hi),
+        black_box(m) | 1,
+        black_box(np),
+    );
+    unsafe { *out = black_box(r) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn panic_audit__cios_mont_mul_ct__fb32(
+    a: *const [u32; 8],
+    b: *const [u32; 8],
+    m: *const [u32; 8],
+    np: *const [u32; 8],
+    out: *mut [u32; 8],
+) {
+    let a = Fb256::from(black_box(unsafe { *a }));
+    let b = Fb256::from(black_box(unsafe { *b }));
+    let mut mw = black_box(unsafe { *m });
+    mw[0] |= 1;
+    let m = Fb256::from(mw);
+    let np = Fb256::from(black_box(unsafe { *np }));
+    let r = CiosMontMulCt::cios_mont_mul_ct(&a, &b, &m, &np);
+    unsafe { *out = black_box(*r.words()) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn panic_audit__mod_exp_pr_odd_ct__fb32(
+    base: *const [u32; 8],
+    e: *const [u32; 8],
+    m: *const [u32; 8],
+    out: *mut [u32; 8],
+) {
+    let base = Fb256::from(black_box(unsafe { *base }));
+    let e = Fb256::from(black_box(unsafe { *e }));
+    let mut mw = black_box(unsafe { *m });
+    mw[0] |= 1;
+    // SAFETY: low bit forced above.
+    let m = unsafe { modmath::Odd::new_unchecked(Fb256::from(mw)) };
+    let r = mont_ct_pr::mod_exp_odd(base, e, m);
+    unsafe { *out = black_box(*r.words()) }
+}
+
+/// The constructor a consumer calls with a secret modulus. The returned
+/// `CtOption<Field>` is observed whole — extracting it is the caller's
+/// panic site, not the library's.
+#[unsafe(no_mangle)]
+pub extern "C" fn panic_audit__try_new_odd_ct__fb32(m: *const [u32; 8]) -> u8 {
+    let mut mw = black_box(unsafe { *m });
+    mw[0] |= 1;
+    let f = Field::<Fb256, Ct>::try_new_odd_ct(Fb256::from(mw));
+    let is_some = f.is_some().unwrap_u8();
+    let _ = black_box(f);
+    black_box(is_some)
+}
+
+/// The full blinding-shaped pipeline with zero extraction points:
+/// infallible construction via the `Odd` proof, reduce → exp →
+/// inv_safegcd_ct (observed, not unwrapped) → into_raw, plus the
+/// ladder-support cswap / ct_eq.
+#[unsafe(no_mangle)]
+pub extern "C" fn panic_audit__field_ct_pipeline__fb32(
+    m: *const [u32; 8],
+    x: *const [u32; 8],
+    e: *const [u32; 8],
+    choice: u8,
+    out: *mut [u32; 8],
+) -> u8 {
+    let mut mw = black_box(unsafe { *m });
+    mw[0] |= 1;
+    let x = Fb256::from(black_box(unsafe { *x }));
+    let e = Fb256::from(black_box(unsafe { *e }));
+    // SAFETY: low bit forced above.
+    let proof = unsafe { modmath::Odd::new_unchecked(Fb256::from(mw)) };
+    let f = Field::<Fb256, Ct>::new_odd_ct(proof);
+
+    let mut r = f.reduce(&x);
+    let mut powed = f.exp(&r, &e);
+    let inv = f.inv_safegcd_ct(&powed);
+    let is_some = inv.is_some().unwrap_u8();
+    let _ = black_box(inv);
+    modmath::Residue::cswap(
+        subtle::Choice::from(black_box(choice) & 1),
+        &mut r,
+        &mut powed,
+    );
+    let eq = r.ct_eq(&powed);
+    unsafe { *out = black_box(*f.into_raw(&r).words()) }
+    black_box(is_some ^ eq.unwrap_u8())
+}
+
+#[cfg(feature = "panic-handler")]
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -297,8 +297,13 @@ where
     let n_bits = value.word_count() * core::mem::size_of::<T::Word>() * 8;
     let total_steps = divsteps_total(n_bits);
     // Loop invariants for se_shr1 / half_mod_ct — hoisted so each
-    // divstep doesn't redo a full-width shift.
-    let top_bit_mask = T::one() << (n_bits - 1);
+    // divstep doesn't redo a full-width shift. The mask is MAX − (MAX
+    // >> 1) rather than `one << (n_bits − 1)`: a runtime shift amount
+    // defeats const-folding through multi-limb Shl impls, keeping
+    // their index bounds-check panic path alive post-LTO (flagged by
+    // the panic-free audit); a constant-amount shift folds clean.
+    let max = T::zero().wrapping_sub(T::one());
+    let top_bit_mask = max.wrapping_sub(max.clone() >> 1);
     let m_half = modulus.clone() >> 1;
 
     let mut f = SignedExt {


### PR DESCRIPTION
Completes Step 6 of the CT hardening plan — the last unfinished phase item.

## What's here

- **`ct-verify/panic-free-audit`** — `#[no_mangle]` wrappers over the CT surface shaped like a deployed consumer: no `unwrap`, `Odd::new_unchecked` at the trust boundary, `CtOption` results observed through `black_box` instead of extracted (extraction is the caller's panic site, not the library's). Covers the wide-mul/REDC pair, CIOS, CT modexp, `try_new_odd_ct`, and a full blinding-shaped pipeline (`new_odd_ct` → reduce → exp → `inv_safegcd_ct` → cswap/ct_eq → into_raw).
- **`check.sh`** — cross-builds the staticlib with the pinned release profile and asserts via `llvm-nm` that no `core::panicking` machinery was synthesized. For CT code a reachable panic is both a DoS edge and a timing oracle (the formatting path's cost depends on the values being formatted). fixed-bigint's equivalent audit is manual; this one is a CI job (thumbv7m + riscv32imc rows in `ct-verify.yml` — the property is codegen-level, not per-target).

## The audit's first run caught a live panic path

`panic_bounds_check` + `panic_fmt` were reachable from the blinding pipeline, traced (via the line-table debug info from #26's review round, pleasingly) to safegcd's hoisted `one << (n_bits − 1)`: a **runtime** shift amount defeats const-folding through the multi-limb `Shl` impl, keeping its word-move index bounds-check alive post-LTO. The mask is now `MAX − (MAX >> 1)` — constant-amount shift only, same value, no new trait bounds — and the panic machinery disappears from the archive on every audited target.

Asm-grep (7 targets) and ctgrind gates re-verified green after the safegcd change; 437 workspace tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)