### PR TITLE
v0.4.2: refresh README, fill rustdoc gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,23 @@
 [![Coverage Status](https://coveralls.io/repos/github/kaidokert/modmath-rs/badge.svg?branch=main)](https://coveralls.io/github/kaidokert/modmath-rs?branch=main)
 
 
-Yet another mod math implementation, but written for _traits_. Functions
-are constrained by `core::ops::` and [`const-num-traits`](https://crates.io/crates/const-num-traits)
-traits, so any integer backend implementing them works — no concrete
-bigint type is named anywhere.
+Yet another mod math implementation, but written for _traits_. Everything
+is constrained by `core::ops::` and
+[`const-num-traits`](https://crates.io/crates/const-num-traits) traits.
 
 Implements:
 - Unsigned modular addition and subtraction
 - Unsigned modular multiplication
 - Unsigned modular exponentiation
-- Unsigned modular inverse (extended Euclidean, and constant-time
-  Bernstein–Yang for odd moduli)
-- Unsigned modular Montgomery multiply (wide-REDC and CIOS)
+- Unsigned modular inverse
+- Unsigned modular Montgomery multiply
 - Unsigned modular Montgomery exponentiation
+- Constant-time variants of the Montgomery and inverse paths, behind a
+  `Ct` typestate
 
-Two ways in:
-- Free functions under the `basic` / `constrained` / `strict` modules —
-  the same algorithms over three operand shapes (`Copy` by-value,
-  `Clone` mixed, reference-based).
-- `Field<T, P>` — precomputed Montgomery parameters with lifetime-branded
-  residues. The `P` typestate selects the personality: `Nct` for
-  variable-time verify paths, `Ct` for constant-time sign/decrypt paths,
-  where operations finalize branchlessly and variable-time entry points
-  are rejected at compile time.
+The code isn't intended to be fast or efficient, just as generic as possible
+to work with multiple implementations.
 
-The constant-time surface is checked in CI by the harnesses under
-`ct-verify/`: Valgrind taint analysis on x86_64/aarch64, per-target
-disassembly scanning on Cortex-M and RISC-V, and a panic-free linker
-audit. See `ct-verify/README.md` for what each layer does and doesn't
-cover.
-
-`no_std`, no-alloc. The generic code trades speed for portability; if
-you need maximum performance, use a dedicated bigint crate's own
-modular arithmetic.
+Note: While `const` traits are not yet stable and commonplace, this cannot
+be very efficient. In almost all real world code you'll want to directly use
+crates that implement big integers with `const` functions.

--- a/README.md
+++ b/README.md
@@ -6,21 +6,36 @@
 [![Coverage Status](https://coveralls.io/repos/github/kaidokert/modmath-rs/badge.svg?branch=main)](https://coveralls.io/github/kaidokert/modmath-rs?branch=main)
 
 
-Yet another mod math implementation, but written for _traits_. All functions
-are free functions that are constrainted by `core::ops::` and `num_traits::`
-traits.
+Yet another mod math implementation, but written for _traits_. Functions
+are constrained by `core::ops::` and [`const-num-traits`](https://crates.io/crates/const-num-traits)
+traits, so any integer backend implementing them works — no concrete
+bigint type is named anywhere.
 
 Implements:
 - Unsigned modular addition and subtraction
 - Unsigned modular multiplication
 - Unsigned modular exponentiation
-- Unsigned modular inverse
-- Unsigned modular Montgomery multiply
+- Unsigned modular inverse (extended Euclidean, and constant-time
+  Bernstein–Yang for odd moduli)
+- Unsigned modular Montgomery multiply (wide-REDC and CIOS)
 - Unsigned modular Montgomery exponentiation
 
-The code isn't intended to be fast or efficient, just as generic as possible
-to work with multiple implementations.
+Two ways in:
+- Free functions under the `basic` / `constrained` / `strict` modules —
+  the same algorithms over three operand shapes (`Copy` by-value,
+  `Clone` mixed, reference-based).
+- `Field<T, P>` — precomputed Montgomery parameters with lifetime-branded
+  residues. The `P` typestate selects the personality: `Nct` for
+  variable-time verify paths, `Ct` for constant-time sign/decrypt paths,
+  where operations finalize branchlessly and variable-time entry points
+  are rejected at compile time.
 
-Note: While `const` traits are not yet stable and commonplace, this cannot
-be very efficient. In almost all real world code you'll want to directly use
-crates that implement big integers with `const` functions.
+The constant-time surface is checked in CI by the harnesses under
+`ct-verify/`: Valgrind taint analysis on x86_64/aarch64, per-target
+disassembly scanning on Cortex-M and RISC-V, and a panic-free linker
+audit. See `ct-verify/README.md` for what each layer does and doesn't
+cover.
+
+`no_std`, no-alloc. The generic code trades speed for portability; if
+you need maximum performance, use a dedicated bigint crate's own
+modular arithmetic.

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = """
 Modular math implemented with traits.

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -70,6 +70,8 @@ pub trait MontStorage: zeroize::Zeroize {}
 #[cfg(feature = "zeroize")]
 impl<T: zeroize::Zeroize> MontStorage for T {}
 
+/// Bound on the value stored in a [`Residue`]. With the `zeroize`
+/// feature this requires `T: Zeroize`; otherwise it's vacuous.
 #[cfg(not(feature = "zeroize"))]
 pub trait MontStorage {}
 #[cfg(not(feature = "zeroize"))]

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -1073,6 +1073,8 @@ where
     basic_montgomery_mod_mul_pr_odd(reduce_mod(a, m), reduce_mod(b, m), modulus)
 }
 
+/// Returns None if modulus is even or zero. Thin wrapper around
+/// [`basic_montgomery_mod_mul_odd`].
 pub fn basic_montgomery_mod_mul<T>(a: T, b: T, modulus: T) -> Option<T>
 where
     T: Copy

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -280,6 +280,9 @@ where
     strict_mod_mul_pr(a.rem_nonzero(m), &b_mod, &m_raw)
 }
 
+/// # Modular Multiplication (Strict)
+/// Most constrained version that works with references. Reduces both
+/// operands, then multiplies via repeated modular doubling.
 pub fn strict_mod_mul<T>(mut a: T, b: &T, m: &T) -> T
 where
     T: Clone


### PR DESCRIPTION
Version bump shipping the accumulated CT fixes over 0.4.1 — the thumbv6m `ct_i64_positive` select-rewrite fix (#27), the `ct_lt` carry sweep (#29), and the panic-proof safegcd top-bit mask (#30).

## README

Corrections only, original shape and voice kept: `const-num-traits` instead of the stale `num_traits` reference, a typo, and one feature-list line for the `Ct` typestate. No overview sections, no harness/CI material — that lives in rustdoc and `ct-verify/README.md`.

## Public API review (rustdoc JSON)

Top-level surface is 4 modules + 21 re-exports; verdict: **coherent, left as-is.**

- The typestate set (`Field`/`FieldCt`/`FieldNct`, `Residue` + aliases, `MontStorage`), the bound-building traits (`NonCt`, `Parity`, `WideMul`, `CiosMontMul(Ct)`), and the proof types (`Odd`, `DivNonZero`, `HasNonZero`) all earn their root placement — consumers need to name them.
- The root-level Montgomery precompute helpers (`compute_*`, `type_bit_width`, `NPrimeMethod`) are the debatable set — they'd read more naturally only under `modmath::montgomery`. They're documented as deliberate and removal is breaking, so noted as 0.5 demotion candidates rather than touched.
- `safegcd_inv_ct` deliberately has no free-function path — `Field::inv_safegcd_ct` is the supported entry.
- Three undocumented public items found and fixed (`basic_montgomery_mod_mul`, `strict_mod_mul`, the non-zeroize `MontStorage` branch).

## Semver note

The #29 carry sweep added `CtIsZero`/`ConstantTimeLess` bounds to a few `Field<T, Ct>` methods and the wide-REDC free functions. Strictly that's a breaking change dressed as a patch; every supported carrier (primitives, `FixedUInt`) satisfies the new bounds via const-num-traits, and third-party backends are disabled pending the migration, so 0.4.2 seems fine — flagging in case you'd rather call it 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the crate overview wording to match the trait-based constraint surface and updated the description of constant-time variants (including Montgomery and modular inverse paths via `Ct`).
  * Clarified that `Residue`’s stored value is bounded, with the bound depending on whether the `zeroize` feature is enabled.
  * Added documentation on Montgomery multiplication returning `None` for even/zero moduli and improved `strict_mod_mul` explanations.

* **Chores**
  * Bumped the crate version to `0.4.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
