### PR TITLE
modmath-cios 0.1.2: add defaulted cios_accumulator()

### DIFF
--- a/modmath-cios/Cargo.toml
+++ b/modmath-cios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath-cios"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Row-op trait surface for CIOS Montgomery multiplication."
 repository = "https://github.com/kaidokert/modmath-rs"

--- a/modmath-cios/src/lib.rs
+++ b/modmath-cios/src/lib.rs
@@ -31,17 +31,19 @@ pub trait CiosRowOps: Default + Sized {
 
     fn word_count(&self) -> usize;
 
-    /// A zero value wide enough to accumulate a full CIOS product —
-    /// i.e. `word_count()` limbs of storage, all zero.
+    /// A zero value wide enough to accumulate a full CIOS product
+    /// against `self` — i.e. at least `self.word_count()` limbs of
+    /// storage, all zero.
     ///
-    /// For a fixed-width carrier this is just `Self::default()`, which
-    /// the default body returns. A runtime-width carrier (whose
-    /// `Default` is the mathematical zero at logical length 0) must
-    /// override this to hand back a capacity-wide zero, or the driver's
-    /// accumulator overruns. Kept distinct from `Default` so such a
-    /// carrier isn't forced to make its `Default` a surprising
-    /// full-capacity value.
-    fn cios_accumulator() -> Self {
+    /// Takes `&self` (the driver passes an operand, typically the
+    /// modulus) so a carrier whose width is a runtime property — not a
+    /// const generic — can size the accumulator from it. A fixed-width
+    /// carrier ignores `self` and returns `Self::default()`, which the
+    /// default body does; its `Default` is already a full-width zero.
+    /// A runtime-width carrier (whose `Default` is the mathematical
+    /// zero at logical length 0) overrides this to hand back a
+    /// full-width zero, keeping a sensible `Default`.
+    fn cios_accumulator(&self) -> Self {
         Self::default()
     }
 
@@ -216,9 +218,9 @@ mod tests {
         // The default body hands back `Self::default()`; the primitive
         // carriers must not diverge from it (a runtime-width carrier is
         // the only implementor expected to override).
-        assert_eq!(<u8 as CiosRowOps>::cios_accumulator(), u8::default());
-        assert_eq!(<u16 as CiosRowOps>::cios_accumulator(), u16::default());
-        assert_eq!(<u32 as CiosRowOps>::cios_accumulator(), u32::default());
-        assert_eq!(<u64 as CiosRowOps>::cios_accumulator(), u64::default());
+        assert_eq!(0u8.cios_accumulator(), u8::default());
+        assert_eq!(0u16.cios_accumulator(), u16::default());
+        assert_eq!(0u32.cios_accumulator(), u32::default());
+        assert_eq!(0u64.cios_accumulator(), u64::default());
     }
 }

--- a/modmath-cios/src/lib.rs
+++ b/modmath-cios/src/lib.rs
@@ -31,6 +31,20 @@ pub trait CiosRowOps: Default + Sized {
 
     fn word_count(&self) -> usize;
 
+    /// A zero value wide enough to accumulate a full CIOS product —
+    /// i.e. `word_count()` limbs of storage, all zero.
+    ///
+    /// For a fixed-width carrier this is just `Self::default()`, which
+    /// the default body returns. A runtime-width carrier (whose
+    /// `Default` is the mathematical zero at logical length 0) must
+    /// override this to hand back a capacity-wide zero, or the driver's
+    /// accumulator overruns. Kept distinct from `Default` so such a
+    /// carrier isn't forced to make its `Default` a surprising
+    /// full-capacity value.
+    fn cios_accumulator() -> Self {
+        Self::default()
+    }
+
     /// Infallible. Caller guarantees `i < self.word_count()` and `i`
     /// is public.
     fn word(&self, i: usize) -> Self::Word;
@@ -196,4 +210,15 @@ mod tests {
         u64_phase2,
         u64
     );
+
+    #[test]
+    fn default_accumulator_matches_default_for_primitives() {
+        // The default body hands back `Self::default()`; the primitive
+        // carriers must not diverge from it (a runtime-width carrier is
+        // the only implementor expected to override).
+        assert_eq!(<u8 as CiosRowOps>::cios_accumulator(), u8::default());
+        assert_eq!(<u16 as CiosRowOps>::cios_accumulator(), u16::default());
+        assert_eq!(<u32 as CiosRowOps>::cios_accumulator(), u32::default());
+        assert_eq!(<u64 as CiosRowOps>::cios_accumulator(), u64::default());
+    }
 }


### PR DESCRIPTION
Resolves §4 of fixed-bigint's HeaplessBigInt spec — the CIOS-accumulator `Default` question — with a smaller change than either option the spec offered.

## The problem

`CiosRowOps` implicitly requires that the product accumulator equals `Self::default()` (the driver does `let mut acc = T::default()`). Every current impl satisfies this because their `Default` is already a full-width zero. A **runtime-width** carrier (the spec's `HeaplessBigInt`) breaks it: its natural `Default` is the mathematical zero at logical length 0, which under-sizes the accumulator and overruns the driver loop.

## The fix

A new trait method with a default body:

```rust
fn cios_accumulator() -> Self { Self::default() }
```

- **Non-breaking** → `0.1.2`, not `0.2.0`. Every existing impl (primitives, `FixedUInt`) inherits the default body and changes nothing.
- A runtime-width carrier overrides just `cios_accumulator()` to return a capacity-wide zero, keeping a sensible mathematical-zero `Default`. The two meanings that were conflated get separate names.

The spec proposed either (A) live with `Default = full-CAP` as a documented sharp edge, or (B) *drop* the `Default` supertrait and add the method — a breaking change needing a coordinated release. The defaulted-method shape gets (B)'s clean separation at (A)'s zero cost.

## Sequencing

modmath's driver keeps calling `T::default()` until `0.1.2` is on the registry; the switch to `T::cios_accumulator()` is a one-line follow-up modmath PR then (verified end-to-end here via a throwaway `[patch]`: 439 modmath tests green with the driver on the new method, CIOS output unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a dedicated CIOS accumulator constructor to decouple accumulator width from `Default` and support runtime-width carriers.

New Features:
- Introduce the `cios_accumulator()` trait method on `CiosRowOps` with a default implementation returning `Self::default()`.

Build:
- Bump the `modmath-cios` crate version to 0.1.2.

Tests:
- Add a regression test ensuring primitive `CiosRowOps` implementations keep `cios_accumulator()` equal to their `Default`.