### PR TITLE
v0.4.3

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = """
 Modular math implemented with traits.


### PR DESCRIPTION
Version bump for #32, which should have carried it: the CT where-clause relaxations (dropping unused `CtIsZero`/`Zero`/`Parity`/`ConstantTimeEq`/`CiosMontMulCt`/`Shl` bounds) are what third-party backend integrations consume, so they need a release to be reachable. Relaxed bounds are non-breaking — patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)