### PR TITLE
Shed vestigial bounds from the CT where-clauses

### DIFF
--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -89,6 +89,17 @@ pub mod pre_reduced {
 /// hasn't published one (the CIOS path is the canonical CT-mul entry
 /// point — see
 /// [`cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)).
+///
+/// # Operator contract
+///
+/// CT entry points never invoke plain `+` / `-` / `*` on the carrier:
+/// every overflow-relevant operation goes through an explicitly-named
+/// trait (`WrappingAdd`/`WrappingSub`/`WrappingMul`, `BorrowingSub`,
+/// `CtIsZero`, subtle's comparisons), so a backend whose `core::ops`
+/// impls panic on overflow is safe here. Where a `core::ops` bound
+/// does appear in a CT where-clause, it is the `Output = T` pin that
+/// const-num-traits' named ops are defined against — a type-level
+/// requirement, not a call.
 pub mod ct {
     /// Pre-reduced CT variants. Precondition: `base < modulus`.
     pub mod pre_reduced {

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -277,7 +277,7 @@ where
     /// [`new_odd`]: Self::new_odd
     pub fn new_odd_ct(modulus: Odd<T>) -> Self
     where
-        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess + const_num_traits::CtIsZero,
+        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess,
     {
         let modulus = modulus.get();
         let w = type_bit_width::<T>();
@@ -637,10 +637,7 @@ where
     /// [`CtParity`]: const_num_traits::CtParity
     pub fn try_new_odd_ct(modulus: T) -> subtle::CtOption<Self>
     where
-        T: const_num_traits::CtParity
-            + const_num_traits::CtIsZero
-            + subtle::ConditionallySelectable
-            + subtle::ConstantTimeLess,
+        T: const_num_traits::CtParity + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
     {
         // Mask the parity check (no branch on the secret modulus). The
         // precompute below uses the CT path ([`Self::new_odd_ct`]) so
@@ -757,7 +754,6 @@ where
         T: CiosMontMulCt
             + const_num_traits::CtIsZero
             + subtle::ConditionallySelectable
-            + subtle::ConstantTimeEq
             + core::ops::Shr<usize, Output = T>
             + core::ops::BitAnd<Output = T>,
     {
@@ -912,7 +908,6 @@ where
         T: CiosMontMulCt
             + const_num_traits::CtIsZero
             + subtle::ConditionallySelectable
-            + subtle::ConstantTimeEq
             + core::ops::Shr<usize, Output = T>
             + core::ops::BitAnd<Output = T>,
     {
@@ -945,14 +940,12 @@ where
     /// [`inv_fermat`]: Self::inv_fermat
     pub fn inv_safegcd_ct(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>
     where
-        T: CiosMontMulCt
-            + WideMul
+        T: WideMul
             + subtle::ConditionallySelectable
             + subtle::ConstantTimeLess
             + const_num_traits::CtIsZero
             + modmath_cios::CiosRowOps
             + core::ops::Shr<usize, Output = T>
-            + core::ops::Shl<usize, Output = T>
             + core::ops::BitOr<Output = T>,
         <T as modmath_cios::CiosRowOps>::Word: const_num_traits::CtParity,
     {

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -290,7 +290,6 @@ where
         + WrappingAdd<Output = T>
         + WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + core::ops::Shl<usize, Output = T>
         + core::ops::BitOr<Output = T>,
     T::Word: CtParity,
 {

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -515,7 +515,6 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingAdd
-        + const_num_traits::CtIsZero
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -560,12 +559,10 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingAdd
-        + const_num_traits::CtIsZero
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
         + subtle::ConstantTimeLess,
 {
     mod_exp2_ct(T::one(), modulus, w)
@@ -597,12 +594,10 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingAdd
-        + const_num_traits::CtIsZero
         + const_num_traits::WrappingSub
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
         + subtle::ConstantTimeLess,
 {
     mod_exp2_ct(r_mod_n, modulus, w)
@@ -759,7 +754,6 @@ where
 pub fn wide_redc_ct<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
         + const_num_traits::WrappingAdd
@@ -798,7 +792,6 @@ where
 pub fn strict_wide_redc_ct<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
         + const_num_traits::WrappingAdd
@@ -856,7 +849,6 @@ where
 pub fn wide_montgomery_mul_ct<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
         + const_num_traits::WrappingAdd
@@ -904,7 +896,6 @@ where
 pub fn strict_wide_montgomery_mul_ct<T>(a_mont: &T, b_mont: &T, modulus: &T, n_prime: &T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + WideMul
         + const_num_traits::WrappingAdd
@@ -955,10 +946,11 @@ where
 
 /// Wide multiply-accumulate — constant-time carry propagation.
 ///
-/// Same shape as [`wide_montgomery_mul_acc`] but routes the carry
-/// combination through `accumulate_high_half_carry_ct` so the
-/// per-term cost has no value-dependent branches. Use in CT-sensitive
-/// paths; pair with [`wide_redc_ct`] for the final reduction.
+/// Same shape as [`wide_montgomery_mul_acc`] but the carry select is
+/// branchless (`ct_lt`-derived `Choice` into `conditional_select`), so
+/// the per-term cost has no value-dependent branches. Use in
+/// CT-sensitive paths; pair with [`wide_redc_ct`] for the final
+/// reduction.
 ///
 /// Same bound as [`wide_montgomery_mul_acc`] — caller-verified `N ≤ R/q`.
 pub fn wide_montgomery_mul_acc_ct<T>(acc_lo: T, acc_hi: T, a: T, b: T) -> (T, T)
@@ -1331,14 +1323,12 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + const_num_traits::WrappingSub
         + const_num_traits::CtIsZero
-        + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
         + subtle::ConstantTimeLess,
 {
     let modulus = modulus.get();
@@ -1398,7 +1388,6 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeEq
         + subtle::ConstantTimeLess,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd_ct(base, exponent, m))

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -82,12 +82,12 @@ where
 /// CIOS Montgomery multiplication — constant-time finalize.
 ///
 /// Same algorithm as [`cios_montgomery_mul`] but performs the final
-/// conditional subtraction branchlessly via `subtle::ConditionallySelectable`
-/// and `subtle::ConstantTimeEq`, removing the operand-magnitude side-channel.
+/// conditional subtraction branchlessly via `subtle::ConditionallySelectable`,
+/// removing the operand-magnitude side-channel.
 ///
-/// `acc_hi` is a `T::Word`; we use `ConstantTimeEq` on the word for the
-/// "high half nonzero" test. The "low half ≥ modulus" test is free — the
-/// borrow flag from `borrowing_sub` already encodes `acc < modulus`.
+/// `acc_hi` is a `T::Word`; its `CtIsZero` provides the "high half
+/// nonzero" test. The "low half ≥ modulus" test is free — the borrow
+/// flag from `borrowing_sub` already encodes `acc < modulus`.
 pub fn cios_montgomery_mul_ct<T>(a: &T, b: &T, modulus: &T, n_prime_0: T::Word) -> T
 where
     T: CiosRowOps
@@ -102,7 +102,6 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>
-        + subtle::ConstantTimeEq
         + subtle::ConditionallySelectable,
 {
     let n = a.word_count();
@@ -194,7 +193,6 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>
-        + subtle::ConstantTimeEq
         + subtle::ConditionallySelectable,
 {
     #[inline]


### PR DESCRIPTION
Follow-up from the crypto-bigint/bnum ecosystem integration effort: an audit (three parallel per-file sub-agent passes, cross-checked, compiler-verified) of every `_ct` where-clause, classifying each bound as directly used / transitively required / dead.

## Deleted (dead)

- `CtIsZero` from `mod_exp2_ct` / `compute_r_mod_n_ct` / `compute_r2_mod_n_ct` and their `Field` constructors — those bodies use `ct_eq`, never `ct_is_zero`
- `Zero` from the four wide-REDC functions
- `Parity` from `basic_montgomery_mod_exp_pr_odd_ct` (never calls `Odd::new`)
- `ConstantTimeEq` where fully unused (`Field::exp` — the ladder compares nothing) or supertrait-implied via `ConstantTimeLess`
- `CiosMontMulCt` and `Shl` from `Field::inv_safegcd_ct` / `safegcd_inv_ct` — the inverse never CIOS-multiplies, and #30's top-bit-mask rewrite removed the last `<<`
- `Word: ConstantTimeEq` from the CIOS CT path (its rustdoc claimed `ct_eq` does the high-half test; the code uses `CtIsZero` — doc fixed)

## Deliberately kept: the `core::ops` Output pins

The audit's most useful finding is why `Add/Sub/Mul<Output = T>` **cannot** be shed wherever `Wrapping*`/`Borrowing*` bounds sit: const-num-traits defines its named ops against the core::ops associated type (`wrapping_sub` returns `<Self as Sub>::Output`, `borrowing_sub` likewise). Those bounds are type-level Output pins, not evidence that plain operators execute. Two of the audit agents initially flagged them as sheddable; the third caught the coupling, and the compiler confirms.

## The contract, written down

New "Operator contract" note on the `ct` hub: CT bodies never invoke plain `+`/`-`/`*` on the carrier — all overflow-relevant arithmetic goes through explicitly-named traits — so a backend whose `core::ops` impls panic on overflow (crypto-bigint) or mode-dispatch (bnum) satisfies the CT surface safely. This is the fact the integration session tripped over: the bounds *signaled* plain-op involvement that doesn't exist.

Relaxing pub fn bounds is non-breaking. Net diff: −34/+24 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened support for several constant-time field and Montgomery operations by loosening generic requirements, making more numeric types work without changing results.
  * Improved constant-time modular inversion and exponentiation paths so they align better with the operations they actually use.
  * Updated Montgomery reduction/multiplication handling to use a more consistent branchless final-selection approach.
* **Documentation**
  * Clarified constant-time operator expectations and the behavior of branchless carry and reduction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->