### PR TITLE
v0.5.0: migrate to const-num-traits 0.2

### DIFF
--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.1", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.2", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.2", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.4", default-features = false, features = ["cios"] }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", branch = "experiment/const-num-traits-0.2", default-features = false, features = ["cios"] }
+const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] }
-const-num-traits = { version = "0.1.1", default-features = false, features = ["ct"] }
+fixed-bigint = { path = "../../../fixed-bigint-rs", default-features = false, features = ["cios"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { path = "../../../fixed-bigint-rs", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.1", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", branch = "experiment/const-num-traits-0.2", default-features = false, features = ["cios"] }
+fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] }
 const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.4", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,7 +20,7 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.4", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,7 +20,7 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", branch = "experiment/const-num-traits-0.2", default-features = false, features = ["cios"] }
+fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] }
 const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,8 +20,8 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] }
-const-num-traits = { version = "0.1.1", default-features = false, features = ["ct"] }
+fixed-bigint = { path = "../../../fixed-bigint-rs", default-features = false, features = ["cios"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,8 +20,8 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.4", default-features = false, features = ["cios"] }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", branch = "experiment/const-num-traits-0.2", default-features = false, features = ["cios"] }
+const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,7 +20,7 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.1", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.2", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,7 +20,7 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.2", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,7 +20,7 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { path = "../../../fixed-bigint-rs", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.1", default-features = false, features = ["cios"] }
 const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,14 +16,17 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-const-num-traits = { version = "0.1.1", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 # Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
 # identity everywhere — modmath, its test binaries, and fixed-bigint's
 # dev-dep all resolve the same copy.
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.4", default-features = false, features = ["cios"] }
+# Temporarily a local path: fixed-bigint's const-num-traits-0.2 migration
+# branch isn't pushed/tagged yet. Move to the git tag (then the registry
+# version) when it lands. Dev-dep only, so nothing leaks to consumers.
+fixed-bigint = { path = "../../fixed-bigint-rs", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # so nothing leaks to consumers. The v0.5.0-alpha.3 tag was re-pointed
 # to fixed-bigint's version-revert commit, so the tagged manifest reads
 # 0.5.0 again; stale local caches need `git fetch --tags --force`.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.4", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -23,12 +23,7 @@ const-num-traits = { version = "0.2", default-features = false, features = ["ct"
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-# Git branch until fixed-bigint 0.5 publishes to crates.io (its alpha.4
-# tag still pins const-num-traits by git tag, which would split the
-# trait identity against our registry 0.2 dep; the branch tip carries
-# the registry flip). Dev-dep only, so nothing leaks to consumers.
-# Move to the next fixed-bigint tag, then the registry version.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", branch = "experiment/const-num-traits-0.2", default-features = false, features = ["cios"] }
+fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 description = """
 Modular math implemented with traits.

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -25,7 +25,7 @@ modmath-cios = { version = "0.1" }
 [dev-dependencies]
 # Git tag until fixed-bigint 0.5 publishes to crates.io. Dev-dep only,
 # so nothing leaks to consumers.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.2", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -23,10 +23,9 @@ const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = 
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-# Temporarily a local path: fixed-bigint's const-num-traits-0.2 migration
-# branch isn't pushed/tagged yet. Move to the git tag (then the registry
-# version) when it lands. Dev-dep only, so nothing leaks to consumers.
-fixed-bigint = { path = "../../fixed-bigint-rs", default-features = false, features = ["cios"] }
+# Git tag until fixed-bigint 0.5 publishes to crates.io. Dev-dep only,
+# so nothing leaks to consumers.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.1", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -24,7 +24,9 @@ modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
 # Git tag until fixed-bigint 0.5 publishes to crates.io. Dev-dep only,
-# so nothing leaks to consumers.
+# so nothing leaks to consumers. The v0.5.0-alpha.3 tag was re-pointed
+# to fixed-bigint's version-revert commit, so the tagged manifest reads
+# 0.5.0 again; stale local caches need `git fetch --tags --force`.
 fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.3", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,18 +16,19 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 # Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
 # identity everywhere — modmath, its test binaries, and fixed-bigint's
 # dev-dep all resolve the same copy.
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-# Git tag until fixed-bigint 0.5 publishes to crates.io. Dev-dep only,
-# so nothing leaks to consumers. The v0.5.0-alpha.3 tag was re-pointed
-# to fixed-bigint's version-revert commit, so the tagged manifest reads
-# 0.5.0 again; stale local caches need `git fetch --tags --force`.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.4", default-features = false, features = ["cios"] }
+# Git branch until fixed-bigint 0.5 publishes to crates.io (its alpha.4
+# tag still pins const-num-traits by git tag, which would split the
+# trait identity against our registry 0.2 dep; the branch tip carries
+# the registry flip). Dev-dep only, so nothing leaks to consumers.
+# Move to the next fixed-bigint tag, then the registry version.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", branch = "experiment/const-num-traits-0.2", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -25,7 +25,7 @@ modmath-cios = { version = "0.1" }
 [dev-dependencies]
 # Git tag until fixed-bigint 0.5 publishes to crates.io. Dev-dep only,
 # so nothing leaks to consumers.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.1", default-features = false, features = ["cios"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.5.0-alpha.2", default-features = false, features = ["cios"] }
 # Third-party bigint backends (num-bigint, bnum, crypto-bigint, ibig and
 # their `_patched` forks) are temporarily disabled while modmath migrates
 # to `const-num-traits`. Re-enable once those backends grow

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -10,9 +10,7 @@ c0nst::c0nst! {
         T: [c0nst] core::cmp::PartialOrd
             + Copy
             + [c0nst] OverflowingAdd<Output = T>
-            + [c0nst] core::ops::Add<Output = T>
             + [c0nst] OverflowingSub<Output = T>
-            + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Rem<Output = T>,
     {
         let a = a % m;
@@ -34,8 +32,6 @@ where
         + Copy
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
         + crate::NonCt,
 {
@@ -57,8 +53,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
@@ -73,8 +67,6 @@ where
         + Copy
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let sum = a.wrapping_add(b);
@@ -94,8 +86,6 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -116,8 +106,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
@@ -133,8 +121,6 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let sum = a.clone().wrapping_add(b.clone());
@@ -154,8 +140,6 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
@@ -178,8 +162,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
@@ -195,8 +177,6 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let (sum, overflow) = a.overflowing_add(b.clone());

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -9,9 +9,9 @@ c0nst::c0nst! {
     where
         T: [c0nst] core::cmp::PartialOrd
             + Copy
-            + [c0nst] OverflowingAdd
+            + [c0nst] OverflowingAdd<Output = T>
             + [c0nst] core::ops::Add<Output = T>
-            + [c0nst] OverflowingSub
+            + [c0nst] OverflowingSub<Output = T>
             + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Rem<Output = T>,
     {
@@ -32,8 +32,8 @@ pub fn basic_mod_add<T>(a: T, b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
@@ -55,8 +55,8 @@ where
         + Copy
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -71,8 +71,8 @@ pub fn basic_mod_add_pr<T>(a: T, b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -92,8 +92,8 @@ pub fn constrained_mod_add<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -114,8 +114,8 @@ where
         + Clone
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -131,8 +131,8 @@ pub fn constrained_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -152,8 +152,8 @@ pub fn strict_mod_add<T>(mut a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -176,8 +176,8 @@ where
         + Clone
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -193,8 +193,8 @@ pub fn strict_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -92,14 +92,14 @@ pub mod pre_reduced {
 ///
 /// # Operator contract
 ///
-/// CT entry points never invoke plain `+` / `-` / `*` on the carrier:
+/// CT entry points never invoke plain `+` / `-` / `*` on the carrier,
+/// and since const-num-traits 0.2 they no longer *bound* them either:
 /// every overflow-relevant operation goes through an explicitly-named
 /// trait (`WrappingAdd`/`WrappingSub`/`WrappingMul`, `BorrowingSub`,
-/// `CtIsZero`, subtle's comparisons), so a backend whose `core::ops`
-/// impls panic on overflow is safe here. Where a `core::ops` bound
-/// does appear in a CT where-clause, it is the `Output = T` pin that
-/// const-num-traits' named ops are defined against — a type-level
-/// requirement, not a call.
+/// `CtIsZero`, subtle's comparisons), each carrying its own `Output`.
+/// A backend can satisfy the entire CT surface without implementing
+/// `core::ops` arithmetic at all — panicking or mode-dispatched
+/// operator impls elsewhere in the carrier are irrelevant here.
 pub mod ct {
     /// Pre-reduced CT variants. Precondition: `base < modulus`.
     pub mod pre_reduced {

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -19,9 +19,7 @@ c0nst::c0nst! {
             + [c0nst] One
             + [c0nst] core::ops::BitAnd<Output = T>
             + [c0nst] OverflowingAdd<Output = T>
-            + [c0nst] core::ops::Add<Output = T>
             + [c0nst] OverflowingSub<Output = T>
-            + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Shr<usize, Output = T>
             + [c0nst] core::ops::ShrAssign<usize>
             + [c0nst] core::ops::Rem<Output = T>,
@@ -58,8 +56,6 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
         + Copy
         + crate::NonCt,
@@ -85,8 +81,6 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
         + Copy
         + crate::NonCt,
@@ -114,8 +108,6 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
         + Copy
         + crate::NonCt,
@@ -152,15 +144,10 @@ where
         + const_num_traits::Zero
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
-    for<'a> T: core::ops::RemAssign<&'a T>
-        + core::ops::DivAssign<&'a T>
-        + core::ops::Rem<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
+    for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: crate::parity::Parity,
 {
     if modulus == &T::one() {
@@ -181,8 +168,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
@@ -206,8 +191,6 @@ where
         + const_num_traits::Zero
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
@@ -247,15 +230,9 @@ where
         + const_num_traits::Zero
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
-    for<'a> T: core::ops::RemAssign<&'a T>
-        + core::ops::DivAssign<&'a T>
-        + core::ops::ShrAssign<usize>
-        + core::ops::Rem<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
+    for<'a> T: core::ops::RemAssign<&'a T> + core::ops::ShrAssign<usize>,
     for<'a> &'a T: crate::parity::Parity,
 {
     if modulus == &T::one() {
@@ -276,8 +253,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::ShrAssign<usize>,
@@ -301,8 +276,6 @@ where
         + const_num_traits::Zero
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::ShrAssign<usize>,

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -18,9 +18,9 @@ c0nst::c0nst! {
             + [c0nst] Zero
             + [c0nst] One
             + [c0nst] core::ops::BitAnd<Output = T>
-            + [c0nst] OverflowingAdd
+            + [c0nst] OverflowingAdd<Output = T>
             + [c0nst] core::ops::Add<Output = T>
-            + [c0nst] OverflowingSub
+            + [c0nst] OverflowingSub<Output = T>
             + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Shr<usize, Output = T>
             + [c0nst] core::ops::ShrAssign<usize>
@@ -56,8 +56,8 @@ where
         + crate::parity::Parity
         + core::ops::Rem<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
@@ -83,8 +83,8 @@ where
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
@@ -112,8 +112,8 @@ where
         + const_num_traits::Zero
         + crate::parity::Parity
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
@@ -150,8 +150,8 @@ where
         + PartialOrd
         + const_num_traits::One
         + const_num_traits::Zero
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
@@ -179,8 +179,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
@@ -204,8 +204,8 @@ where
         + PartialOrd
         + const_num_traits::One
         + const_num_traits::Zero
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::ShrAssign<usize>
@@ -245,8 +245,8 @@ where
         + PartialOrd
         + const_num_traits::One
         + const_num_traits::Zero
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -274,8 +274,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -299,8 +299,8 @@ where
         + PartialOrd
         + const_num_traits::One
         + const_num_traits::Zero
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -217,10 +217,10 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -360,10 +360,10 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -597,10 +597,10 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -213,18 +213,11 @@ impl<T, P: Personality> Field<T, P> {
 impl<T, P: Personality> Field<T, P>
 where
     T: Copy
-        + PartialEq
-        + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + Parity
         + MontStorage,
 {
     /// Construct a new `Field` from an already-proven-odd modulus.
@@ -241,7 +234,10 @@ where
     /// so this also discharges the modulus-nonzero check that [`new`] does.
     ///
     /// [`new`]: Self::new
-    pub fn new_odd(modulus: Odd<T>) -> Self {
+    pub fn new_odd(modulus: Odd<T>) -> Self
+    where
+        T: PartialEq + PartialOrd + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
+    {
         let modulus = modulus.get();
         let w = type_bit_width::<T>();
         let n_prime = compute_n_prime_newton(modulus, w);
@@ -302,7 +298,13 @@ where
     /// `Option<Self>` the caller must `.unwrap()`.
     ///
     /// [`new_odd`]: Self::new_odd
-    pub fn new(modulus: T) -> Option<Self> {
+    pub fn new(modulus: T) -> Option<Self>
+    where
+        T: PartialEq
+            + PartialOrd
+            + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+            + Parity,
+    {
         Odd::new(modulus).map(Self::new_odd)
     }
 
@@ -364,9 +366,6 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + Parity
         + crate::NonCt
         + MontStorage,
@@ -536,7 +535,11 @@ where
     /// paths. Returns `None` when `a` is not coprime to modulus.
     pub fn inv_eea(&self, a: &Residue<'_, T, Nct>) -> Option<Residue<'_, T, Nct>>
     where
-        T: WideMul + core::ops::Div<Output = T> + core::ops::Sub<Output = T>,
+        T: WideMul
+            + core::ops::Div<Output = T>
+            + core::ops::Add<Output = T>
+            + core::ops::Sub<Output = T>
+            + core::ops::Mul<Output = T>,
     {
         if a.mont == T::zero() {
             return None;
@@ -594,17 +597,11 @@ impl<T> Field<T, Ct>
 where
     T: Copy
         + PartialEq
-        + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
-        + Parity
         + MontStorage,
 {
     /// Construct a `Field<T, Ct>` from a **secret** modulus without a

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -34,10 +34,8 @@ where
         + core::ops::Sub<Output = T>
         + core::cmp::PartialOrd,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>
         + core::cmp::PartialOrd,
     for<'a> &'a T: core::ops::Div<&'a T, Output = T> + core::ops::Sub<T, Output = T>,
 {

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -671,7 +671,8 @@ where
 /// register-passes either way; the by-ref form matters for non-`Copy`
 /// bigint backends where each value pass would clone.
 ///
-/// Drops the `Copy` bound — usable with backends that don't impl it.
+/// Takes operands by reference; `T: Copy` is still required (the body
+/// deref-copies into the word-level kernel).
 pub fn strict_wide_redc<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
 where
     T: Copy
@@ -739,8 +740,8 @@ where
 /// REDC on a double-width input — constant-time finalize, reference-based inputs.
 ///
 /// Same algorithm as [`wide_redc_ct`] but takes all operands by reference,
-/// avoiding the per-call value copy. See [`strict_wide_redc`] for the
-/// rationale on dropping `Copy`.
+/// avoiding the per-call value copy. `T: Copy` is still required — see
+/// [`strict_wide_redc`].
 pub fn strict_wide_redc_ct<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
 where
     T: Copy

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -243,8 +243,8 @@ where
         + Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -263,8 +263,8 @@ where
         + Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -344,8 +344,8 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::BitAnd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::parity::Parity
@@ -378,8 +378,8 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::BitAnd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::parity::Parity
@@ -408,8 +408,8 @@ fn mod_double<T>(val: T, modulus: T) -> T
 where
     T: Copy
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
 {
@@ -430,10 +430,8 @@ where
 fn mod_double_ct<T>(val: T, modulus: T) -> T
 where
     T: Copy
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -458,9 +456,9 @@ where
     T: Copy
         + const_num_traits::One
         + const_num_traits::Zero
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -488,8 +486,8 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
 {
@@ -514,10 +512,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeEq
         + subtle::ConstantTimeLess,
@@ -542,8 +538,8 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
 {
@@ -558,10 +554,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -578,8 +572,8 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
 {
@@ -593,10 +587,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -618,7 +610,7 @@ where
 fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
 where
     T: const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Add<Output = T>,
 {
     if carry1 {
@@ -642,9 +634,8 @@ where
 fn accumulate_high_half_carry_ct<T>(result: T, carry1: Choice, carry2: Choice) -> (T, Choice)
 where
     T: const_num_traits::One
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::CtIsZero
-        + core::ops::Add<Output = T>
         + subtle::ConditionallySelectable,
 {
     // Always compute the addition; branchlessly choose whether to keep
@@ -677,9 +668,9 @@ where
         + const_num_traits::One
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -720,9 +711,9 @@ where
         + const_num_traits::One
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -756,13 +747,10 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::CtIsZero
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -794,13 +782,10 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::CtIsZero
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -831,9 +816,9 @@ where
         + const_num_traits::One
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -851,13 +836,10 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::CtIsZero
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -877,9 +859,9 @@ where
         + const_num_traits::One
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -898,13 +880,10 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::CtIsZero
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingSub
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess,
 {
@@ -928,7 +907,7 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Add<Output = T>,
 {
     let (m_lo, m_hi) = a.wide_mul(&b);
@@ -958,9 +937,8 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + subtle::ConstantTimeLess
-        + core::ops::Add<Output = T>
         + subtle::ConditionallySelectable,
 {
     let (m_lo, m_hi) = a.wide_mul(&b);
@@ -984,7 +962,7 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Add<Output = T>,
 {
     let (m_lo, m_hi) = a.wide_mul(b);
@@ -1008,9 +986,8 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::WrappingAdd
+        + const_num_traits::WrappingAdd<Output = T>
         + subtle::ConstantTimeLess
-        + core::ops::Add<Output = T>
         + subtle::ConditionallySelectable,
 {
     let (m_lo, m_hi) = a.wide_mul(b);
@@ -1052,10 +1029,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -1075,10 +1052,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1106,10 +1083,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -1148,10 +1125,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1170,10 +1147,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1200,10 +1177,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1225,10 +1202,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1275,10 +1252,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1318,10 +1295,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + const_num_traits::CtIsZero
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -1376,10 +1353,10 @@ where
         + PartialEq
         + PartialOrd
         + WideMul
-        + const_num_traits::WrappingMul
-        + const_num_traits::WrappingAdd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::WrappingSub
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
         + const_num_traits::CtIsZero
         + Parity
         + core::ops::Add<Output = T>

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -36,7 +36,6 @@ pub enum NPrimeMethod {
 fn compute_n_prime_trial_search<T>(modulus: T, r: T) -> Option<T>
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + PartialEq
         + PartialOrd
@@ -79,7 +78,6 @@ where
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
-        + core::ops::Rem<Output = T>
         + core::ops::Div<Output = T>,
 {
     // We need to solve: modulus * N' ≡ -1 (mod R)
@@ -110,13 +108,11 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialEq
-        + PartialOrd
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::Shl<usize, Output = T>,
 {
     // Hensel's lifting for N' computation when R = 2^k
     // Start with base case: find N' such that modulus * N' ≡ -1 (mod 2)
@@ -183,8 +179,7 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::Add<Output = T>,
 {
     // Step 1: Find R = 2^k where R > modulus
     let mut r = T::one();
@@ -230,8 +225,7 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::Add<Output = T>,
 {
     basic_compute_montgomery_params_with_method(modulus, NPrimeMethod::default())
 }
@@ -245,8 +239,6 @@ where
         + const_num_traits::One
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>
         + crate::parity::Parity
@@ -265,8 +257,6 @@ where
         + const_num_traits::One
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::parity::Parity
         + crate::NonCt,
@@ -284,7 +274,6 @@ where
 pub fn basic_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
         + core::ops::Mul<Output = T>
@@ -346,8 +335,6 @@ where
         + core::ops::BitAnd<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::parity::Parity
         + crate::NonCt,
 {
@@ -380,8 +367,6 @@ where
         + core::ops::BitAnd<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::parity::Parity
         + crate::NonCt,
 {
@@ -409,9 +394,7 @@ where
     T: Copy
         + PartialOrd
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     let (doubled, overflow) = val.overflowing_add(val);
     if overflow || doubled >= modulus {
@@ -458,10 +441,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + const_num_traits::WrappingAdd<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + const_num_traits::WrappingAdd<Output = T>,
 {
     let two = T::one().wrapping_add(T::one());
     let mut x = T::one(); // modulus * 1 ≡ 1 (mod 2) for odd modulus
@@ -487,9 +467,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     // For modulus == 1, any value mod 1 == 0
     if modulus == T::one() {
@@ -539,9 +517,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     mod_exp2(T::one(), modulus, w)
 }
@@ -573,9 +549,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     mod_exp2(r_mod_n, modulus, w)
 }
@@ -609,9 +583,7 @@ where
 /// REDC path, see `accumulate_high_half_carry_ct`.
 fn accumulate_high_half_carry<T>(result: T, carry1: bool, carry2: bool) -> (T, bool)
 where
-    T: const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>,
+    T: const_num_traits::One + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
 {
     if carry1 {
         let (r2, carry3) = result.overflowing_add(T::one());
@@ -664,16 +636,12 @@ where
 pub fn wide_redc<T>(t_lo: T, t_hi: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
         + WideMul
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     // m = t_lo * N'  (mod 2^W -- wrapping mul gives that for free)
     let m = t_lo.wrapping_mul(n_prime);
@@ -707,16 +675,12 @@ where
 pub fn strict_wide_redc<T>(t_lo: &T, t_hi: &T, modulus: &T, n_prime: &T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
         + WideMul
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     let m = (*t_lo).wrapping_mul(*n_prime);
     let (m_lo, m_hi) = m.wide_mul(modulus);
@@ -812,16 +776,12 @@ where
 pub fn wide_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
         + WideMul
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     let (lo, hi) = a_mont.wide_mul(&b_mont);
     wide_redc(lo, hi, modulus, n_prime)
@@ -855,16 +815,12 @@ where
 pub fn strict_wide_montgomery_mul<T>(a_mont: &T, b_mont: &T, modulus: &T, n_prime: &T) -> T
 where
     T: Copy
-        + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
         + WideMul
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     let (lo, hi) = a_mont.wide_mul(b_mont);
     strict_wide_redc(&lo, &hi, modulus, n_prime)
@@ -907,8 +863,7 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>,
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
 {
     let (m_lo, m_hi) = a.wide_mul(&b);
     let (new_lo, carry1) = acc_lo.overflowing_add(m_lo);
@@ -962,8 +917,7 @@ where
     T: Copy
         + const_num_traits::One
         + WideMul
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>,
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
 {
     let (m_lo, m_hi) = a.wide_mul(b);
     let (new_lo, carry1) = (*acc_lo).overflowing_add(m_lo);
@@ -1033,9 +987,6 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>,
 {
     let m = modulus.get();
@@ -1057,9 +1008,6 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_mul_odd(a, b, m))
@@ -1086,10 +1034,7 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>,
 {
     let modulus = modulus.get();
     let w = type_bit_width::<T>();
@@ -1129,10 +1074,7 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + Parity,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_mul_pr_odd(a, b, m))
 }
@@ -1152,11 +1094,7 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>,
 {
     let m = modulus.get();
@@ -1182,11 +1120,7 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_odd(base, exponent, m))
@@ -1207,9 +1141,6 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::ShrAssign<usize>,
 {
     let modulus = modulus.get();
@@ -1257,9 +1188,6 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::ShrAssign<usize>,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd(base, exponent, m))
@@ -1300,9 +1228,6 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + const_num_traits::CtIsZero
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
@@ -1359,9 +1284,6 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + const_num_traits::CtIsZero
         + Parity
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -29,13 +29,12 @@ use subtle::{Choice, ConditionallySelectable};
 /// docs for the cost breakdown.
 pub fn cios_montgomery_mul<T>(a: &T, b: &T, modulus: &T, n_prime_0: T::Word) -> T
 where
-    T: CiosRowOps + PartialOrd + BorrowingSub<Output = T> + core::ops::Sub<Output = T> + Copy,
+    T: CiosRowOps + PartialOrd + BorrowingSub<Output = T> + Copy,
     T::Word: const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingMul<Output = T::Word>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
-        + core::ops::Add<Output = T::Word>
-        + core::ops::Mul<Output = T::Word>,
+        + core::ops::Add<Output = T::Word>,
 {
     debug_assert!(a < modulus, "CIOS input a must be in [0, modulus)");
     debug_assert!(b < modulus, "CIOS input b must be in [0, modulus)");
@@ -97,7 +96,6 @@ where
         + const_num_traits::CtIsZero
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
         + core::ops::Add<Output = T::Word>
-        + core::ops::Mul<Output = T::Word>
         + subtle::ConditionallySelectable,
 {
     let n = a.word_count();
@@ -141,21 +139,18 @@ where
 /// with the required `Word` bounds. Higher-level code (e.g. `MontgomeryCtx`)
 /// can bound on this trait instead of requiring knowledge of `MulAccOps::Word`
 /// or the CIOS call signature. For CT-sensitive paths, see [`CiosMontMulCt`].
-pub trait CiosMontMul:
-    CiosRowOps + PartialOrd + BorrowingSub + core::ops::Sub<Output = Self> + Copy
-{
+pub trait CiosMontMul: CiosRowOps + PartialOrd + BorrowingSub<Output = Self> + Copy {
     fn cios_mont_mul(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Self;
 }
 
 impl<T> CiosMontMul for T
 where
-    T: CiosRowOps + PartialOrd + BorrowingSub<Output = T> + core::ops::Sub<Output = T> + Copy,
+    T: CiosRowOps + PartialOrd + BorrowingSub<Output = T> + Copy,
     T::Word: const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::WrappingMul<Output = T::Word>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
-        + core::ops::Add<Output = T::Word>
-        + core::ops::Mul<Output = T::Word>,
+        + core::ops::Add<Output = T::Word>,
 {
     #[inline]
     fn cios_mont_mul(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Self {
@@ -184,7 +179,6 @@ where
         + const_num_traits::CtIsZero
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
         + core::ops::Add<Output = T::Word>
-        + core::ops::Mul<Output = T::Word>
         + subtle::ConditionallySelectable,
 {
     #[inline]

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -29,11 +29,11 @@ use subtle::{Choice, ConditionallySelectable};
 /// docs for the cost breakdown.
 pub fn cios_montgomery_mul<T>(a: &T, b: &T, modulus: &T, n_prime_0: T::Word) -> T
 where
-    T: CiosRowOps + PartialOrd + BorrowingSub + core::ops::Sub<Output = T> + Copy,
+    T: CiosRowOps + PartialOrd + BorrowingSub<Output = T> + core::ops::Sub<Output = T> + Copy,
     T::Word: const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingMul<Output = T::Word>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>,
 {
@@ -90,16 +90,12 @@ where
 /// flag from `borrowing_sub` already encodes `acc < modulus`.
 pub fn cios_montgomery_mul_ct<T>(a: &T, b: &T, modulus: &T, n_prime_0: T::Word) -> T
 where
-    T: CiosRowOps
-        + BorrowingSub
-        + core::ops::Sub<Output = T>
-        + subtle::ConditionallySelectable
-        + Copy,
+    T: CiosRowOps + BorrowingSub<Output = T> + subtle::ConditionallySelectable + Copy,
     T::Word: const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
+        + const_num_traits::WrappingMul<Output = T::Word>
         + const_num_traits::CtIsZero
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>
         + subtle::ConditionallySelectable,
@@ -153,11 +149,11 @@ pub trait CiosMontMul:
 
 impl<T> CiosMontMul for T
 where
-    T: CiosRowOps + PartialOrd + BorrowingSub + core::ops::Sub<Output = T> + Copy,
+    T: CiosRowOps + PartialOrd + BorrowingSub<Output = T> + core::ops::Sub<Output = T> + Copy,
     T::Word: const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::WrappingMul<Output = T::Word>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>,
 {
@@ -174,23 +170,19 @@ where
 /// required `Word` bounds (including `ConstantTimeEq`). Calls
 /// [`cios_montgomery_mul_ct`] under the hood.
 pub trait CiosMontMulCt:
-    CiosRowOps + BorrowingSub + core::ops::Sub<Output = Self> + subtle::ConditionallySelectable + Copy
+    CiosRowOps + BorrowingSub<Output = Self> + subtle::ConditionallySelectable + Copy
 {
     fn cios_mont_mul_ct(a: &Self, b: &Self, modulus: &Self, n_prime: &Self) -> Self;
 }
 
 impl<T> CiosMontMulCt for T
 where
-    T: CiosRowOps
-        + BorrowingSub
-        + core::ops::Sub<Output = T>
-        + subtle::ConditionallySelectable
-        + Copy,
+    T: CiosRowOps + BorrowingSub<Output = T> + subtle::ConditionallySelectable + Copy,
     T::Word: const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::WrappingMul
+        + const_num_traits::WrappingMul<Output = T::Word>
         + const_num_traits::CtIsZero
-        + const_num_traits::ops::overflowing::OverflowingAdd
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T::Word>
         + core::ops::Add<Output = T::Word>
         + core::ops::Mul<Output = T::Word>
         + subtle::ConditionallySelectable,

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -21,12 +21,8 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
+    for<'a> T: core::ops::Mul<&'a T, Output = T>,
 {
     // We need to find N' where modulus * N' ≡ R - 1 (mod R)
     let target = r.clone().wrapping_sub(T::one()); // This is -1 mod R
@@ -56,7 +52,6 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
@@ -92,11 +87,9 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shl<usize, Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
+    for<'a> T: core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     // Hensel's lifting for N' computation when R = 2^k
@@ -151,8 +144,7 @@ where
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::RemAssign<&'a T>,
+        + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T>
         + core::ops::Div<&'a T, Output = T>
         + core::ops::Rem<&'a T, Output = T>,
@@ -204,12 +196,10 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
-        + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::RemAssign<&'a T>,
+        + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T>
         + core::ops::Div<&'a T, Output = T>
         + core::ops::Rem<&'a T, Output = T>,
@@ -226,8 +216,6 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
@@ -248,9 +236,7 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::BitAnd<&'a T, Output = T>,
 {
@@ -308,10 +294,7 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
-        + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
     for<'a> &'a T: crate::parity::Parity,

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -19,8 +19,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -56,8 +56,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
@@ -90,8 +90,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shl<usize, Output = T>
@@ -142,8 +142,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -198,8 +198,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -224,8 +224,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -247,8 +247,8 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T>,
@@ -306,8 +306,8 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
@@ -338,8 +338,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -379,8 +379,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -416,8 +416,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>
@@ -480,8 +480,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -16,11 +16,7 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T>,
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>,
@@ -64,19 +60,12 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
+    for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>
+        + core::ops::Add<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<T, Output = T>
         + core::ops::Add<&'a T, Output = T>,
@@ -111,16 +100,10 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T>,
-    for<'a> &'a T: core::ops::Add<&'a T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>
+    for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Rem<&'a T, Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::Rem<&'a T, Output = T>,
 {
     // Hensel's lifting for N' computation when R = 2^k
     // Start with base case: find N' such that modulus * N' ≡ -1 (mod 2)
@@ -185,23 +168,18 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
+    for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
+        + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::Add<&'a T, Output = T>,
 {
     strict_compute_montgomery_params_with_method(
         modulus,
@@ -225,23 +203,18 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::RemAssign<&'a T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
+    for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
+        + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::BitAnd<Output = T>,
+        + core::ops::Add<&'a T, Output = T>,
 {
     // Step 1: Find R = 2^k where R > modulus
     let mut r = T::one();
@@ -293,14 +266,11 @@ where
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::RemAssign<&'a T>
         + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::BitAnd<Output = T>,
     for<'a> &'a T: crate::parity::Parity,
@@ -324,13 +294,10 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::BitAnd<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::Mul<&'a T, Output = T> + core::ops::BitAnd<&'a T, Output = T>,
 {
     // Montgomery reduction algorithm:
     // Input: a_mont (Montgomery form), N (modulus), N', r_bits
@@ -378,8 +345,6 @@ where
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
@@ -405,7 +370,6 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
@@ -415,10 +379,8 @@ where
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
+        + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -471,7 +433,6 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
@@ -481,10 +442,8 @@ where
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
+        + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -514,7 +473,6 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
@@ -525,10 +483,8 @@ where
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
+        + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -595,7 +551,6 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
@@ -606,10 +561,8 @@ where
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::AddAssign<&'a T>,
+        + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -16,8 +16,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>,
@@ -64,8 +64,8 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
     for<'a> T: core::ops::RemAssign<&'a T>
@@ -110,8 +110,8 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
@@ -184,8 +184,8 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
@@ -224,8 +224,8 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
@@ -291,8 +291,8 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Shl<usize, Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -326,7 +326,7 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd,
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
@@ -376,8 +376,8 @@ where
         + PartialOrd
         + const_num_traits::Zero
         + const_num_traits::One
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -407,8 +407,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
@@ -473,8 +473,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
@@ -517,8 +517,8 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -598,8 +598,8 @@ where
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -15,9 +15,7 @@ c0nst::c0nst! {
             + [c0nst] One
             + [c0nst] core::ops::BitAnd<Output = T>
             + [c0nst] OverflowingAdd<Output = T>
-            + [c0nst] core::ops::Add<Output = T>
             + [c0nst] OverflowingSub<Output = T>
-            + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Shr<usize, Output = T>
             + [c0nst] core::ops::Rem<Output = T>,
     {
@@ -63,8 +61,6 @@ where
         + crate::parity::Parity
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>
         + crate::NonCt,
@@ -105,8 +101,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
 {
@@ -129,8 +123,6 @@ where
         + crate::parity::Parity
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
 {
@@ -174,8 +166,6 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
@@ -198,8 +188,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> &'a T: crate::parity::Parity,
@@ -220,8 +208,6 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> &'a T: crate::parity::Parity,
@@ -269,8 +255,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> &'a T: crate::parity::Parity,
@@ -291,8 +275,6 @@ where
         + PartialOrd
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>,
@@ -315,8 +297,6 @@ where
         + PartialOrd
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt,
     for<'a> &'a T: crate::parity::Parity,

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -14,9 +14,9 @@ c0nst::c0nst! {
             + [c0nst] Zero
             + [c0nst] One
             + [c0nst] core::ops::BitAnd<Output = T>
-            + [c0nst] OverflowingAdd
+            + [c0nst] OverflowingAdd<Output = T>
             + [c0nst] core::ops::Add<Output = T>
-            + [c0nst] OverflowingSub
+            + [c0nst] OverflowingSub<Output = T>
             + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Shr<usize, Output = T>
             + [c0nst] core::ops::Rem<Output = T>,
@@ -61,8 +61,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + crate::parity::Parity
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -103,8 +103,8 @@ where
         + crate::parity::Parity
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -127,8 +127,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + crate::parity::Parity
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -172,8 +172,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -196,8 +196,8 @@ where
         + PartialOrd
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -218,8 +218,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -267,8 +267,8 @@ where
         + PartialOrd
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -289,8 +289,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -313,8 +313,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -10,9 +10,7 @@ c0nst::c0nst! {
         T: [c0nst] core::cmp::PartialOrd
             + Copy
             + [c0nst] OverflowingAdd<Output = T>
-            + [c0nst] core::ops::Add<Output = T>
             + [c0nst] OverflowingSub<Output = T>
-            + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Rem<Output = T>,
     {
         let a = a % m;
@@ -34,8 +32,6 @@ where
         + Copy
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
         + crate::NonCt,
 {
@@ -51,8 +47,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
@@ -67,8 +61,6 @@ where
         + Copy
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let diff = a.wrapping_sub(b);
@@ -89,8 +81,6 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -108,8 +98,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
@@ -125,8 +113,6 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let diff = a.clone().wrapping_sub(b.clone());
@@ -147,8 +133,6 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
@@ -167,8 +151,6 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let m_raw = T::nonzero_get(m);
@@ -184,8 +166,6 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
-        + core::ops::Sub<Output = T>
         + crate::NonCt,
 {
     let (diff, overflow) = a.overflowing_sub(b.clone());

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -9,9 +9,9 @@ c0nst::c0nst! {
     where
         T: [c0nst] core::cmp::PartialOrd
             + Copy
-            + [c0nst] OverflowingAdd
+            + [c0nst] OverflowingAdd<Output = T>
             + [c0nst] core::ops::Add<Output = T>
-            + [c0nst] OverflowingSub
+            + [c0nst] OverflowingSub<Output = T>
             + [c0nst] core::ops::Sub<Output = T>
             + [c0nst] core::ops::Rem<Output = T>,
     {
@@ -32,8 +32,8 @@ pub fn basic_mod_sub<T>(a: T, b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
@@ -49,8 +49,8 @@ where
         + Copy
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -65,8 +65,8 @@ pub fn basic_mod_sub_pr<T>(a: T, b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -87,8 +87,8 @@ pub fn constrained_mod_sub<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -106,8 +106,8 @@ where
         + Clone
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -123,8 +123,8 @@ pub fn constrained_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::wrapping::WrappingAdd
-        + const_num_traits::ops::wrapping::WrappingSub
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -145,8 +145,8 @@ pub fn strict_mod_sub<T>(mut a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -165,8 +165,8 @@ where
         + Clone
         + const_num_traits::HasNonZero
         + const_num_traits::DivNonZero<Output = T>
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
@@ -182,8 +182,8 @@ pub fn strict_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
-        + const_num_traits::ops::overflowing::OverflowingAdd
-        + const_num_traits::ops::overflowing::OverflowingSub
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,

--- a/modmath/src/test_carrier.rs
+++ b/modmath/src/test_carrier.rs
@@ -50,18 +50,21 @@ impl const_num_traits::Parity for &NcU64 {
 }
 
 impl const_num_traits::ops::wrapping::WrappingAdd for NcU64 {
+    type Output = NcU64;
     fn wrapping_add(self, v: Self) -> Self {
         NcU64(self.0.wrapping_add(v.0))
     }
 }
 
 impl const_num_traits::ops::wrapping::WrappingSub for NcU64 {
+    type Output = NcU64;
     fn wrapping_sub(self, v: Self) -> Self {
         NcU64(self.0.wrapping_sub(v.0))
     }
 }
 
 impl const_num_traits::ops::overflowing::OverflowingAdd for NcU64 {
+    type Output = NcU64;
     fn overflowing_add(self, v: Self) -> (Self, bool) {
         let (r, o) = self.0.overflowing_add(v.0);
         (NcU64(r), o)
@@ -69,6 +72,7 @@ impl const_num_traits::ops::overflowing::OverflowingAdd for NcU64 {
 }
 
 impl const_num_traits::ops::overflowing::OverflowingSub for NcU64 {
+    type Output = NcU64;
     fn overflowing_sub(self, v: Self) -> (Self, bool) {
         let (r, o) = self.0.overflowing_sub(v.0);
         (NcU64(r), o)

--- a/modmath/src/wide_mul.rs
+++ b/modmath/src/wide_mul.rs
@@ -12,7 +12,7 @@ where
     T: Copy
         + const_num_traits::Zero
         + core::ops::Mul<Output = T>
-        + const_num_traits::CarryingMul<Unsigned = T>,
+        + const_num_traits::CarryingMul<Unsigned = T, Output = T>,
 {
     fn wide_mul(&self, rhs: &Self) -> (Self, Self) {
         const_num_traits::CarryingMul::carrying_mul(*self, *rhs, T::zero())

--- a/modmath/src/wide_mul.rs
+++ b/modmath/src/wide_mul.rs
@@ -9,10 +9,7 @@ pub trait WideMul {
 
 impl<T> WideMul for T
 where
-    T: Copy
-        + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
-        + const_num_traits::CarryingMul<Unsigned = T, Output = T>,
+    T: Copy + const_num_traits::Zero + const_num_traits::CarryingMul<Unsigned = T, Output = T>,
 {
     fn wide_mul(&self, rhs: &Self) -> (Self, Self) {
         const_num_traits::CarryingMul::carrying_mul(*self, *rhs, T::zero())


### PR DESCRIPTION
Tagged `v0.5.0-alpha.1` for downstream git consumption; manifest version is plain `0.5.0`.

## What changes

cnt 0.2 decouples the named-op traits from their `core::ops` twins via a fresh associated `Output`. Consequences here:

- Every op bound pins it explicitly: `WrappingSub<Output = T>`, `BorrowingSub<Output = T>`, `CarryingMul<Unsigned = T, Output = T>`, etc. (245 sites, mechanical).
- The plain `core::ops::Add/Sub/Mul` pins that 0.1's coupling forced onto the CT where-clauses are **deleted** — the CT chain now demands only explicitly-contracted named ops.
- `CiosMontMul` / `CiosMontMulCt` drop their `Sub<Output = Self>` supertrait; `BorrowingSub<Output = Self>` carries the result type itself.

Net effect for backend integrations (crypto-bigint, bnum): **a carrier can satisfy the entire CT surface without implementing plain operators at all.** This closes the underspecified-`core::ops::Sub` contract question from the ecosystem work for good — there is no plain-op involvement left to mis-signal.

Minor version bump: the Output pinning and supertrait change are breaking for carriers implementing the 0.1-shaped traits.

## Deps

All registry: `const-num-traits 0.2.0`, `fixed-bigint 0.5.0` (dev-dep), `modmath-cios 0.1.1`. No git deps remain — publishable as-is.

## Verification (local, pinned 1.86)

437 workspace tests (parity), seven-target asm-grep sweep, ctgrind taint gate, panic-free audit on thumbv7m + riscv32imc, clippy/docs — all clean. The draft PR exists partly to get CI runs on the branch, since push workflows only cover `main`/`feature/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

