### PR TITLE
Migrate Signed<T> EEA off implementation-defined core::ops::Mul

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -29,8 +29,8 @@ fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] 
 # krabitls backend-swap experiments), so their test matrices are live
 # again. Upstream (unforked) crates and num-bigint/ibig stay disabled:
 # no const-num-traits impls upstream; ibig is blocked architecturally.
-bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-9", default-features = false }
-crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-10", default-features = false }
+bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-13", default-features = false }
+crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-13", default-features = false }
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
 # ibig = "0.3"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = """
 Modular math implemented with traits.

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -533,6 +533,13 @@ where
     /// Works for any odd modulus (composite is fine). Variable-time —
     /// do not call with secret inputs; use [`Self::inv_fermat`] for CT
     /// paths. Returns `None` when `a` is not coprime to modulus.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the carrier `T` is too narrow to hold the extended-GCD
+    /// intermediates (checked coefficient arithmetic overflows). This is
+    /// a carrier-precondition violation, distinct from the `None` return
+    /// for a non-coprime input.
     pub fn inv_eea(&self, a: &Residue<'_, T, Nct>) -> Option<Residue<'_, T, Nct>>
     where
         T: WideMul

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -537,9 +537,9 @@ where
     where
         T: WideMul
             + core::ops::Div<Output = T>
-            + core::ops::Add<Output = T>
+            + const_num_traits::CheckedAdd<Output = T>
             + core::ops::Sub<Output = T>
-            + core::ops::Mul<Output = T>,
+            + const_num_traits::CheckedMul<Output = T>,
     {
         if a.mont == T::zero() {
             return None;

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -33,16 +33,17 @@ function inverse(a, n)
 /// violation, distinct from the `None` return for a non-invertible input.
 pub fn strict_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
-    // Checked `Signed` coefficient adds (see `basic_mod_inv`); the raw `T`
-    // r-sequence keeps reference `Mul<&T>` (heap carriers don't overflow).
+    // Checked mul/add throughout (see `basic_mod_inv`): both the `Signed`
+    // coefficients and the raw `T` r-sequence refuse to rely on `*`'s
+    // implementation-defined overflow.
     T: const_num_traits::Zero
         + const_num_traits::One
         + PartialEq
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + core::ops::Sub<Output = T>
         + core::cmp::PartialOrd,
-    for<'a> T: core::ops::Mul<&'a T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>
+    for<'a> T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Add<&'a T, Output = T>
         + core::cmp::PartialOrd,
     for<'a> &'a T: core::ops::Div<&'a T, Output = T> + core::ops::Sub<T, Output = T>,
@@ -55,15 +56,19 @@ where
 
     while new_r != T::zero() {
         let quotient = &r / &new_r;
+        // strict avoids a `Clone` bound: duplicate `quotient` via the same
+        // reference-add trick used for `r`/`t`, so each coefficient update can
+        // consume an owned copy through the checked multiply.
+        let quotient2 = T::zero() + &quotient;
 
         // clone
         let tmp_t = Signed::new(T::zero(), false) + &new_t;
-        new_t = t - new_t * &quotient;
+        new_t = t - new_t * quotient;
         t = tmp_t;
 
         // clone
         let tmp_r = T::zero() + &new_r;
-        new_r = r - new_r * &quotient;
+        new_r = r - new_r.checked_mul(quotient2).expect(signed::OVERFLOW_MSG);
         r = tmp_r;
     }
 
@@ -92,11 +97,10 @@ where
 /// violation, distinct from the `None` return for a non-invertible input.
 pub fn constrained_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
-    // Checked magnitude ops on the `Signed` coefficients (see
-    // `basic_mod_inv`); the raw `T` r-sequence keeps plain `Mul` (heap
-    // carriers don't overflow).
+    // Checked mul/add throughout (see `basic_mod_inv`): both the `Signed`
+    // coefficients and the raw `T` r-sequence refuse to rely on `*`'s
+    // implementation-defined overflow.
     T: const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + Clone
         + PartialEq
@@ -120,7 +124,7 @@ where
         t = tmp_t;
 
         let tmp_r = new_r.clone();
-        new_r = r - new_r * quotient;
+        new_r = r - new_r.checked_mul(quotient).expect(signed::OVERFLOW_MSG);
         r = tmp_r;
     }
 

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -285,9 +285,9 @@ mod bnum_inv_tests {
     inv_test_module!(
         bnum_patched,
         bnum_patched::types::U256,
-        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        strict: on,
+        constrained: on,
+        basic: on,
     );
 
     //     inv_test_module!(
@@ -301,9 +301,9 @@ mod bnum_inv_tests {
     inv_test_module!(
         crypto_bigint_patched,
         crypto_bigint_patched::U256,
-        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        strict: on,
+        constrained: on,
+        basic: on,
     );
 
     //     inv_test_module!(

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -25,6 +25,12 @@ function inverse(a, n)
 /// # Modular Inverse (Strict)
 /// Most constrained version that works with references. Requires
 /// reference-based operations for division and subtraction.
+///
+/// # Panics
+///
+/// Panics if `T` is too narrow to hold the extended-GCD intermediates
+/// (checked coefficient arithmetic overflows) — a carrier-precondition
+/// violation, distinct from the `None` return for a non-invertible input.
 pub fn strict_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
     // Checked `Signed` coefficient adds (see `basic_mod_inv`); the raw `T`
@@ -78,6 +84,12 @@ where
 /// # Modular Inverse (Constrained)
 /// Version that works with references. Requires Clone and
 /// reference-based operations.
+///
+/// # Panics
+///
+/// Panics if `T` is too narrow to hold the extended-GCD intermediates
+/// (checked coefficient arithmetic overflows) — a carrier-precondition
+/// violation, distinct from the `None` return for a non-invertible input.
 pub fn constrained_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
     // Checked magnitude ops on the `Signed` coefficients (see
@@ -125,6 +137,12 @@ where
 
 /// # Modular Inverse (Basic)
 /// Simple version that operates on values and copies them.
+///
+/// # Panics
+///
+/// Panics if `T` is too narrow to hold the extended-GCD intermediates
+/// (checked coefficient arithmetic overflows) — a carrier-precondition
+/// violation, distinct from the `None` return for a non-invertible input.
 pub fn basic_mod_inv<T>(a: T, modulus: T) -> Option<T>
 where
     // `Signed<T>` uses checked mul/add, not plain `*`/`+` whose overflow on

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -35,7 +35,6 @@ where
         + const_num_traits::One
         + PartialEq
         + const_num_traits::CheckedAdd<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::cmp::PartialOrd,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
@@ -89,14 +88,13 @@ where
     // plain `Mul` — its products are bounded by the modulus, and this
     // flavor's intended carriers are arbitrary-precision (non-overflowing).
     T: const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + Clone
         + PartialEq
         + core::cmp::PartialOrd
         + const_num_traits::CheckedAdd<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + const_num_traits::CheckedMul<Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T> + core::ops::Div<&'a T, Output = T>,

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -27,9 +27,14 @@ function inverse(a, n)
 /// reference-based operations for division and subtraction.
 pub fn strict_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
+    // `Signed<T>`'s value magnitude ops are checked (see `basic_mod_inv`);
+    // `CheckedAdd` covers the sign-tracked coefficient adds. The raw `T`
+    // r-sequence uses reference `Mul<&T>` (unbounded-carrier flavor), left
+    // plain — products bounded by the modulus, heap carriers don't overflow.
     T: const_num_traits::Zero
         + const_num_traits::One
         + PartialEq
+        + const_num_traits::CheckedAdd<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::cmp::PartialOrd,
@@ -78,14 +83,21 @@ where
 /// reference-based operations.
 pub fn constrained_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
+    // `Signed<T>`'s magnitude ops are checked (see `basic_mod_inv`), so
+    // the `CheckedAdd`/`CheckedMul` bounds cover the sign-tracked
+    // coefficients. The raw `T` r-sequence (`new_r * quotient`) stays on
+    // plain `Mul` — its products are bounded by the modulus, and this
+    // flavor's intended carriers are arbitrary-precision (non-overflowing).
     T: const_num_traits::Zero
         + const_num_traits::One
         + Clone
         + PartialEq
         + core::cmp::PartialOrd
+        + const_num_traits::CheckedAdd<Output = T>
         + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T> + core::ops::Div<&'a T, Output = T>,
 {
@@ -121,14 +133,23 @@ where
 /// Simple version that operates on values and copies them.
 pub fn basic_mod_inv<T>(a: T, modulus: T) -> Option<T>
 where
+    // `Signed<T>` uses checked multiply/add on the magnitudes. The EEA
+    // coefficient products are bounded by ≈modulus/2, so on a value
+    // carrier sized for the modulus they always fit — the point of the
+    // checked ops is not a live overflow but to stop *relying* on plain
+    // `*`/`+`, whose overflow behavior on `T` is implementation-defined.
+    // A carrier that reports overflow on shape rather than value (a
+    // runtime-length bignum) then surfaces as a deterministic panic with
+    // a clear message, never a silently-wrong inverse. `Sub` stays plain —
+    // `Signed` only ever subtracts smaller from larger.
     T: const_num_traits::Zero
         + const_num_traits::One
         + Copy
         + PartialEq
         + core::ops::Div<Output = T>
-        + core::ops::Add<Output = T>
+        + const_num_traits::CheckedAdd<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + core::cmp::PartialOrd,
 {
     let mut t = Signed::new(T::zero(), false);
@@ -264,9 +285,9 @@ mod bnum_inv_tests {
     inv_test_module!(
         bnum_patched,
         bnum_patched::types::U256,
-        strict: on,
-        constrained: on,
-        basic: on,
+        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
     );
 
     //     inv_test_module!(
@@ -280,9 +301,9 @@ mod bnum_inv_tests {
     inv_test_module!(
         crypto_bigint_patched,
         crypto_bigint_patched::U256,
-        strict: on,
-        constrained: on,
-        basic: on,
+        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
     );
 
     //     inv_test_module!(

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -27,10 +27,8 @@ function inverse(a, n)
 /// reference-based operations for division and subtraction.
 pub fn strict_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
-    // `Signed<T>`'s value magnitude ops are checked (see `basic_mod_inv`);
-    // `CheckedAdd` covers the sign-tracked coefficient adds. The raw `T`
-    // r-sequence uses reference `Mul<&T>` (unbounded-carrier flavor), left
-    // plain — products bounded by the modulus, heap carriers don't overflow.
+    // Checked `Signed` coefficient adds (see `basic_mod_inv`); the raw `T`
+    // r-sequence keeps reference `Mul<&T>` (heap carriers don't overflow).
     T: const_num_traits::Zero
         + const_num_traits::One
         + PartialEq
@@ -82,11 +80,9 @@ where
 /// reference-based operations.
 pub fn constrained_mod_inv<T>(a: T, modulus: &T) -> Option<T>
 where
-    // `Signed<T>`'s magnitude ops are checked (see `basic_mod_inv`), so
-    // the `CheckedAdd`/`CheckedMul` bounds cover the sign-tracked
-    // coefficients. The raw `T` r-sequence (`new_r * quotient`) stays on
-    // plain `Mul` — its products are bounded by the modulus, and this
-    // flavor's intended carriers are arbitrary-precision (non-overflowing).
+    // Checked magnitude ops on the `Signed` coefficients (see
+    // `basic_mod_inv`); the raw `T` r-sequence keeps plain `Mul` (heap
+    // carriers don't overflow).
     T: const_num_traits::Zero
         + core::ops::Mul<Output = T>
         + const_num_traits::One
@@ -131,15 +127,11 @@ where
 /// Simple version that operates on values and copies them.
 pub fn basic_mod_inv<T>(a: T, modulus: T) -> Option<T>
 where
-    // `Signed<T>` uses checked multiply/add on the magnitudes. The EEA
-    // coefficient products are bounded by ≈modulus/2, so on a value
-    // carrier sized for the modulus they always fit — the point of the
-    // checked ops is not a live overflow but to stop *relying* on plain
-    // `*`/`+`, whose overflow behavior on `T` is implementation-defined.
-    // A carrier that reports overflow on shape rather than value (a
-    // runtime-length bignum) then surfaces as a deterministic panic with
-    // a clear message, never a silently-wrong inverse. `Sub` stays plain —
-    // `Signed` only ever subtracts smaller from larger.
+    // `Signed<T>` uses checked mul/add, not plain `*`/`+` whose overflow on
+    // `T` is implementation-defined. Products fit any carrier sized for the
+    // modulus, so this guards no live overflow — it refuses to rely on
+    // unspecified behavior, turning a too-narrow carrier into a clear panic
+    // rather than a wrong inverse. `Sub` stays plain (smaller from larger).
     T: const_num_traits::Zero
         + const_num_traits::One
         + Copy

--- a/modmath/src/inv/signed.rs
+++ b/modmath/src/inv/signed.rs
@@ -1,13 +1,10 @@
 use const_num_traits::{CheckedAdd, CheckedMul};
 use core::cmp::Ordering;
 
-/// Panic message when a `Signed<T>` magnitude op exceeds the carrier
-/// width. A precondition violation — the carrier is too narrow for the
-/// modular-inverse intermediates (bounded by ~2·modulus) — surfaced as a
-/// loud, deterministic panic, never a silently-wrong inverse. The checked
-/// ops replace plain `*`/`+`, whose overflow behavior on `T` is
-/// implementation-defined (wrap, panic, or a length-shaped overflow on a
-/// fixed-capacity carrier).
+/// Overflow in a `Signed<T>` magnitude op means the carrier is too narrow
+/// for the modular-inverse intermediates. The checked ops make that a
+/// deterministic panic instead of relying on plain `*`/`+`, whose overflow
+/// on `T` is implementation-defined.
 const OVERFLOW_MSG: &str = "Signed<T>: carrier too narrow for modular-inverse intermediates";
 
 /// Partial signed implementation for modular inverse calculations
@@ -229,9 +226,8 @@ where
 
     fn add(self, rhs: Self) -> Self::Output {
         match (self.negative, rhs.negative) {
-            // Same-sign: magnitudes add and can exceed the carrier. Mixed
-            // sign takes the larger-minus-smaller branch, which cannot
-            // underflow, so `Sub` stays plain.
+            // Same-sign magnitudes add and can exceed the carrier; mixed
+            // sign is larger-minus-smaller, which can't underflow (plain `Sub`).
             (false, false) => Self::new_unchecked(
                 self.value.checked_add(rhs.value).expect(OVERFLOW_MSG),
                 false,

--- a/modmath/src/inv/signed.rs
+++ b/modmath/src/inv/signed.rs
@@ -5,7 +5,8 @@ use core::cmp::Ordering;
 /// for the modular-inverse intermediates. The checked ops make that a
 /// deterministic panic instead of relying on plain `*`/`+`, whose overflow
 /// on `T` is implementation-defined.
-const OVERFLOW_MSG: &str = "Signed<T>: carrier too narrow for modular-inverse intermediates";
+pub(super) const OVERFLOW_MSG: &str =
+    "Signed<T>: carrier too narrow for modular-inverse intermediates";
 
 /// Partial signed implementation for modular inverse calculations
 ///
@@ -297,25 +298,6 @@ where
     }
 }
 
-/// Multiplication of Signed<T> with a reference to an unsigned value &T.
-///
-/// # Requirements
-/// Both `T` and `other` must be unsigned types. The `other` parameter should
-/// represent a non-negative value to maintain correctness.
-impl<'a, T> core::ops::Mul<&'a T> for Signed<T>
-where
-    T: core::ops::Mul<&'a T, Output = T> + 'a,
-{
-    type Output = Self;
-
-    fn mul(self, other: &'a T) -> Self::Output {
-        Self {
-            value: self.value * other,
-            negative: self.negative,
-        }
-    }
-}
-
 impl<T> core::ops::Div for Signed<T>
 where
     T: core::ops::Div<Output = T>,
@@ -331,9 +313,8 @@ where
 }
 
 #[cfg(test)]
-// op_ref allowed: the by-ref arms deliberately exercise the `Add<&T>` /
-// `Mul<&T>` impls; "fixing" `a * &b` to `a * b` would switch which impl
-// is under test.
+// op_ref allowed: the by-ref arms deliberately exercise the `Add<&T>`
+// impls; "fixing" `a + &b` to `a + b` would switch which impl is under test.
 #[allow(clippy::op_ref)]
 mod signed_tests {
     use super::Signed;
@@ -770,18 +751,6 @@ mod signed_tests {
         let a = Signed::new(3u32, true); // -3
         let result = a * 5u32; // -3 * 5 = -15
         assert_eq!(result.value, 15u32);
-        assert!(result.negative);
-
-        // Test Mul<&T> - positive Signed * &T
-        let a = Signed::new(8u32, false); // +8
-        let result = a * &3u32; // +8 * 3 = +24
-        assert_eq!(result.value, 24u32);
-        assert!(!result.negative);
-
-        // Test Mul<&T> - negative Signed * &T
-        let a = Signed::new(9u32, true); // -9
-        let result = a * &2u32; // -9 * 2 = -18
-        assert_eq!(result.value, 18u32);
         assert!(result.negative);
     }
 

--- a/modmath/src/inv/signed.rs
+++ b/modmath/src/inv/signed.rs
@@ -1,4 +1,14 @@
+use const_num_traits::{CheckedAdd, CheckedMul};
 use core::cmp::Ordering;
+
+/// Panic message when a `Signed<T>` magnitude op exceeds the carrier
+/// width. A precondition violation — the carrier is too narrow for the
+/// modular-inverse intermediates (bounded by ~2·modulus) — surfaced as a
+/// loud, deterministic panic, never a silently-wrong inverse. The checked
+/// ops replace plain `*`/`+`, whose overflow behavior on `T` is
+/// implementation-defined (wrap, panic, or a length-shaped overflow on a
+/// fixed-capacity carrier).
+const OVERFLOW_MSG: &str = "Signed<T>: carrier too narrow for modular-inverse intermediates";
 
 /// Partial signed implementation for modular inverse calculations
 ///
@@ -213,14 +223,22 @@ where
 
 impl<T> core::ops::Add for Signed<T>
 where
-    T: core::ops::Add<Output = T> + core::ops::Sub<Output = T> + core::cmp::PartialOrd,
+    T: CheckedAdd<Output = T> + core::ops::Sub<Output = T> + core::cmp::PartialOrd,
 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
         match (self.negative, rhs.negative) {
-            (false, false) => Self::new_unchecked(self.value + rhs.value, false),
-            (true, true) => Self::new_unchecked(self.value + rhs.value, true),
+            // Same-sign: magnitudes add and can exceed the carrier. Mixed
+            // sign takes the larger-minus-smaller branch, which cannot
+            // underflow, so `Sub` stays plain.
+            (false, false) => Self::new_unchecked(
+                self.value.checked_add(rhs.value).expect(OVERFLOW_MSG),
+                false,
+            ),
+            (true, true) => {
+                Self::new_unchecked(self.value.checked_add(rhs.value).expect(OVERFLOW_MSG), true)
+            }
             (false, true) | (true, false) => {
                 if self.value >= rhs.value {
                     Self::new_unchecked(self.value - rhs.value, self.negative)
@@ -234,7 +252,7 @@ where
 
 impl<T> core::ops::Sub for Signed<T>
 where
-    T: core::ops::Add<Output = T> + core::ops::Sub<Output = T> + core::cmp::PartialOrd,
+    T: CheckedAdd<Output = T> + core::ops::Sub<Output = T> + core::cmp::PartialOrd,
 {
     type Output = Self;
 
@@ -252,13 +270,13 @@ where
 /// a non-negative magnitude. Using signed types will break this assumption.
 impl<T> core::ops::Mul for Signed<T>
 where
-    T: core::ops::Mul<Output = T>,
+    T: CheckedMul<Output = T>,
 {
     type Output = Self;
 
     fn mul(self, other: Self) -> Self::Output {
         Self {
-            value: self.value * other.value,
+            value: self.value.checked_mul(other.value).expect(OVERFLOW_MSG),
             negative: self.negative != other.negative,
         }
     }
@@ -271,13 +289,13 @@ where
 /// represent a non-negative value to maintain correctness.
 impl<T> core::ops::Mul<T> for Signed<T>
 where
-    T: core::ops::Mul<Output = T>,
+    T: CheckedMul<Output = T>,
 {
     type Output = Self;
 
     fn mul(self, other: T) -> Self::Output {
         Self {
-            value: self.value * other,
+            value: self.value.checked_mul(other).expect(OVERFLOW_MSG),
             negative: self.negative,
         }
     }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -73,6 +73,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Add<Output = T>
@@ -172,6 +174,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -218,6 +222,8 @@ where
     T: Copy
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -38,7 +38,7 @@ where
     T: Copy
         + const_num_traits::One
         + core::ops::Add<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Sub<Output = T>
@@ -52,7 +52,12 @@ where
     // O(log R) alternatives for larger moduli.
     let mut n_prime = T::one();
     loop {
-        if (modulus * n_prime) % r == target {
+        if modulus
+            .checked_mul(n_prime)
+            .expect(crate::montgomery::OVERFLOW_MSG)
+            % r
+            == target
+        {
             return Some(n_prime);
         }
         n_prime = n_prime + T::one();
@@ -107,7 +112,7 @@ where
     T: Copy
         + const_num_traits::Zero
         + core::ops::Add<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + const_num_traits::One
         + PartialEq
         + core::ops::Sub<Output = T>
@@ -135,7 +140,11 @@ where
         //     x_new = x - x - 1/modulus  (but we work mod powers of 2)
 
         let target_mod = T::one() << k; // 2^k
-        let check_val = (modulus * n_prime + T::one()) % target_mod;
+        let check_val = (modulus
+            .checked_mul(n_prime)
+            .expect(crate::montgomery::OVERFLOW_MSG)
+            + T::one())
+            % target_mod;
 
         if check_val != T::zero() {
             // Need to adjust n_prime
@@ -149,7 +158,10 @@ where
     }
 
     // Final check and adjustment to ensure modulus * N' ≡ -1 (mod R)
-    let final_check = (modulus * n_prime) % r;
+    let final_check = modulus
+        .checked_mul(n_prime)
+        .expect(crate::montgomery::OVERFLOW_MSG)
+        % r;
     let target = r - T::one(); // -1 mod R
 
     if final_check != target {
@@ -280,7 +292,7 @@ where
     T: Copy
         + const_num_traits::One
         + core::ops::Add<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialOrd
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -306,13 +318,20 @@ where
     let mask = (T::one() << r_bits) - T::one(); // mask = 2^r_bits - 1
 
     // Step 1: m = ((a_mont & mask) * N') & mask
-    let m = ((a_mont & mask) * n_prime) & mask;
+    let m = (a_mont & mask)
+        .checked_mul(n_prime)
+        .expect(crate::montgomery::OVERFLOW_MSG)
+        & mask;
 
     // Step 2: t = (a_mont + m * N) >> r_bits
-    // WARNING: m * N can overflow for large moduli (m < R, N < R, so
-    // m*N can reach R^2). Use wide_redc(a_mont, T::zero(), modulus, n_prime)
-    // for overflow-free reduction.
-    let t = (a_mont + m * modulus) >> r_bits;
+    // m * N reaches up to R² (m < R, N < R); checked_mul turns a
+    // carrier-too-narrow product into a panic rather than a wrapped, wrong
+    // reduction. Use wide_redc(a_mont, T::zero(), modulus, n_prime) for
+    // overflow-free reduction.
+    let t = (a_mont
+        + m.checked_mul(modulus)
+            .expect(crate::montgomery::OVERFLOW_MSG))
+        >> r_bits;
 
     // Step 3: Final reduction
     if t >= modulus { t - modulus } else { t }
@@ -329,7 +348,7 @@ where
     T: Copy
         + const_num_traits::Zero
         + core::ops::Add<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + const_num_traits::One
         + PartialOrd
         + core::ops::Sub<Output = T>
@@ -362,7 +381,7 @@ where
     T: Copy
         + const_num_traits::Zero
         + core::ops::Add<Output = T>
-        + core::ops::Mul<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + const_num_traits::One
         + PartialOrd
         + core::ops::Sub<Output = T>

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -37,11 +37,11 @@ fn compute_n_prime_trial_search<T>(modulus: T, r: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::One
+        + core::ops::Add<Output = T>
+        + core::ops::Mul<Output = T>
         + PartialEq
         + PartialOrd
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>,
 {
     // We need to find N' where modulus * N' ≡ R - 1 (mod R)
@@ -77,9 +77,7 @@ where
         + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Div<Output = T>,
 {
     // We need to solve: modulus * N' ≡ -1 (mod R)
@@ -108,11 +106,11 @@ fn compute_n_prime_hensels_lifting<T>(modulus: T, r: T, r_bits: usize) -> Option
 where
     T: Copy
         + const_num_traits::Zero
+        + core::ops::Add<Output = T>
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + PartialEq
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
         + core::ops::Shl<usize, Output = T>,
 {
@@ -173,6 +171,7 @@ pub fn basic_compute_montgomery_params_with_method<T>(
 where
     T: Copy
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -181,7 +180,6 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Div<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
         + core::ops::Add<Output = T>,
 {
@@ -221,6 +219,7 @@ pub fn basic_compute_montgomery_params<T>(modulus: T) -> Option<(T, T, T, usize)
 where
     T: Copy
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -229,7 +228,6 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Div<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Rem<Output = T>
         + core::ops::Add<Output = T>,
 {
@@ -281,9 +279,9 @@ pub fn basic_from_montgomery<T>(a_mont: T, modulus: T, n_prime: T, r_bits: usize
 where
     T: Copy
         + const_num_traits::One
-        + PartialOrd
-        + core::ops::Mul<Output = T>
         + core::ops::Add<Output = T>
+        + core::ops::Mul<Output = T>
+        + PartialOrd
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Shl<usize, Output = T>
@@ -330,10 +328,10 @@ pub fn basic_montgomery_mul<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, r_b
 where
     T: Copy
         + const_num_traits::Zero
+        + core::ops::Add<Output = T>
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + PartialOrd
-        + core::ops::Mul<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
         + core::ops::Shr<usize, Output = T>
@@ -363,10 +361,10 @@ pub fn basic_montgomery_mul_pr<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, 
 where
     T: Copy
         + const_num_traits::Zero
+        + core::ops::Add<Output = T>
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + PartialOrd
-        + core::ops::Mul<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Shl<usize, Output = T>

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -50,6 +50,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
@@ -133,6 +135,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
@@ -188,6 +192,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
@@ -319,6 +325,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
@@ -360,6 +368,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
@@ -397,6 +407,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
@@ -461,6 +473,8 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -21,8 +21,8 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::Mul<&'a T, Output = T>,
 {
     // We need to find N' where modulus * N' ≡ R - 1 (mod R)
     let target = r.clone().wrapping_sub(T::one()); // This is -1 mod R
@@ -30,7 +30,11 @@ where
     // Simple trial search for N'
     let mut n_prime = T::one();
     loop {
-        if (modulus.clone() * &n_prime) % r == target {
+        let product = modulus
+            .clone()
+            .checked_mul(n_prime.clone())
+            .expect(crate::montgomery::OVERFLOW_MSG);
+        if product % r == target {
             return Some(n_prime);
         }
         n_prime = n_prime.wrapping_add(T::one());
@@ -55,8 +59,7 @@ where
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>,
+        + core::ops::Sub<Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T> + core::ops::Div<&'a T, Output = T>,
 {
@@ -88,9 +91,9 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> T: core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     // Hensel's lifting for N' computation when R = 2^k
@@ -99,7 +102,10 @@ where
     // Lift from 2^1 to 2^r_bits using Newton's method
     for k in 2..=r_bits {
         let target_mod = T::one() << k; // 2^k
-        let temp_prod = modulus.clone() * &n_prime;
+        let temp_prod = modulus
+            .clone()
+            .checked_mul(n_prime.clone())
+            .expect(crate::montgomery::OVERFLOW_MSG);
         let temp_sum = temp_prod.wrapping_add(T::one());
         let check_val = &temp_sum % &target_mod;
 
@@ -112,7 +118,11 @@ where
     }
 
     // Final check
-    let final_check = (modulus.clone() * &n_prime) % r;
+    let final_prod = modulus
+        .clone()
+        .checked_mul(n_prime.clone())
+        .expect(crate::montgomery::OVERFLOW_MSG);
+    let final_check = final_prod % r;
     let target = r.clone().wrapping_sub(T::one()); // -1 mod R
 
     if final_check != target {
@@ -239,8 +249,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingSub<Output = T>,
-    for<'a> T: core::ops::Mul<&'a T, Output = T>,
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
+        + const_num_traits::CheckedMul<Output = T>,
     for<'a> &'a T: core::ops::BitAnd<&'a T, Output = T>,
 {
     // Montgomery reduction algorithm:
@@ -262,13 +272,18 @@ where
 
     // Step 1: m = ((a_mont & mask) * N') & mask
     let a_low = &a_mont & &mask;
-    let product = a_low * n_prime;
+    let product = a_low
+        .checked_mul(n_prime.clone())
+        .expect(crate::montgomery::OVERFLOW_MSG);
     let m = &product & &mask;
 
     // Step 2: t = (a_mont + m * N) >> r_bits
-    // Warning: m * N can overflow for large moduli (m < R, N < R, so m*N
-    // can reach R²). For overflow-free reduction, use wide-REDC.
-    let m_times_n = m * modulus;
+    // m * N reaches up to R² (m < R, N < R); checked_mul turns a
+    // carrier-too-narrow product into a panic rather than a wrapped, wrong
+    // reduction. For overflow-free reduction, use wide-REDC.
+    let m_times_n = m
+        .checked_mul(modulus.clone())
+        .expect(crate::montgomery::OVERFLOW_MSG);
     let temp_sum = a_mont.wrapping_add(m_times_n);
     let t = temp_sum >> r_bits;
 
@@ -297,6 +312,7 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -55,7 +55,6 @@ where
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Mul<Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
@@ -134,6 +133,7 @@ pub fn constrained_compute_montgomery_params_with_method<T>(
 where
     T: Clone
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -141,9 +141,7 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T>
@@ -191,6 +189,7 @@ pub fn constrained_compute_montgomery_params<T>(modulus: &T) -> Option<(T, T, T,
 where
     T: Clone
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -198,9 +197,7 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Add<&'a T, Output = T>
@@ -324,6 +321,7 @@ pub fn constrained_montgomery_mod_mul_with_method<T>(
 where
     T: Clone
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -331,9 +329,7 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt
@@ -367,6 +363,7 @@ pub fn constrained_montgomery_mod_mul<T>(a: T, b: &T, modulus: &T) -> Option<T>
 where
     T: Clone
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -374,9 +371,7 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt
@@ -406,6 +401,7 @@ pub fn constrained_montgomery_mod_exp_with_method<T>(
 where
     T: Clone
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -413,9 +409,7 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
@@ -472,6 +466,7 @@ pub fn constrained_montgomery_mod_exp<T>(base: T, exponent: &T, modulus: &T) -> 
 where
     T: Clone
         + const_num_traits::Zero
+        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -479,9 +474,7 @@ where
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
-        + core::ops::Mul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -794,9 +794,9 @@ mod backend_montgomery_tests {
     montgomery_test_module!(
         bnum_patched,
         bnum_patched::types::U256,
-        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        strict: on,
+        constrained: on,
+        basic: on,
     );
 
     //     montgomery_test_module!(
@@ -810,9 +810,9 @@ mod backend_montgomery_tests {
     montgomery_test_module!(
         crypto_bigint_patched,
         crypto_bigint_patched::U256,
-        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
-        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        strict: off, // fork: n-prime path needs more &T reference ops (&T op T / &T op &T)
+        constrained: off, // fork: n-prime path needs more &T reference ops (&T op T / &T op &T)
+        basic: on,
     );
 
     //     montgomery_test_module!(

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -794,9 +794,9 @@ mod backend_montgomery_tests {
     montgomery_test_module!(
         bnum_patched,
         bnum_patched::types::U256,
-        strict: on,
-        constrained: on,
-        basic: on,
+        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
     );
 
     //     montgomery_test_module!(
@@ -810,9 +810,9 @@ mod backend_montgomery_tests {
     montgomery_test_module!(
         crypto_bigint_patched,
         crypto_bigint_patched::U256,
-        strict: off, // fork gap: Montgomery n-prime path needs more &T reference ops than inv
-        constrained: off, // fork gap: Montgomery n-prime path needs more &T reference ops than inv
-        basic: on,
+        strict: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        constrained: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
+        basic: off, // needs CheckedAdd/CheckedMul (Signed EEA migrated off unspecified core::ops::Mul)
     );
 
     //     montgomery_test_module!(

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -24,6 +24,13 @@ pub(crate) mod strict_mont;
 
 pub mod cios;
 
+/// The R>N schoolbook REDC forms a full-width `m * N` (up to R²) product; if
+/// the carrier can't hold it the reduction would silently wrap into a wrong
+/// result, so the checked multiplies panic instead. Sized moduli should route
+/// through wide-REDC / CIOS, which never forms this intermediate.
+pub(crate) const OVERFLOW_MSG: &str =
+    "montgomery R>N: carrier too narrow for the m*N intermediate; use wide-REDC / CIOS";
+
 // Flavor-neutral items live at this flat path: the NPrimeMethod enum
 // (shared by every flavor's `*_with_method` siblings), the wide-REDC
 // param helpers (`compute_n_prime_newton` etc., generic over any T:

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -16,10 +16,9 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
+        + const_num_traits::CheckedMul<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
-    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     // We need to find N' where modulus * N' ≡ R - 1 (mod R)
     let target = r - &T::one(); // This is -1 mod R
@@ -30,8 +29,10 @@ where
     let mut n_prime = T::one();
     loop {
         // Check if (modulus * n_prime) % r == target
-        // Use references to avoid copying large integers
-        let product = modulus * &n_prime;
+        let product = modulus
+            .clone()
+            .checked_mul(n_prime.clone())
+            .expect(crate::montgomery::OVERFLOW_MSG);
         let remainder = &product % r;
         if remainder == target {
             return Some(n_prime);
@@ -63,9 +64,7 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Sub<Output = T>,
-    for<'a> T: core::ops::Mul<&'a T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>,
+    for<'a> T: core::ops::Sub<&'a T, Output = T> + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Div<&'a T, Output = T>
         + core::ops::Sub<T, Output = T>
@@ -99,12 +98,11 @@ where
         + const_num_traits::One
         + PartialEq
         + PartialOrd
+        + const_num_traits::CheckedMul<Output = T>
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Rem<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::Sub<&'a T, Output = T> + core::ops::Rem<&'a T, Output = T>,
 {
     // Hensel's lifting for N' computation when R = 2^k
     // Start with base case: find N' such that modulus * N' ≡ -1 (mod 2)
@@ -122,7 +120,10 @@ where
         // This is the core of Hensel lifting: extending solutions modulo increasing powers
 
         let target_mod = T::one() << k; // 2^k
-        let temp_prod = modulus * &n_prime;
+        let temp_prod = modulus
+            .clone()
+            .checked_mul(n_prime.clone())
+            .expect(crate::montgomery::OVERFLOW_MSG);
         let (temp_sum, _overflow) = temp_prod.overflowing_add(T::one());
         let check_val = &temp_sum % &target_mod;
 
@@ -143,7 +144,11 @@ where
 
     // Verification: ensure the computed N' satisfies modulus * N' ≡ -1 (mod R)
     // This check validates the mathematical correctness of our Hensel lifting
-    let final_check = (modulus * &n_prime) % r;
+    let final_prod = modulus
+        .clone()
+        .checked_mul(n_prime.clone())
+        .expect(crate::montgomery::OVERFLOW_MSG);
+    let final_check = &final_prod % r;
     let target = r - &T::one(); // -1 mod R
 
     if final_check != target {
@@ -264,6 +269,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + PartialOrd
+        + const_num_traits::CheckedMul<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Shl<usize, Output = T>
@@ -299,8 +305,9 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Sub<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
-    for<'a> T: core::ops::Mul<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
-    for<'a> &'a T: core::ops::Mul<&'a T, Output = T> + core::ops::BitAnd<&'a T, Output = T>,
+    T: const_num_traits::CheckedMul<Output = T>,
+    for<'a> T: core::ops::Sub<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::BitAnd<&'a T, Output = T>,
 {
     // Montgomery reduction algorithm:
     // Input: a_mont (Montgomery form), N (modulus), N', r_bits
@@ -324,13 +331,18 @@ where
     // Step 1: m = ((a_mont & mask) * N') & mask
     // Only use low r_bits of a_mont, then mask result to low r_bits
     let a_low = &a_mont & &mask;
-    let product = &a_low * n_prime;
+    let product = a_low
+        .checked_mul(n_prime.clone())
+        .expect(crate::montgomery::OVERFLOW_MSG);
     let m = &product & &mask;
 
     // Step 2: t = (a_mont + m * N) >> r_bits
-    // Warning: m * N can overflow for large moduli (m < R, N < R, so m*N
-    // can reach R²). For overflow-free reduction, use wide-REDC.
-    let m_times_n = &m * modulus;
+    // m * N reaches up to R² (m < R, N < R); checked_mul turns a
+    // carrier-too-narrow product into a panic rather than a wrapped, wrong
+    // reduction. For overflow-free reduction, use wide-REDC.
+    let m_times_n = m
+        .checked_mul(modulus.clone())
+        .expect(crate::montgomery::OVERFLOW_MSG);
     let (sum, _overflow) = a_mont.overflowing_add(m_times_n);
     let t = sum >> r_bits; // Divide by R = 2^r_bits using bit shift
 

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -58,6 +58,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Add<Output = T>
@@ -164,6 +165,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -199,6 +201,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -367,6 +370,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -430,6 +434,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -470,6 +475,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -548,6 +554,7 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
+        + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -61,7 +61,6 @@ where
         + const_num_traits::CheckedAdd<Output = T>
         + PartialEq
         + PartialOrd
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -170,7 +169,6 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
@@ -206,7 +204,6 @@ where
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + for<'a> core::ops::Rem<&'a T, Output = T>,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
@@ -377,7 +374,6 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
@@ -441,7 +437,6 @@ where
         + core::ops::Shr<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
         + for<'a> core::ops::Rem<&'a T, Output = T>,
@@ -483,7 +478,6 @@ where
         + core::ops::ShrAssign<usize>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>
@@ -562,7 +556,6 @@ where
         + core::ops::ShrAssign<usize>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + core::ops::Add<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt,
     for<'a> T: core::ops::RemAssign<&'a T>

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -59,6 +59,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Sub<Output = T>,
@@ -165,6 +166,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -200,6 +202,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -368,6 +371,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -431,6 +435,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -471,6 +476,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>
@@ -549,6 +555,7 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
         + core::ops::Shl<usize, Output = T>

--- a/modmath/src/test_carrier.rs
+++ b/modmath/src/test_carrier.rs
@@ -49,6 +49,20 @@ impl const_num_traits::Parity for &NcU64 {
     }
 }
 
+impl const_num_traits::CheckedAdd for NcU64 {
+    type Output = NcU64;
+    fn checked_add(self, v: Self) -> Option<Self> {
+        self.0.checked_add(v.0).map(NcU64)
+    }
+}
+
+impl const_num_traits::CheckedMul for NcU64 {
+    type Output = NcU64;
+    fn checked_mul(self, v: Self) -> Option<Self> {
+        self.0.checked_mul(v.0).map(NcU64)
+    }
+}
+
 impl const_num_traits::ops::wrapping::WrappingAdd for NcU64 {
     type Output = NcU64;
     fn wrapping_add(self, v: Self) -> Self {

--- a/modmath/src/test_carrier.rs
+++ b/modmath/src/test_carrier.rs
@@ -274,6 +274,25 @@ mod tests {
     }
 
     #[test]
+    fn nc_u64_checked_add() {
+        use const_num_traits::CheckedAdd;
+        assert_eq!(NcU64(2).checked_add(NcU64(3)), Some(NcU64(5)));
+        assert_eq!(
+            NcU64(u64::MAX - 1).checked_add(NcU64(1)),
+            Some(NcU64(u64::MAX))
+        );
+        assert_eq!(NcU64(u64::MAX).checked_add(NcU64(1)), None);
+    }
+
+    #[test]
+    fn nc_u64_checked_mul() {
+        use const_num_traits::CheckedMul;
+        assert_eq!(NcU64(6).checked_mul(NcU64(7)), Some(NcU64(42)));
+        assert_eq!(NcU64(u64::MAX).checked_mul(NcU64(1)), Some(NcU64(u64::MAX)));
+        assert_eq!(NcU64(u64::MAX).checked_mul(NcU64(2)), None);
+    }
+
+    #[test]
     fn montgomery_strict_matches_u64() {
         use crate::montgomery::strict_mont::{
             strict_montgomery_mod_exp, strict_montgomery_mod_mul,


### PR DESCRIPTION
## Why

The schoolbook modular inverse (`Signed<T>`'s EEA) multiplied and added magnitudes through plain `core::ops::{Mul, Add}` on `T`, whose overflow behavior is **unspecified** — wrap, panic, or (on a runtime-length carrier) a shape-based overflow. That's the same "don't build on underspecified primitives" discipline the constant-time surface already follows; the schoolbook path was the last holdout.

The gap surfaced concretely when cross-testing against fixed-bigint's `HeaplessBigInt`, whose fixed-capacity `*` reports overflow on accumulated *shape* rather than value — turning a mathematically-in-range product into a raw `HeaplessBigInt::mul overflow` panic.

## What

`Signed<T>`'s magnitude ops now use `CheckedMul` / `CheckedAdd` with `.expect()`:
- A too-narrow carrier is a **deterministic panic with a clear message** (carrier-precondition violation), never a silently-wrong inverse — the failure mode `wrapping_mul` would have given.
- `Sub` stays plain — `Signed` only ever subtracts smaller from larger, which cannot underflow.

**Not a live-bug fix on value carriers.** EEA coefficient products are bounded by ≈modulus/2, so on any carrier sized for the modulus they always fit; primitives and `FixedUInt` never overflowed. The change removes the *reliance* on unspecified behavior and gives a clean, contract-level failure on shape-limited carriers.

## Bound cost

`basic`/`constrained`/`strict_mod_inv`, `Field::inv_eea`, and the N-prime / Montgomery-param callers that reach them now require `CheckedAdd` / `CheckedMul` (17 functions propagated; `strict` only needs `CheckedAdd` since its `Mul<&T>` stays plain). A carrier that impls plain `Mul`/`Add` but not the checked forms would lose those rows — so the fork test matrix moved to `bnum` const-13 / `crypto-bigint` const-13, which now impl `CheckedAdd`/`CheckedMul<Output=Self>`. The `NcU64` test carrier gains delegating impls. Primitives and `FixedUInt` already have them.

## Verification

460 workspace tests, clippy, docs, fmt — all green. Fork inv + montgomery matrix rows run against the const-13 forks (crypto montgomery stays basic-only for a pre-existing `&T` reference-op gap, unrelated to `Checked`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen modular inverse and Montgomery arithmetic by replacing implementation-defined magnitude arithmetic with checked operations and updating carrier and backend constraints accordingly.

Enhancements:
- Switch Signed<T> magnitude addition and multiplication to CheckedAdd/CheckedMul with a clear overflow panic message to avoid relying on implementation-defined behavior.
- Propagate CheckedAdd/CheckedMul bounds through mod_inv helpers, field inversion, and Montgomery backends to ensure carriers support checked arithmetic.
- Add CheckedAdd and CheckedMul implementations for the NcU64 test carrier to keep the test matrix compatible with the new constraints.
- Bump bnum and crypto-bigint fork dependencies to const-13 variants that provide the required checked arithmetic traits and adjust backend test comments to reflect reference-op gaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modular inverse and Montgomery arithmetic safety by detecting arithmetic overflow instead of allowing unreliable results.
  * Strengthened checked arithmetic across supported number types for more predictable calculations.
* **Compatibility**
  * Updated arithmetic support to work with newer constant-friendly numeric implementations.
* **Tests**
  * Expanded test coverage for checked addition and multiplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->