### PR TITLE
Adopt cios_accumulator() in the CIOS driver

### DIFF
--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -42,7 +42,7 @@ where
     let n = a.word_count();
     let zero = <T::Word as Zero>::zero();
     let one = <T::Word as One>::one();
-    let mut acc = T::default();
+    let mut acc = modulus.cios_accumulator();
     let mut acc_hi = zero;
     let mut acc_hi2 = zero;
 
@@ -101,7 +101,7 @@ where
     let n = a.word_count();
     let zero = <T::Word as Zero>::zero();
     let one = <T::Word as One>::one();
-    let mut acc = T::default();
+    let mut acc = modulus.cios_accumulator();
     let mut acc_hi = zero;
     let mut acc_hi2 = zero;
 


### PR DESCRIPTION
Follow-up to #36, now that modmath-cios 0.1.2 is published. The two CIOS accumulator sites move from `T::default()` to `modulus.cios_accumulator()`.

Identical behavior for every current carrier (primitives and `FixedUInt` both have a full-width-zero `Default`, which the trait's default body returns). The change is enabling, not behavioral: a runtime-width carrier can now size the accumulator from the modulus operand instead of being forced into a surprising full-capacity `Default`. Closes the driver half of the HeaplessBigInt spec's `CiosRowOps` decision (§4).

Verified: 460 workspace tests, clippy/fmt clean, asm-grep (thumbv7m + riscv32imc) and CIOS output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adopt modulus-driven CIOS accumulator initialization in the Montgomery CIOS driver to support runtime-width carriers without changing behavior for existing carriers.