### PR TITLE
Draft: CIOS on the width-and-CT model (HeaplessBigInt first-class CT carrier)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,3 @@ panic = "abort"
 debug = "line-tables-only"
 overflow-checks = false
 incremental = false
-
-# Transitional: bnum/crypto-bigint/num-bigint test-matrix forks still git-pin
-# const-num-traits to the alpha tag (crate-version 0.2.1, git source), which
-# hard-conflicts with the crates.io 0.2.1 the lib now uses. Redirect the git
-# source to the published crate so the whole graph unifies on one registry
-# const-num-traits. Remove once those forks re-pin to crates.io directly.
-[patch."https://github.com/kaidokert/num-traits.git"]
-const-num-traits = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ panic = "abort"
 debug = "line-tables-only"
 overflow-checks = false
 incremental = false
+
+[patch.crates-io]
+const-num-traits = { path = "../num-traits" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,3 @@ panic = "abort"
 debug = "line-tables-only"
 overflow-checks = false
 incremental = false
-
-[patch.crates-io]
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ overflow-checks = false
 incremental = false
 
 [patch.crates-io]
-const-num-traits = { path = "../num-traits" }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,11 @@ panic = "abort"
 debug = "line-tables-only"
 overflow-checks = false
 incremental = false
+
+# Transitional: bnum/crypto-bigint/num-bigint test-matrix forks still git-pin
+# const-num-traits to the alpha tag (crate-version 0.2.1, git source), which
+# hard-conflicts with the crates.io 0.2.1 the lib now uses. Redirect the git
+# source to the published crate so the whole graph unifies on one registry
+# const-num-traits. Remove once those forks re-pin to crates.io directly.
+[patch."https://github.com/kaidokert/num-traits.git"]
+const-num-traits = "0.2.1"

--- a/ct-verify/ct-ctgrind/src/fixtures.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures.rs
@@ -62,19 +62,14 @@ macro_rules! tri_u64 {
 // which the contract explicitly permits; secret-modulus exponentiation
 // is covered by the `Field::try_new_odd_ct`-based fixtures instead.
 unsafe extern "C" {
-    fn ct_fix__mod_exp_pr_odd__u64__N1(
-        base: *const u64,
-        e: *const u64,
-        m: *const u64,
-        out: *mut u64,
-    );
+    fn ct_fix__field_exp__u64__N1(base: *const u64, e: *const u64, m: *const u64, out: *mut u64);
 }
-ctgrind_fixture!(ct_fix__mod_exp_pr_odd__u64__N1, {
+ctgrind_fixture!(ct_fix__field_exp__u64__N1, {
     let (base, e, m) = (0u64, 0u64, 0u64);
     let mut out = 0u64;
     taint_val(&base);
     taint_val(&e);
-    unsafe { ct_fix__mod_exp_pr_odd__u64__N1(&base, &e, &m, &mut out) }
+    unsafe { ct_fix__field_exp__u64__N1(&base, &e, &m, &mut out) }
     untaint_val(&out);
     let _ = black_box(out);
 });
@@ -119,16 +114,16 @@ ctgrind_fixture!(ct_fix__cios_mont_mul__fb32__N8, {
 });
 
 unsafe extern "C" {
-    fn ct_fix__mod_exp_pr_odd__fb32__N8(base: *const W8, e: *const W8, m: *const W8, out: *mut W8);
+    fn ct_fix__field_exp__fb32__N8(base: *const W8, e: *const W8, m: *const W8, out: *mut W8);
 }
 // Modulus untainted — same public-modulus contract as the u64 variant
 // above.
-ctgrind_fixture!(ct_fix__mod_exp_pr_odd__fb32__N8, {
+ctgrind_fixture!(ct_fix__field_exp__fb32__N8, {
     let (base, e, m) = ([0u32; 8], [0u32; 8], [0u32; 8]);
     let mut out = [0u32; 8];
     taint_val(&base);
     taint_val(&e);
-    unsafe { ct_fix__mod_exp_pr_odd__fb32__N8(&base, &e, &m, &mut out) }
+    unsafe { ct_fix__field_exp__fb32__N8(&base, &e, &m, &mut out) }
     untaint_val(&out);
     let _ = black_box(out);
 });

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -317,8 +317,9 @@ const HELPER_ALLOWLIST: &[&str] = &[
     r"modmath5field50Field\$LT\$T\$C\$const_num_traits\.\.personality\.\.Ct\$GT\$3exp",
     r"modmath10montgomery10basic_mont11mod_exp2_ct",
     r"modmath10montgomery10basic_mont22compute_n_prime_newton",
-    r"modmath10montgomery10basic_mont34basic_montgomery_mod_exp_pr_odd_ct",
-    // NCT precompute reached from the mod_exp_pr_odd fixtures. Its
+    // NCT precompute reached from the `field_exp` fixtures via
+    // `Field::try_new_odd_ct` (the modexp fixtures migrated off the retired
+    // `montgomery::ct::pre_reduced` free-function). Its
     // rustdoc documents the modulus as public and the NCT compute_*
     // helpers as intentional; the branches here (including the
     // modulus == one compare that pulls in FixedUInt's PartialEq) are

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -318,10 +318,8 @@ const HELPER_ALLOWLIST: &[&str] = &[
     r"modmath10montgomery10basic_mont11mod_exp2_ct",
     r"modmath10montgomery10basic_mont22compute_n_prime_newton",
     // NCT precompute reached from the `field_exp` fixtures via
-    // `Field::try_new_odd_ct` (the modexp fixtures migrated off the retired
-    // `montgomery::ct::pre_reduced` free-function). Its
-    // rustdoc documents the modulus as public and the NCT compute_*
-    // helpers as intentional; the branches here (including the
+    // `Field::try_new_odd_ct`. Its rustdoc documents the modulus as public and
+    // the NCT compute_* helpers as intentional; the branches here (including the
     // modulus == one compare that pulls in FixedUInt's PartialEq) are
     // on that public modulus. The length-prefixed mangling ("8mod_exp2",
     // "10mod_double") keeps these from also matching the _ct variants.

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -27,6 +27,6 @@ modmath = { path = "../../modmath" }
 # Registry, not path — matches modmath's own dep so the CiosRowOps
 # trait identity stays single (a path copy of fixed-bigint would pull
 # a second modmath-cios and split it).
-fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] }
+fixed-bigint = { version = "0.6", default-features = false, features = ["cios"] }
 const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/src/fixtures_core.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_core.rs
@@ -11,7 +11,6 @@ use crate::bb;
 use const_num_traits::Ct;
 use fixed_bigint::FixedUInt;
 use modmath::CiosMontMulCt;
-use modmath::basic::montgomery::ct::pre_reduced as mont_ct_pr;
 use modmath::basic::montgomery::wide::ct as wide_ct;
 
 type Fb256 = FixedUInt<u32, 8, Ct>;
@@ -82,35 +81,7 @@ pub extern "C" fn ct_fix__cios_mont_mul__fb32__N8(
     unsafe { *out = bb(*r.words()) }
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn ct_fix__mod_exp_pr_odd__u64__N1(
-    base: *const u64,
-    e: *const u64,
-    m: *const u64,
-    out: *mut u64,
-) {
-    let base = bb(unsafe { *base });
-    let e = bb(unsafe { *e });
-    let m = bb(unsafe { *m }) | 1;
-    // SAFETY: low bit forced above.
-    let m = unsafe { modmath::Odd::new_unchecked(m) };
-    let r = mont_ct_pr::mod_exp_odd(base, e, m);
-    unsafe { *out = bb(r) }
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn ct_fix__mod_exp_pr_odd__fb32__N8(
-    base: *const [u32; 8],
-    e: *const [u32; 8],
-    m: *const [u32; 8],
-    out: *mut [u32; 8],
-) {
-    let base = Fb256::from(bb(unsafe { *base }));
-    let e = Fb256::from(bb(unsafe { *e }));
-    let mut mw = bb(unsafe { *m });
-    mw[0] |= 1;
-    // SAFETY: low bit forced above.
-    let m = unsafe { modmath::Odd::new_unchecked(Fb256::from(mw)) };
-    let r = mont_ct_pr::mod_exp_odd(base, e, m);
-    unsafe { *out = bb(*r.words()) }
-}
+// Modexp moved to the shipped `Field<T, Ct>::exp` surface — see
+// `ct_fix__field_exp__*` in `fixtures_field`. The retired
+// `montgomery::ct::pre_reduced` free-function is no longer part of the
+// public surface, so there is nothing to taint here.

--- a/ct-verify/ct-fixtures/src/fixtures_core.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_core.rs
@@ -81,7 +81,5 @@ pub extern "C" fn ct_fix__cios_mont_mul__fb32__N8(
     unsafe { *out = bb(*r.words()) }
 }
 
-// Modexp moved to the shipped `Field<T, Ct>::exp` surface — see
-// `ct_fix__field_exp__*` in `fixtures_field`. The retired
-// `montgomery::ct::pre_reduced` free-function is no longer part of the
-// public surface, so there is nothing to taint here.
+// Modexp is tainted on the shipped `Field<T, Ct>::exp` path — see
+// `ct_fix__field_exp__*` in `fixtures_field`.

--- a/ct-verify/ct-fixtures/src/fixtures_field.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_field.rs
@@ -21,6 +21,42 @@ use modmath::Field;
 
 type Fb256 = FixedUInt<u32, 8, Ct>;
 
+/// CT modular exponentiation through the shipped `Field<T, Ct>::exp`
+/// ladder — the surface that replaced the retired
+/// `montgomery::ct::pre_reduced` free-function. Modulus public (forced
+/// odd via `|= 1`, so `try_new_odd_ct`'s `CtOption` unwrap branches on a
+/// fixture-defined bit); base and exponent secret.
+#[unsafe(no_mangle)]
+pub extern "C" fn ct_fix__field_exp__u64__N1(
+    base: *const u64,
+    e: *const u64,
+    m: *const u64,
+    out: *mut u64,
+) {
+    let base = bb(unsafe { *base });
+    let e = bb(unsafe { *e });
+    let m = bb(unsafe { *m }) | 1;
+    let f = Field::<u64, Ct>::try_new_odd_ct(m).unwrap();
+    let r = f.exp(&f.reduce(&base), &e);
+    unsafe { *out = bb(f.into_raw(&r)) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn ct_fix__field_exp__fb32__N8(
+    base: *const [u32; 8],
+    e: *const [u32; 8],
+    m: *const [u32; 8],
+    out: *mut [u32; 8],
+) {
+    let base = Fb256::from(bb(unsafe { *base }));
+    let e = Fb256::from(bb(unsafe { *e }));
+    let mut mw = bb(unsafe { *m });
+    mw[0] |= 1;
+    let f = Field::<Fb256, Ct>::try_new_odd_ct(Fb256::from(mw)).unwrap();
+    let r = f.exp(&f.reduce(&base), &e);
+    unsafe { *out = bb(*f.into_raw(&r).words()) }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn ct_fix__field_inv_safegcd__u64__N1(m: *const u64, v: *const u64) -> u8 {
     let m = bb(unsafe { *m }) | 1;

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -20,7 +20,7 @@ panic-handler = []
 [dependencies]
 modmath = { path = "../../modmath" }
 # Registry, not path — same trait-identity rationale as ct-fixtures.
-fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] }
+fixed-bigint = { version = "0.6", default-features = false, features = ["cios"] }
 const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/src/lib.rs
+++ b/ct-verify/panic-free-audit/src/lib.rs
@@ -24,7 +24,6 @@ use core::hint::black_box;
 
 use const_num_traits::Ct;
 use fixed_bigint::FixedUInt;
-use modmath::basic::montgomery::ct::pre_reduced as mont_ct_pr;
 use modmath::basic::montgomery::wide::ct as wide_ct;
 use modmath::{CiosMontMulCt, Field};
 
@@ -78,7 +77,7 @@ pub extern "C" fn panic_audit__cios_mont_mul_ct__fb32(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn panic_audit__mod_exp_pr_odd_ct__fb32(
+pub extern "C" fn panic_audit__field_exp__fb32(
     base: *const [u32; 8],
     e: *const [u32; 8],
     m: *const [u32; 8],
@@ -88,10 +87,12 @@ pub extern "C" fn panic_audit__mod_exp_pr_odd_ct__fb32(
     let e = Fb256::from(black_box(unsafe { *e }));
     let mut mw = black_box(unsafe { *m });
     mw[0] |= 1;
-    // SAFETY: low bit forced above.
-    let m = unsafe { modmath::Odd::new_unchecked(Fb256::from(mw)) };
-    let r = mont_ct_pr::mod_exp_odd(base, e, m);
-    unsafe { *out = black_box(*r.words()) }
+    // SAFETY: low bit forced above. Infallible `new_odd_ct` (no `.unwrap()`)
+    // keeps the panic-symbol audit clean.
+    let proof = unsafe { modmath::Odd::new_unchecked(Fb256::from(mw)) };
+    let f = Field::<Fb256, Ct>::new_odd_ct(proof);
+    let r = f.exp(&f.reduce(&base), &e);
+    unsafe { *out = black_box(*f.into_raw(&r).words()) }
 }
 
 /// The constructor a consumer calls with a secret modulus. The returned

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.6", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.7", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -36,7 +36,10 @@ fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag =
 bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false }
 crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false }
 # num-bigint = { package = "num-bigint", version = "0.4"}
-# num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
+# num-bigint_patched: fork v0.4.4-const-2 does not compile standalone yet
+# (bigint.rs imports nonexistent `num_traits::Signum`; `Checked*` impls use a
+# value receiver against num-traits' `&self`). Re-enable once the fork builds.
+# num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-2", default-features = false }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.2", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.3", default-features = false, features = ["ct"] }
 # Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
 # identity everywhere — modmath, its test binaries, and fixed-bigint's
 # dev-dep all resolve the same copy.
@@ -27,14 +27,14 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.23", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.25", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live
 # again. Upstream (unforked) crates and num-bigint/ibig stay disabled:
 # no const-num-traits impls upstream; ibig is blocked architecturally.
-bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-16", default-features = false }
-crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-16", default-features = false }
+bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false }
+crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false }
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
 # ibig = "0.3"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.3", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.6", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -38,7 +38,7 @@ crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/k
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
 # `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.
-num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-5" }
+num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-6" }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.14", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.16", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1", default-features = false, features = ["ct"] }
 # Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
 # identity everywhere — modmath, its test binaries, and fixed-bigint's
 # dev-dep all resolve the same copy.
@@ -27,14 +27,14 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.13", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.14", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live
 # again. Upstream (unforked) crates and num-bigint/ibig stay disabled:
 # no const-num-traits impls upstream; ibig is blocked architecturally.
-bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-13", default-features = false }
-crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-13", default-features = false }
+bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-15", default-features = false }
+crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-15", default-features = false }
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
 # ibig = "0.3"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.3", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.2.1", default-features = false, features = ["ct"] }
 # Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
 # identity everywhere — modmath, its test binaries, and fixed-bigint's
 # dev-dep all resolve the same copy.
@@ -30,7 +30,7 @@ modmath-cios = { version = "0.1" }
 # `zeroize` on the carrier gives the test matrix `Zeroize`/`DefaultIsZeroes`, so
 # the suite compiles under `--features zeroize` (which gates `MontStorage` on
 # `Zeroize`) — the column every real consumer builds. Dev-only; harmless off.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.27", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.28", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -36,12 +36,12 @@ fixed-bigint = { version = "0.6.0", default-features = false, features = ["cios"
 # crypto-bigint, and num-bigint (heap-backed `FixedWidthBigUint`) are all
 # enabled below. Upstream (unforked) crates stay disabled (no const-num-traits
 # impls upstream); ibig is blocked architecturally.
-bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false, features = ["zeroize"] }
-crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false, features = ["zeroize"] }
+bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-18", default-features = false, features = ["zeroize"] }
+crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-18", default-features = false, features = ["zeroize"] }
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
 # `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.
-num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-7" }
+num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-8" }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.16", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.17", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,14 +27,17 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.25", default-features = false, features = ["cios", "heapless-runtime-len"] }
+# `zeroize` on the carrier gives the test matrix `Zeroize`/`DefaultIsZeroes`, so
+# the suite compiles under `--features zeroize` (which gates `MontStorage` on
+# `Zeroize`) — the column every real consumer builds. Dev-only; harmless off.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.25", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live
 # again. Upstream (unforked) crates and num-bigint/ibig stay disabled:
 # no const-num-traits impls upstream; ibig is blocked architecturally.
-bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false }
-crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false }
+bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false, features = ["zeroize"] }
+crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false, features = ["zeroize"] }
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
 # `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -30,7 +30,7 @@ modmath-cios = { version = "0.1" }
 # `zeroize` on the carrier gives the test matrix `Zeroize`/`DefaultIsZeroes`, so
 # the suite compiles under `--features zeroize` (which gates `MontStorage` on
 # `Zeroize`) — the column every real consumer builds. Dev-only; harmless off.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.25", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.26", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -36,10 +36,9 @@ fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag =
 bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false }
 crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false }
 # num-bigint = { package = "num-bigint", version = "0.4"}
-# num-bigint_patched: fork v0.4.4-const-2 does not compile standalone yet
-# (bigint.rs imports nonexistent `num_traits::Signum`; `Checked*` impls use a
-# value receiver against num-traits' `&self`). Re-enable once the fork builds.
-# num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-2", default-features = false }
+# Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
+# `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.
+num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-4" }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -23,19 +23,11 @@ const-num-traits = { version = "0.2.1", default-features = false, features = ["c
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-# fixed-bigint 0.6 (registry) exposes HeaplessBigInt (fixed capacity, runtime
-# length) as a default, unconditional part of the crate — added to the backend
-# test matrix. `zeroize` on the carrier gives the matrix `Zeroize`/
-# `DefaultIsZeroes`, so the suite compiles under `--features zeroize` (which
-# gates `MontStorage` on `Zeroize`) — the column every real consumer builds.
-# Dev-only; harmless off.
+# `zeroize` lets the test matrix compile under `--features zeroize`, which gates
+# `MontStorage` on `Zeroize`.
 fixed-bigint = { version = "0.6.0", default-features = false, features = ["cios", "zeroize"] }
-# Third-party bigint backends. The `_patched` kaidokert forks carry
-# const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
-# krabitls backend-swap experiments), so their test matrices are live: bnum,
-# crypto-bigint, and num-bigint (heap-backed `FixedWidthBigUint`) are all
-# enabled below. Upstream (unforked) crates stay disabled (no const-num-traits
-# impls upstream); ibig is blocked architecturally.
+# `_patched` forks add the const-num-traits + modmath-cios impls upstream lacks,
+# so these backends can join the test matrix. ibig is blocked architecturally.
 bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-18", default-features = false, features = ["zeroize"] }
 crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-18", default-features = false, features = ["zeroize"] }
 # num-bigint = { package = "num-bigint", version = "0.4"}

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -23,19 +23,19 @@ const-num-traits = { version = "0.2.1", default-features = false, features = ["c
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-# Experiment: fixed-bigint 0.6-alpha exposes HeaplessBigInt (fixed
-# capacity, runtime length) behind heapless-runtime-len. Pulled as a
-# git tag to add it to the backend test matrix. Move back to a plain
-# registry version when done experimenting.
-# `zeroize` on the carrier gives the test matrix `Zeroize`/`DefaultIsZeroes`, so
-# the suite compiles under `--features zeroize` (which gates `MontStorage` on
-# `Zeroize`) — the column every real consumer builds. Dev-only; harmless off.
+# fixed-bigint 0.6 (registry) exposes HeaplessBigInt (fixed capacity, runtime
+# length) as a default, unconditional part of the crate — added to the backend
+# test matrix. `zeroize` on the carrier gives the matrix `Zeroize`/
+# `DefaultIsZeroes`, so the suite compiles under `--features zeroize` (which
+# gates `MontStorage` on `Zeroize`) — the column every real consumer builds.
+# Dev-only; harmless off.
 fixed-bigint = { version = "0.6.0", default-features = false, features = ["cios", "zeroize"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
-# krabitls backend-swap experiments), so their test matrices are live
-# again. Upstream (unforked) crates and num-bigint/ibig stay disabled:
-# no const-num-traits impls upstream; ibig is blocked architecturally.
+# krabitls backend-swap experiments), so their test matrices are live: bnum,
+# crypto-bigint, and num-bigint (heap-backed `FixedWidthBigUint`) are all
+# enabled below. Upstream (unforked) crates stay disabled (no const-num-traits
+# impls upstream); ibig is blocked architecturally.
 bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-17", default-features = false, features = ["zeroize"] }
 crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-17", default-features = false, features = ["zeroize"] }
 # num-bigint = { package = "num-bigint", version = "0.4"}

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.1", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.3", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.17", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.20", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -38,7 +38,7 @@ crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/k
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
 # `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.
-num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-6" }
+num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-7" }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["numerics", "bignum"]
 c0nst = { version = "0.2", optional = true }
 subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.2", default-features = false, features = ["ct"] }
 # Leaf crate + registry-only (no path) so `CiosRowOps` has exactly one
 # identity everywhere — modmath, its test binaries, and fixed-bigint's
 # dev-dep all resolve the same copy.
@@ -27,14 +27,14 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.21", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.23", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live
 # again. Upstream (unforked) crates and num-bigint/ibig stay disabled:
 # no const-num-traits impls upstream; ibig is blocked architecturally.
-bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-15", default-features = false }
-crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-15", default-features = false }
+bnum_patched = { package = "bnum", git = "https://github.com/kaidokert/bnum.git", tag = "v0.14.4-const-16", default-features = false }
+crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/kaidokert/crypto-bigint.git", tag = "v0.7.5-const-16", default-features = false }
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git" , tag = "v0.4.6_patch" }
 # ibig = "0.3"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -30,7 +30,7 @@ modmath-cios = { version = "0.1" }
 # `zeroize` on the carrier gives the test matrix `Zeroize`/`DefaultIsZeroes`, so
 # the suite compiles under `--features zeroize` (which gates `MontStorage` on
 # `Zeroize`) — the column every real consumer builds. Dev-only; harmless off.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.28", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
+fixed-bigint = { version = "0.6.0", default-features = false, features = ["cios", "zeroize"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -38,7 +38,7 @@ crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/k
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
 # `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.
-num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-4" }
+num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-5" }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -30,7 +30,7 @@ modmath-cios = { version = "0.1" }
 # `zeroize` on the carrier gives the test matrix `Zeroize`/`DefaultIsZeroes`, so
 # the suite compiles under `--features zeroize` (which gates `MontStorage` on
 # `Zeroize`) — the column every real consumer builds. Dev-only; harmless off.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.26", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.27", default-features = false, features = ["cios", "heapless-runtime-len", "zeroize"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.20", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.21", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.10", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.13", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -27,7 +27,7 @@ modmath-cios = { version = "0.1" }
 # capacity, runtime length) behind heapless-runtime-len. Pulled as a
 # git tag to add it to the backend test matrix. Move back to a plain
 # registry version when done experimenting.
-fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.7", default-features = false, features = ["cios", "heapless-runtime-len"] }
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.10", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -23,7 +23,11 @@ const-num-traits = { version = "0.2", default-features = false, features = ["ct"
 modmath-cios = { version = "0.1" }
 
 [dev-dependencies]
-fixed-bigint = { version = "0.5", default-features = false, features = ["cios"] }
+# Experiment: fixed-bigint 0.6-alpha exposes HeaplessBigInt (fixed
+# capacity, runtime length) behind heapless-runtime-len. Pulled as a
+# git tag to add it to the backend test matrix. Move back to a plain
+# registry version when done experimenting.
+fixed-bigint = { git = "https://github.com/kaidokert/fixed-bigint-rs.git", tag = "v0.6.0-alpha.1", default-features = false, features = ["cios", "heapless-runtime-len"] }
 # Third-party bigint backends. The `_patched` kaidokert forks carry
 # const-num-traits 0.2 + modmath-cios impls (proven end-to-end in the
 # krabitls backend-swap experiments), so their test matrices are live

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -450,6 +450,15 @@ mod bnum_add_tests {
         constrained: on,
         basic: on,
     );
+
+    add_test_module!(
+        heapless_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u32, 4>;
+        strict: on,
+        constrained: on,
+        basic: on,
+    );
 }
 
 #[cfg(test)]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -64,7 +64,7 @@ where
 
 /// # Modular Addition (Basic, pre-reduced)
 /// Precondition: `a < m` and `b < m`. No `Rem` bound.
-pub fn basic_mod_add_pr<T>(a: T, b: T, m: T) -> T
+pub(crate) fn basic_mod_add_pr<T>(a: T, b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
@@ -123,7 +123,7 @@ where
 
 /// # Modular Addition (Constrained, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
-pub fn constrained_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
+pub(crate) fn constrained_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
@@ -184,7 +184,7 @@ where
 
 /// # Modular Addition (Strict, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
-pub fn strict_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
+pub(crate) fn strict_mod_add_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -426,20 +426,16 @@ mod bnum_add_tests {
     //         basic: off, // Copy cannot be implemented, heap allocation
     //     );
 
-    // num-bigint fork (`FixedWidthBigUint`) is Nct/constrained/strict-only
-    // (heap, not `Copy`). Blocked re-enabling: the v0.4.4-const-2 fork does not
-    // compile standalone (`bigint.rs` imports the nonexistent `num_traits::Signum`
-    // and impls `num_traits::Checked*` with const-num-traits' value-receiver
-    // signature), and `FixedWidthBigUint` has no width-free `From<uN>` for the
-    // test macro's `U256::from(..)` constructors.
-    //     add_test_module!(
-    //         num_bigint_patched,
-    //         num_bigint_patched::FixedWidthBigUint,
-    //         type U256 = num_bigint_patched::FixedWidthBigUint;
-    //         strict: on,
-    //         constrained: on,
-    //         basic: off, // Copy cannot be implemented, heap allocation
-    //     );
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct, constrained/strict
+    // only (not `Copy`, so `basic: off`).
+    add_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+        strict: on,
+        constrained: on,
+        basic: off,
+    );
 
     //     add_test_module!(
     //         ibig,

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -69,6 +69,9 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + crate::NonCt,
 {
+    // Widen a to the modulus width so the carry from a + b fires at bit W,
+    // not at a's narrower stored width. `m - m` is a field-width zero.
+    let a = m.wrapping_sub(m).wrapping_add(a);
     let sum = a.wrapping_add(b);
     if sum >= m || sum < a {
         sum.wrapping_sub(m)
@@ -123,6 +126,9 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + crate::NonCt,
 {
+    // Widen a to the modulus width so the carry from a + b fires at bit W,
+    // not at a's narrower stored width. `m - m` is a field-width zero.
+    let a = m.clone().wrapping_sub(m.clone()).wrapping_add(a);
     let sum = a.clone().wrapping_add(b.clone());
     if &sum >= m || sum < a {
         sum.wrapping_sub(m.clone())
@@ -179,6 +185,9 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + crate::NonCt,
 {
+    // Widen a to the modulus width so the carry from a + b fires at bit W,
+    // not at a's narrower stored width. `m - m` is a field-width zero.
+    let a = m.clone().overflowing_sub(m.clone()).0.overflowing_add(a).0;
     let (sum, overflow) = a.overflowing_add(b.clone());
     if &sum >= m || overflow {
         sum.overflowing_sub(m.clone()).0
@@ -459,6 +468,29 @@ mod bnum_add_tests {
         constrained: on,
         basic: on,
     );
+
+    // Operands occupy one byte, modulus spans two: a runtime-width carrier
+    // must reduce at the modulus width, not wrap at the operand's. Regression
+    // guard for the len(a) < len(m) case the single-word modules can't reach.
+    #[test]
+    fn heapless_narrow_operand_wide_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 4>;
+        let m: H = 1000u16.into();
+        let want: H = 400u16.into();
+        assert_eq!(
+            super::basic_mod_add(H::from(200u8), H::from(200u8), m),
+            want
+        );
+        assert_eq!(
+            super::constrained_mod_add(H::from(200u8), &H::from(200u8), &m),
+            want
+        );
+        assert_eq!(
+            super::strict_mod_add(H::from(200u8), &H::from(200u8), &m),
+            want
+        );
+    }
 }
 
 #[cfg(test)]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -1,3 +1,4 @@
+use const_num_traits::WithPrecision;
 #[cfg(feature = "nightly")]
 use const_num_traits::{OverflowingAdd, OverflowingSub};
 
@@ -33,7 +34,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Rem<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     basic_mod_add_pr(a % m, b % m, m)
 }
@@ -53,7 +55,8 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     basic_mod_add_pr(a.rem_nonzero(m), b.rem_nonzero(m), m_raw)
@@ -67,11 +70,11 @@ where
         + Copy
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
-    // Widen a to the modulus width so the carry from a + b fires at bit W,
-    // not at a's narrower stored width. `m - m` is a field-width zero.
-    let a = m.wrapping_sub(m).wrapping_add(a);
+    // Widen a to the modulus width so the carry from a + b fires at bit W.
+    let a = a.widen_to_precision_of(&m);
     let sum = a.wrapping_add(b);
     if sum >= m || sum < a {
         sum.wrapping_sub(m)
@@ -89,7 +92,8 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     let a_mod = &a % m;
@@ -109,7 +113,8 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = b.clone().rem_nonzero(m);
@@ -124,11 +129,11 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
-    // Widen a to the modulus width so the carry from a + b fires at bit W,
-    // not at a's narrower stored width. `m - m` is a field-width zero.
-    let a = m.clone().wrapping_sub(m.clone()).wrapping_add(a);
+    // Widen a to the modulus width so the carry from a + b fires at bit W.
+    let a = a.widen_to_precision(m.clone().bits_precision());
     let sum = a.clone().wrapping_add(b.clone());
     if &sum >= m || sum < a {
         sum.wrapping_sub(m.clone())
@@ -146,7 +151,8 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -168,7 +174,8 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = b.clone().rem_nonzero(m);
@@ -183,11 +190,11 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
-    // Widen a to the modulus width so the carry from a + b fires at bit W,
-    // not at a's narrower stored width. `m - m` is a field-width zero.
-    let a = m.clone().overflowing_sub(m.clone()).0.overflowing_add(a).0;
+    // Widen a to the modulus width so the carry from a + b fires at bit W.
+    let a = a.widen_to_precision(m.clone().bits_precision());
     let (sum, overflow) = a.overflowing_add(b.clone());
     if &sum >= m || overflow {
         sum.overflowing_sub(m.clone()).0

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -535,6 +535,34 @@ mod fixed_bigint_pr_tests {
         let a = U256::from(15u8);
         assert_eq!(basic_mod_add_pr(a, b, m), expected);
     }
+
+    // The `_pr` ops widen only the left operand `a` to the modulus width, not
+    // `b`. That is sufficient: `wrapping_add`/`overflowing_add` incorporate a
+    // narrower right operand at the (widened) left width, so a one-limb `b`
+    // against a full-width multi-limb modulus reduces correctly — including the
+    // carry/borrow branch where `a ± b` crosses the modulus width.
+    #[test]
+    fn narrow_b_against_full_width_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 4>;
+        let m = 65533u32; // full 2-limb: a ± b can cross the 16-bit width
+        let hm = H::from(m as u16);
+        for a in [65000u32, 65500, 65532, 40000] {
+            for b in [1u32, 50, 100, 255] {
+                let (ha, hb) = (H::from(a as u16), H::from(b as u8)); // b is one limb
+                assert_eq!(
+                    super::basic_mod_add_pr(ha, hb, hm),
+                    H::from(((a + b) % m) as u16),
+                    "add {a}+{b}"
+                );
+                assert_eq!(
+                    crate::sub::basic_mod_sub_pr(ha, hb, hm),
+                    H::from((((a + m) - b) % m) as u16),
+                    "sub {a}-{b}"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -133,7 +133,7 @@ where
         + WithPrecision,
 {
     // Widen a to the modulus width so the carry from a + b fires at bit W.
-    let a = a.widen_to_precision(m.bits_precision());
+    let a = a.widen_to_precision_of(m);
     let sum = a.clone().wrapping_add(b.clone());
     if &sum >= m || sum < a {
         sum.wrapping_sub(m.clone())
@@ -194,7 +194,7 @@ where
         + WithPrecision,
 {
     // Widen a to the modulus width so the carry from a + b fires at bit W.
-    let a = a.widen_to_precision(m.bits_precision());
+    let a = a.widen_to_precision_of(m);
     let (sum, overflow) = a.overflowing_add(b.clone());
     if &sum >= m || overflow {
         sum.overflowing_sub(m.clone()).0
@@ -426,10 +426,16 @@ mod bnum_add_tests {
     //         basic: off, // Copy cannot be implemented, heap allocation
     //     );
 
+    // num-bigint fork (`FixedWidthBigUint`) is Nct/constrained/strict-only
+    // (heap, not `Copy`). Blocked re-enabling: the v0.4.4-const-2 fork does not
+    // compile standalone (`bigint.rs` imports the nonexistent `num_traits::Signum`
+    // and impls `num_traits::Checked*` with const-num-traits' value-receiver
+    // signature), and `FixedWidthBigUint` has no width-free `From<uN>` for the
+    // test macro's `U256::from(..)` constructors.
     //     add_test_module!(
     //         num_bigint_patched,
-    //         num_bigint_patched::BigUint,
-    //         type U256 = num_bigint_patched::BigUint;
+    //         num_bigint_patched::FixedWidthBigUint,
+    //         type U256 = num_bigint_patched::FixedWidthBigUint;
     //         strict: on,
     //         constrained: on,
     //         basic: off, // Copy cannot be implemented, heap allocation

--- a/modmath/src/add.rs
+++ b/modmath/src/add.rs
@@ -133,7 +133,7 @@ where
         + WithPrecision,
 {
     // Widen a to the modulus width so the carry from a + b fires at bit W.
-    let a = a.widen_to_precision(m.clone().bits_precision());
+    let a = a.widen_to_precision(m.bits_precision());
     let sum = a.clone().wrapping_add(b.clone());
     if &sum >= m || sum < a {
         sum.wrapping_sub(m.clone())
@@ -194,7 +194,7 @@ where
         + WithPrecision,
 {
     // Widen a to the modulus width so the carry from a + b fires at bit W.
-    let a = a.widen_to_precision(m.clone().bits_precision());
+    let a = a.widen_to_precision(m.bits_precision());
     let (sum, overflow) = a.overflowing_add(b.clone());
     if &sum >= m || overflow {
         sum.overflowing_sub(m.clone()).0

--- a/modmath/src/basic/mod.rs
+++ b/modmath/src/basic/mod.rs
@@ -9,15 +9,11 @@
 //! mixed value/reference parameters) or [`modmath::strict`](crate::strict)
 //! (reference-based throughout).
 //!
-//! ## Pre-reduced variants
-//!
-//! [`pre_reduced`] re-exports `add` / `sub` / `mul` / `exp` siblings that
-//! assume inputs are already in `[0, m)` and skip the `% m` reduction
-//! step. Works for backends without `core::ops::Rem` and is the right
-//! entry point inside loops where reduction is handled separately.
-//! Note: `inv` has no pre-reduced sibling — modular inverse via the
-//! extended Euclidean algorithm inside `inv` performs its own
-//! magnitude-dependent loop, with no useful "pre-reduced" shortcut.
+//! A pre-reduced value (already in `[0, m)`) is a residue in a fixed ring;
+//! establish it once through [`SchoolbookField`](crate::SchoolbookField) /
+//! [`FieldOps`](crate::FieldOps) rather than threading raw `T` past the `% m`
+//! boundary — that surface carries the ring width as a type invariant and
+//! cannot seed a narrow value.
 
 #[doc(inline)]
 pub use crate::add::basic_mod_add as add;
@@ -31,19 +27,6 @@ pub use crate::mul::basic_mod_mul as mul;
 pub use crate::sub::basic_mod_sub as sub;
 
 pub mod montgomery;
-
-/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
-/// no `Rem` bound.
-pub mod pre_reduced {
-    #[doc(inline)]
-    pub use crate::add::basic_mod_add_pr as add;
-    #[doc(inline)]
-    pub use crate::exp::basic_mod_exp_pr as exp;
-    #[doc(inline)]
-    pub use crate::mul::basic_mod_mul_pr as mul;
-    #[doc(inline)]
-    pub use crate::sub::basic_mod_sub_pr as sub;
-}
 
 /// Non-zero-modulus variants. Caller provides `m: T::NonZero` (one
 /// boundary-time `m.into_nonzero()?` proof); every `% m` reduction

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -49,67 +49,6 @@ pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul as mod_mul;
 #[doc(inline)]
 pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_odd as mod_mul_odd;
 
-/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
-/// the input `% m` reduction step is skipped.
-pub mod pre_reduced {
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr as mod_exp;
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_odd as mod_exp_odd;
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr as mod_mul;
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr_odd as mod_mul_odd;
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_montgomery_mul_pr as mul;
-    #[doc(inline)]
-    pub use crate::montgomery::basic_mont::basic_to_montgomery_pr as to_mont;
-}
-
-/// Constant-time variants. The complete-pipeline operations with
-/// branchless conditional-subtract finalize via
-/// `subtle::ConditionallySelectable`, removing the operand-magnitude
-/// side-channel on the final reduction step.
-///
-/// **Only pre-reduced entries are exposed.** CT-over-base
-/// requires a CT reduction primitive; `core::ops::Rem` is
-/// hardware-variable on common embedded targets, so any wrapper that
-/// internally reduced via `Rem` would leak the base magnitude.
-/// Callers needing CT-over-base should:
-///
-/// - reduce the base externally via a CT primitive (e.g.
-///   `Field::reduce` on the `Ct` personality, which composes the CT
-///   wide-REDC reduction), then dispatch to
-///   [`pre_reduced::mod_exp`](self::ct::pre_reduced::mod_exp); or
-/// - use the high-level [`Field<T, Ct>::exp`](crate::Field::exp)
-///   surface, which handles reduction + exponentiation as a single
-///   end-to-end CT pipeline.
-///
-/// There is no `mod_mul_ct` here because the underlying source crate
-/// hasn't published one (the CIOS path is the canonical CT-mul entry
-/// point — see
-/// [`cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)).
-///
-/// # Operator contract
-///
-/// CT entry points never invoke plain `+` / `-` / `*` on the carrier,
-/// and since const-num-traits 0.2 they no longer *bound* them either:
-/// every overflow-relevant operation goes through an explicitly-named
-/// trait (`WrappingAdd`/`WrappingSub`/`WrappingMul`, `BorrowingSub`,
-/// `CtIsZero`, subtle's comparisons), each carrying its own `Output`.
-/// A backend can satisfy the entire CT surface without implementing
-/// `core::ops` arithmetic at all — panicking or mode-dispatched
-/// operator impls elsewhere in the carrier are irrelevant here.
-pub mod ct {
-    /// Pre-reduced CT variants. Precondition: `base < modulus`.
-    pub mod pre_reduced {
-        #[doc(inline)]
-        pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_ct as mod_exp;
-        #[doc(inline)]
-        pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_odd_ct as mod_exp_odd;
-    }
-}
-
 /// Wide-REDC primitives at the `R = 2^W` working width — by-value
 /// operands, `Copy`-bound `T`. These are the building blocks the
 /// [`mod_mul`] / [`mod_exp`] pipelines call internally; consumers

--- a/modmath/src/basic/montgomery.rs
+++ b/modmath/src/basic/montgomery.rs
@@ -49,6 +49,67 @@ pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul as mod_mul;
 #[doc(inline)]
 pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_odd as mod_mul_odd;
 
+/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
+/// the input `% m` reduction step is skipped.
+pub mod pre_reduced {
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr as mod_exp;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_odd as mod_exp_odd;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr as mod_mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mod_mul_pr_odd as mod_mul_odd;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_montgomery_mul_pr as mul;
+    #[doc(inline)]
+    pub use crate::montgomery::basic_mont::basic_to_montgomery_pr as to_mont;
+}
+
+/// Constant-time variants. The complete-pipeline operations with
+/// branchless conditional-subtract finalize via
+/// `subtle::ConditionallySelectable`, removing the operand-magnitude
+/// side-channel on the final reduction step.
+///
+/// **Only pre-reduced entries are exposed.** CT-over-base
+/// requires a CT reduction primitive; `core::ops::Rem` is
+/// hardware-variable on common embedded targets, so any wrapper that
+/// internally reduced via `Rem` would leak the base magnitude.
+/// Callers needing CT-over-base should:
+///
+/// - reduce the base externally via a CT primitive (e.g.
+///   `Field::reduce` on the `Ct` personality, which composes the CT
+///   wide-REDC reduction), then dispatch to
+///   [`pre_reduced::mod_exp`](self::ct::pre_reduced::mod_exp); or
+/// - use the high-level [`Field<T, Ct>::exp`](crate::Field::exp)
+///   surface, which handles reduction + exponentiation as a single
+///   end-to-end CT pipeline.
+///
+/// There is no `mod_mul_ct` here because the underlying source crate
+/// hasn't published one (the CIOS path is the canonical CT-mul entry
+/// point — see
+/// [`cios_montgomery_mul_ct`](crate::montgomery::cios::cios_montgomery_mul_ct)).
+///
+/// # Operator contract
+///
+/// CT entry points never invoke plain `+` / `-` / `*` on the carrier,
+/// and since const-num-traits 0.2 they no longer *bound* them either:
+/// every overflow-relevant operation goes through an explicitly-named
+/// trait (`WrappingAdd`/`WrappingSub`/`WrappingMul`, `BorrowingSub`,
+/// `CtIsZero`, subtle's comparisons), each carrying its own `Output`.
+/// A backend can satisfy the entire CT surface without implementing
+/// `core::ops` arithmetic at all — panicking or mode-dispatched
+/// operator impls elsewhere in the carrier are irrelevant here.
+pub mod ct {
+    /// Pre-reduced CT variants. Precondition: `base < modulus`.
+    pub mod pre_reduced {
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_ct as mod_exp;
+        #[doc(inline)]
+        pub use crate::montgomery::basic_mont::basic_montgomery_mod_exp_pr_odd_ct as mod_exp_odd;
+    }
+}
+
 /// Wide-REDC primitives at the `R = 2^W` working width — by-value
 /// operands, `Copy`-bound `T`. These are the building blocks the
 /// [`mod_mul`] / [`mod_exp`] pipelines call internally; consumers

--- a/modmath/src/constrained/mod.rs
+++ b/modmath/src/constrained/mod.rs
@@ -10,15 +10,11 @@
 //! reference-only surface (works with backends that don't expose
 //! `WrappingMul` / `WrappingSub` on owned values).
 //!
-//! ## Pre-reduced variants
-//!
-//! [`pre_reduced`] re-exports `add` / `sub` / `mul` / `exp` siblings that
-//! assume inputs are already in `[0, m)` and skip the `% m` reduction
-//! step. Works for backends without `core::ops::Rem` and is the right
-//! entry point inside loops where reduction is handled separately.
-//! Note: `inv` has no pre-reduced sibling — modular inverse via the
-//! extended Euclidean algorithm inside `inv` performs its own
-//! magnitude-dependent loop, with no useful "pre-reduced" shortcut.
+//! A pre-reduced value (already in `[0, m)`) is a residue in a fixed ring;
+//! establish it once through [`SchoolbookField`](crate::SchoolbookField) /
+//! [`FieldOps`](crate::FieldOps) rather than threading raw `T` past the `% m`
+//! boundary — that surface carries the ring width as a type invariant and
+//! cannot seed a narrow value.
 
 #[doc(inline)]
 pub use crate::add::constrained_mod_add as add;
@@ -32,19 +28,6 @@ pub use crate::mul::constrained_mod_mul as mul;
 pub use crate::sub::constrained_mod_sub as sub;
 
 pub mod montgomery;
-
-/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
-/// no `Rem` bound.
-pub mod pre_reduced {
-    #[doc(inline)]
-    pub use crate::add::constrained_mod_add_pr as add;
-    #[doc(inline)]
-    pub use crate::exp::constrained_mod_exp_pr as exp;
-    #[doc(inline)]
-    pub use crate::mul::constrained_mod_mul_pr as mul;
-    #[doc(inline)]
-    pub use crate::sub::constrained_mod_sub_pr as sub;
-}
 
 /// Non-zero-modulus variants. See [`basic::nonzero`](crate::basic::nonzero).
 pub mod nonzero {

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -101,7 +101,7 @@ where
 /// Note: this only removes the division side-channel from the signature.
 /// The square-and-multiply loop still branches on `exp.is_odd()`; for a
 /// constant-time ladder, use the Montgomery wide-REDC path.
-pub fn basic_mod_exp_pr<T>(mut base: T, exponent: T, modulus: T) -> T
+pub(crate) fn basic_mod_exp_pr<T>(mut base: T, exponent: T, modulus: T) -> T
 where
     T: PartialOrd
         + const_num_traits::One
@@ -188,7 +188,7 @@ where
 /// # Modular Exponentiation (Constrained, pre-reduced)
 /// Precondition: if `*modulus > 1`, then `base < *modulus`. No `Rem` family bound.
 /// Returns `0` when `*modulus == 1`.
-pub fn constrained_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
+pub(crate) fn constrained_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
 where
     T: Clone
         + PartialOrd
@@ -276,7 +276,7 @@ where
 /// # Modular Exponentiation (Strict, pre-reduced)
 /// Precondition: if `*modulus > 1`, then `base < *modulus`. No `Rem` family bound.
 /// Returns `0` when `*modulus == 1`.
-pub fn strict_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
+pub(crate) fn strict_mod_exp_pr<T>(mut base: T, exponent: &T, modulus: &T) -> T
 where
     T: Clone
         + PartialOrd

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -683,9 +683,9 @@ mod bnum_exp_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        strict: off, // fork: ShrAssign<usize> missing (exp ladder does exp >>= 1)
-        constrained: off, // fork: ShrAssign<usize> missing (exp ladder does exp >>= 1)
-        basic: off, // fork: ShrAssign<usize> missing (exp ladder does exp >>= 1)
+        strict: on,
+        constrained: on,
+        basic: on,
     );
 }
 

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -58,7 +58,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::ShrAssign<usize>
         + Copy
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     if modulus == T::one() {
         return T::zero();
@@ -83,7 +84,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::ShrAssign<usize>
         + Copy
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     let m_raw = T::nonzero_get(modulus);
     if m_raw == T::one() {
@@ -110,7 +112,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::ShrAssign<usize>
         + Copy
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     // x mod 1 == 0 for every x, including 1. The square-and-multiply loop
     // below starts with `result = T::one()` and would return 1 in that case.
@@ -146,7 +149,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: crate::parity::Parity,
 {
@@ -170,7 +174,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> &'a T: crate::parity::Parity,
 {
     let m_raw = T::nonzero_get(modulus);
@@ -193,7 +198,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::ShrAssign<usize>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> &'a T: crate::parity::Parity,
 {
     // See `basic_mod_exp_pr` for the modulus==1 rationale.
@@ -231,7 +237,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::ShrAssign<usize>,
     for<'a> &'a T: crate::parity::Parity,
 {
@@ -254,7 +261,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::ShrAssign<usize>,
     for<'a> &'a T: crate::parity::Parity,
 {
@@ -277,7 +285,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::ShrAssign<usize>,
     for<'a> &'a T: crate::parity::Parity,
 {

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -678,6 +678,15 @@ mod bnum_exp_tests {
         constrained: on,
         basic: on,
     );
+
+    exp_test_module!(
+        heapless_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
+        strict: off, // fork: ShrAssign<usize> missing (exp ladder does exp >>= 1)
+        constrained: off, // fork: ShrAssign<usize> missing (exp ladder does exp >>= 1)
+        basic: off, // fork: ShrAssign<usize> missing (exp ladder does exp >>= 1)
+    );
 }
 
 #[cfg(test)]

--- a/modmath/src/exp.rs
+++ b/modmath/src/exp.rs
@@ -649,14 +649,16 @@ mod bnum_exp_tests {
     //         basic: off, // Copy cannot be implemented, heap allocation
     //     );
 
-    //     exp_test_module!(
-    //         num_bigint_patched,
-    //         num_bigint_patched::BigUint,
-    //         type U256 = num_bigint_patched::BigUint;
-    //         strict: on,
-    //         constrained: on,
-    //         basic: off, // Copy cannot be implemented, heap allocation
-    //     );
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct, constrained/strict
+    // only (not `Copy`, so `basic: off`).
+    exp_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+        strict: on,
+        constrained: on,
+        basic: off,
+    );
 
     //     exp_test_module!(
     //         ibig,

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1667,4 +1667,24 @@ mod tests {
         assert!(eq_ab);
         assert!(!eq_ac);
     }
+    #[test]
+    fn heapless_field_roundtrip() {
+        // The coverage that was missing: a full Field round-trip on a carrier
+        // whose size_of != value width AND whose field is narrower than CAP
+        // (len 2 in an 8-word carrier). Catches both the type_bit_width proxy
+        // (precompute R width) and the CarryingMul CAP-split (wide-REDC hi/lo).
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u32, 2, const_num_traits::Nct>;
+        let modulus = H::from_limbs([7u32, 1], 2); // 2^32 + 7, odd, fills CAP=2
+        let w = |v: u32| H::from_limbs([v, 0], 2);
+        let f: Field<H> = Field::new(modulus).unwrap();
+        for raw in [3u32, 5, 200, 255, 1_000_000] {
+            let r = f.reduce(&w(raw));
+            assert_eq!(f.into_raw(&r), w(raw), "round trip {raw}");
+        }
+        // 3 * 5 = 15 < modulus, so the raw product is exactly 15.
+        let a = f.reduce(&w(3));
+        let b = f.reduce(&w(5));
+        assert_eq!(f.into_raw(&f.mul(&a, &b)), w(15));
+    }
 }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -756,8 +756,9 @@ where
 
     /// Modular exponentiation — constant-time over `exp`.
     ///
-    /// Implements a fixed-iteration Montgomery ladder over all
-    /// `bit_length(T)` bits of the exponent. Both square and multiply are
+    /// Implements a fixed-iteration Montgomery ladder over the exponent's
+    /// declared width (`exp.bits_precision()` — a public shape, independent of
+    /// the secret value). Both square and multiply are
     /// performed every iteration; the result is selected branchlessly. Loop
     /// count does not depend on `exp`; per-iteration timing does not depend
     /// on the bit pattern.
@@ -907,16 +908,16 @@ where
     /// iteration CT Montgomery ladder.
     ///
     /// **Requires `modulus` to be prime.** Constant-time over `a`'s
-    /// bits and zero-ness via the fixed `T::BITS`-iteration Montgomery
-    /// ladder in [`Self::exp`]. The loop count depends only on the
-    /// carrier type's bit width, not on `modulus - 2`'s significant
-    /// bit count or `a`'s value. Returns `CtOption::None`-masked for
-    /// the zero residue.
+    /// bits and zero-ness via the fixed-iteration Montgomery ladder in
+    /// [`Self::exp`]. The loop count is the exponent's declared width
+    /// (`(modulus - 2).bits_precision()`, a public shape), not
+    /// `modulus - 2`'s significant bit count or `a`'s value. Returns
+    /// `CtOption::None`-masked for the zero residue.
     ///
-    /// Cost: one full ladder over every bit of `T` (e.g. 256
-    /// square-and-multiply iterations for a 256-bit carrier over a
-    /// Curve25519 scalar field), regardless of whether `modulus - 2`
-    /// occupies the full carrier width. For composite moduli (RSA
+    /// Cost: one full ladder over the exponent's declared width (e.g.
+    /// 256 square-and-multiply iterations for a 256-bit field over a
+    /// Curve25519 scalar field), regardless of whether `modulus - 2`'s
+    /// significant bits fill that width. For composite moduli (RSA
     /// `n = p·q`) where Fermat doesn't apply, use
     /// [`Self::inv_safegcd_ct`] instead.
     pub fn inv_fermat(&self, a: &Residue<'_, T, Ct>) -> subtle::CtOption<Residue<'_, T, Ct>>

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -784,12 +784,14 @@ where
 
     /// Modular exponentiation — constant-time over `exp`.
     ///
-    /// Implements a fixed-iteration Montgomery ladder over the exponent's
-    /// declared width (`exp.bits_precision()` — a public shape, independent of
-    /// the secret value). Both square and multiply are
-    /// performed every iteration; the result is selected branchlessly. Loop
-    /// count does not depend on `exp`; per-iteration timing does not depend
-    /// on the bit pattern.
+    /// Implements a fixed-iteration Montgomery ladder over
+    /// `max(exp.bits_precision(), modulus.bits_precision())` bits — at least the
+    /// modulus width, both public shapes. The modulus floor matters on a
+    /// runtime-width carrier (`HeaplessBigInt`), where a value's `bits_precision`
+    /// tracks its length: without it a narrow secret exponent would shorten the
+    /// loop and leak its magnitude. Both square and multiply run every iteration
+    /// and the result is selected branchlessly, so the loop count and
+    /// per-iteration timing depend only on public widths, not the secret value.
     pub fn exp(&self, base: &Residue<'_, T, Ct>, exp: &T) -> Residue<'_, T, Ct>
     where
         T: CiosMontMulCt
@@ -799,7 +801,9 @@ where
             + core::ops::BitAnd<Output = T>
             + const_num_traits::BitsPrecision,
     {
-        let w = (*exp).bits_precision() as usize;
+        // Floor at the modulus width so a narrow secret exponent on a
+        // runtime-width carrier can't shorten the loop (a timing leak).
+        let w = ((*exp).bits_precision()).max(self.modulus.bits_precision()) as usize;
         let one = T::one();
         let mut result = self.r_mod_n;
 

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -344,7 +344,11 @@ where
     /// The additive identity (0 in Montgomery form is 0).
     pub fn zero(&self) -> Residue<'_, T, P> {
         Residue {
-            mont: T::zero(),
+            // Seed at the ring width (`one()` is already `r_mod_n`, ring-width):
+            // a minimal-width `T::zero()` would be a narrow residue, which a
+            // width-sensitive op (e.g. CIOS mul) could misread on a runtime-width
+            // carrier — the seed hazard this surface exists to preclude.
+            mont: T::zero_with_precision_of(&self.modulus),
             _brand: PhantomData,
             _p: PhantomData,
         }
@@ -1056,18 +1060,21 @@ pub trait FieldOps {
     /// The exponent is a **magnitude** (consumed as bits by square-and-multiply),
     /// so it stays a raw `Backend`, not a residue.
     fn exp<'f>(&'f self, base: &Self::Residue<'f>, e: &Self::Backend) -> Self::Residue<'f>;
-    /// Modular inverse, strategy-neutral: Montgomery backends compute it by
-    /// Fermat (`a^(m−2)`), schoolbook by extended Euclid — the trait names the
-    /// operation, not either algorithm.
+    /// General modular inverse — correct for any modulus, prime or composite.
+    /// Every backend uses a general algorithm (extended Euclid on Nct, safegcd
+    /// on Ct); the prime-only Fermat fast path is *not* used here (it would
+    /// return a wrong value for composite moduli). Callers that know the modulus
+    /// is prime and want the Fermat ladder use the inherent
+    /// [`Field::inv_fermat`].
     ///
     /// **CT contract.** The returned *value* is computed under the backend's
     /// personality (constant-time on a `Ct` backend). The `Option` itself is
     /// **not** constant-time: `None` is observable and means the operand is
-    /// non-invertible, i.e. `≡ 0` (or shares a factor with a composite modulus)
-    /// — a negligible-probability event callers already handle by resampling
-    /// (e.g. an ECDSA nonce). A caller that must not branch even on that bit
-    /// uses the inherent [`Field::inv_fermat`] on a `Ct` field, which returns a
-    /// masked [`subtle::CtOption`] and never collapses the existence flag.
+    /// non-invertible (`≡ 0`, or shares a factor with a composite modulus) — a
+    /// negligible-probability event callers already handle by resampling (e.g.
+    /// an ECDSA nonce). A caller that must not branch even on that bit uses the
+    /// inherent `Ct` inverse ([`Field::inv_safegcd_ct`]), which returns a masked
+    /// [`subtle::CtOption`] and never collapses the existence flag.
     fn inv<'f>(&'f self, a: &Self::Residue<'f>) -> Option<Self::Residue<'f>>;
     fn one(&self) -> Self::Residue<'_>;
     fn zero(&self) -> Self::Residue<'_>;
@@ -1135,7 +1142,11 @@ where
         self.0.exp(base, e)
     }
     fn inv<'f>(&'f self, a: &Residue<'f, T, Nct>) -> Option<Residue<'f, T, Nct>> {
-        self.0.inv_fermat(a)
+        // Extended Euclid, not Fermat: `inv` is a general modular inverse, so it
+        // must be correct for composite moduli too (Fermat's `a^(m-2)` is only
+        // valid for prime `m`). The inherent `Field::inv_fermat` keeps the
+        // prime-only fast path for callers that know the modulus is prime.
+        self.0.inv_eea(a)
     }
     fn one(&self) -> Residue<'_, T, Nct> {
         self.0.one()
@@ -1173,7 +1184,10 @@ where
         + core::ops::BitAnd<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
-        + const_num_traits::WrappingSub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>
+        // `inv` routes to `inv_safegcd_ct` (composite-correct CT inverse).
+        + core::ops::BitOr<Output = T>,
+    <T as modmath_cios::CiosRowOps>::Word: const_num_traits::CtParity,
 {
     type Backend = T;
     type Residue<'f>
@@ -1197,10 +1211,12 @@ where
         self.0.exp(base, e)
     }
     fn inv<'f>(&'f self, a: &Residue<'f, T, Ct>) -> Option<Residue<'f, T, Ct>> {
-        // Collapses the CtOption existence bit (operand ≡ 0) per the trait's CT
-        // contract; the inverse value itself stays constant-time. Callers who
-        // must not branch on existence use the inherent `Field::inv_fermat`.
-        self.0.inv_fermat(a).into_option()
+        // safegcd, not Fermat: `inv` is a general modular inverse (correct for
+        // composite moduli), and safegcd is the CT general inverse. Collapses the
+        // CtOption existence bit (operand non-invertible) per the trait's CT
+        // contract; the inverse value stays constant-time. Callers who must not
+        // branch on existence use the inherent `Field::inv_safegcd_ct`.
+        self.0.inv_safegcd_ct(a).into_option()
     }
     fn one(&self) -> Residue<'_, T, Ct> {
         self.0.one()
@@ -1336,7 +1352,13 @@ where
         self.wrap(crate::sub::basic_mod_sub_pr(a.val, b.val, self.modulus))
     }
     fn exp<'f>(&'f self, base: &SchoolbookResidue<'f, T>, e: &T) -> SchoolbookResidue<'f, T> {
-        self.wrap(crate::exp::basic_mod_exp_pr(base.val, *e, self.modulus))
+        // Re-establish ring width: `basic_mod_exp_pr` returns a minimal-width
+        // `T::one()` for exponent 0 (loop skipped), which would be a narrow
+        // residue on a runtime-width carrier.
+        self.wrap(
+            crate::exp::basic_mod_exp_pr(base.val, *e, self.modulus)
+                .widen_to_precision_of(&self.modulus),
+        )
     }
     fn inv<'f>(&'f self, a: &SchoolbookResidue<'f, T>) -> Option<SchoolbookResidue<'f, T>> {
         // Extended Euclid, not Fermat — the strategy-neutral `inv` names the op.
@@ -2311,6 +2333,40 @@ mod tests {
         // via the FieldFor selector
         check(&<NctF as FieldFor>::field(NctF::from(13u8)).unwrap());
         check(&<CtF as FieldFor>::field(CtF::from(13u8)).unwrap());
+    }
+
+    // `FieldOps::inv` is a general modular inverse, so it must be correct on a
+    // composite (odd) modulus too. The Montgomery backends route to EEA (Nct) /
+    // safegcd (Ct), not Fermat — Fermat's `2^(15-2) mod 15 = 2` is wrong;
+    // `2 * 8 ≡ 1 (mod 15)`. Schoolbook (EEA) is the oracle.
+    #[test]
+    fn fieldops_inv_composite_modulus_agrees() {
+        type NctF = FixedUInt<u8, 4>;
+        type CtF = FixedUInt<u8, 4, Ct>;
+
+        let nct = FieldView(Field::<NctF>::new(NctF::from(15u8)).unwrap());
+        let a = nct.reduce(&NctF::from(2u8));
+        let inv = nct.inv(&a).expect("2 invertible mod 15");
+        assert_eq!(
+            nct.into_raw(&nct.mul(&a, &inv)),
+            NctF::from(1u8),
+            "Nct a·inv"
+        );
+        assert_eq!(nct.into_raw(&inv), NctF::from(8u8), "Nct inv(2 mod 15)");
+
+        let ct = FieldView(Field::<CtF, Ct>::new(CtF::from(15u8)).unwrap());
+        let a = ct.reduce(&CtF::from(2u8));
+        let inv = ct.inv(&a).expect("2 invertible mod 15");
+        assert_eq!(ct.into_raw(&ct.mul(&a, &inv)), CtF::from(1u8), "Ct a·inv");
+        assert_eq!(ct.into_raw(&inv), CtF::from(8u8), "Ct inv(2 mod 15)");
+
+        let sb = SchoolbookField::new(NctF::from(15u8)).unwrap();
+        let sa = sb.reduce(&NctF::from(2u8));
+        assert_eq!(
+            sb.into_raw(&sb.inv(&sa).expect("2 invertible mod 15")),
+            NctF::from(8u8),
+            "schoolbook inv(2 mod 15)"
+        );
     }
 
     // Multi-word modulus (len 8) held sub-CAP (CAP 16): the ed25519 field

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1216,7 +1216,11 @@ where
         + const_num_traits::WithPrecision
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
-        + const_num_traits::WrappingSub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>
+        // `Field::new` (below) is bounded on `MontStorage`, which is `zeroize`-gated
+        // to require `Zeroize`. Without this the blanket is vacuous with `zeroize`
+        // off but unsatisfiable with it on — every real consumer sets `zeroize`.
+        + MontStorage,
     FieldView<T, <T as const_num_traits::HasPersonality>::P>: FieldOps<Backend = T>,
 {
     type Field = FieldView<T, <T as const_num_traits::HasPersonality>::P>;

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1744,4 +1744,29 @@ mod tests {
             );
         }
     }
+
+    // CT safegcd inverse where the modulus FILLS the carrier (top bit set):
+    // the full-CAP RSA deployment shape (2048-bit N in a 2048-bit carrier),
+    // scaled to a 128-bit carrier. Guards the se_shr1 top-bit mask — it must
+    // sit at the modulus's top bit, not the low word's. A narrow mask masks
+    // every coprime inverse to None at multi-word widths (invisible to the
+    // single-word inv tests).
+    #[test]
+    fn heapless_inv_safegcd_ct_full_cap_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u32, 4, Ct>; // 128-bit carrier, modulus fills it
+        let modulus = H::from_limbs([0x1234_5679, 0x1357_9bdf, 0x2468_ace0, 0x8000_0001], 4);
+        let f = FieldCt::new(modulus).unwrap();
+        // Powers of two are coprime to any odd modulus; the inverse must exist.
+        for v in [2u8, 4, 8, 16, 32] {
+            let r = f.reduce(&H::from(v));
+            let inv = f.inv_safegcd_ct(&r);
+            assert_eq!(inv.is_some().unwrap_u8(), 1, "expected inverse for {v}");
+            assert_eq!(
+                f.into_raw(&f.mul(&r, &inv.unwrap())),
+                H::from(1u8),
+                "{v} * inv != 1 in full-cap field"
+            );
+        }
+    }
 }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1225,6 +1225,119 @@ where
     }
 }
 
+// ── [D] Phase 1: schoolbook reduction strategy under `FieldOps` ─────────────
+//
+// The Montgomery `Field` is one reduction strategy; `SchoolbookField` is the
+// other, exposed through the *same* `FieldOps` surface so verify code is
+// strategy-agnostic. Its residue carries ring-width by construction: `reduce`,
+// `zero`, `one` seed at the modulus width, and the pre-reduced `_pr` ops
+// preserve it. Schoolbook is variable-time (the `>= m` branch), so it is
+// Nct-only — the Ct strategy is always Montgomery.
+
+/// A plain (non-Montgomery) residue in `[0, m)`, carried at the ring width.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SchoolbookResidue<'f, T> {
+    val: T,
+    _brand: core::marker::PhantomData<&'f ()>,
+}
+
+/// Schoolbook (double-and-add / peasant) modular arithmetic as a `FieldOps`
+/// strategy. `Copy` carriers only (the `basic` flavor); the modulus is stored
+/// at its own (ring) width.
+#[derive(Clone, Debug)]
+pub struct SchoolbookField<T> {
+    modulus: T,
+}
+
+impl<T> SchoolbookField<T> {
+    /// Build a schoolbook field over `modulus`. Rejects `modulus < 2`.
+    pub fn new(modulus: T) -> Option<Self>
+    where
+        T: const_num_traits::One + PartialOrd,
+    {
+        (modulus > T::one()).then_some(SchoolbookField { modulus })
+    }
+
+    fn wrap<'f>(&self, val: T) -> SchoolbookResidue<'f, T> {
+        SchoolbookResidue {
+            val,
+            _brand: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> FieldOps for SchoolbookField<T>
+where
+    T: Copy
+        + const_num_traits::Zero
+        + const_num_traits::One
+        + PartialEq
+        + PartialOrd
+        + crate::parity::Parity
+        + crate::NonCt
+        + const_num_traits::WithPrecision
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
+        + core::ops::Rem<Output = T>
+        + core::ops::Div<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::ShrAssign<usize>,
+{
+    type Backend = T;
+    type Residue<'f>
+        = SchoolbookResidue<'f, T>
+    where
+        Self: 'f;
+
+    fn reduce<'f>(&'f self, raw: &T) -> SchoolbookResidue<'f, T> {
+        // Enter the ring: reduce, then establish ring width (hedge #3, here).
+        self.wrap((*raw % self.modulus).widen_to_precision_of(&self.modulus))
+    }
+    fn mul<'f>(
+        &'f self,
+        a: &SchoolbookResidue<'f, T>,
+        b: &SchoolbookResidue<'f, T>,
+    ) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::mul::basic_mod_mul_pr(a.val, b.val, self.modulus))
+    }
+    fn add<'f>(
+        &'f self,
+        a: &SchoolbookResidue<'f, T>,
+        b: &SchoolbookResidue<'f, T>,
+    ) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::add::basic_mod_add_pr(a.val, b.val, self.modulus))
+    }
+    fn sub<'f>(
+        &'f self,
+        a: &SchoolbookResidue<'f, T>,
+        b: &SchoolbookResidue<'f, T>,
+    ) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::sub::basic_mod_sub_pr(a.val, b.val, self.modulus))
+    }
+    fn exp<'f>(&'f self, base: &SchoolbookResidue<'f, T>, e: &T) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::exp::basic_mod_exp_pr(base.val, *e, self.modulus))
+    }
+    fn inv_fermat<'f>(&'f self, a: &SchoolbookResidue<'f, T>) -> Option<SchoolbookResidue<'f, T>> {
+        crate::inv::basic_mod_inv(a.val, self.modulus)
+            .map(|v| self.wrap(v.widen_to_precision_of(&self.modulus)))
+    }
+    fn one(&self) -> SchoolbookResidue<'_, T> {
+        self.wrap(T::one_with_precision_of(&self.modulus))
+    }
+    fn zero(&self) -> SchoolbookResidue<'_, T> {
+        self.wrap(T::zero_with_precision_of(&self.modulus))
+    }
+    fn into_raw(&self, a: &SchoolbookResidue<'_, T>) -> T {
+        a.val
+    }
+    fn modulus(&self) -> &T {
+        &self.modulus
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2117,6 +2230,33 @@ mod tests {
                 f.inv_safegcd_ct(&r).is_some().unwrap_u8(),
                 0,
                 "expected None for non-coprime {raw} mod 65535"
+            );
+        }
+    }
+
+    // Phase 1 [D]: schoolbook runs through the same `FieldOps` surface as
+    // Montgomery, and the two strategies agree.
+    #[test]
+    fn schoolbook_strategy_via_fieldops() {
+        type U = FixedUInt<u8, 4>;
+        let sb = SchoolbookField::new(U::from(13u8)).unwrap();
+        let a = sb.reduce(&U::from(3u8));
+        let b = sb.reduce(&U::from(5u8));
+        assert_eq!(sb.into_raw(&sb.mul(&a, &b)), U::from(2u8)); // 15 % 13
+        assert_eq!(sb.into_raw(&sb.add(&a, &b)), U::from(8u8));
+        assert_eq!(sb.into_raw(&sb.sub(&b, &a)), U::from(2u8));
+        assert_eq!(sb.into_raw(&sb.exp(&a, &U::from(3u8))), U::from(1u8)); // 27 % 13
+        let inv = sb.inv_fermat(&a).expect("3 invertible mod 13");
+        assert_eq!(sb.into_raw(&sb.mul(&a, &inv)), U::from(1u8));
+        // schoolbook and Montgomery agree, both through FieldOps
+        let mont = FieldView(Field::<U>::new(U::from(13u8)).unwrap());
+        for x in [1u8, 2, 7, 11, 12] {
+            let rs = sb.reduce(&U::from(x));
+            let rm = mont.reduce(&U::from(x));
+            assert_eq!(
+                sb.into_raw(&sb.mul(&rs, &rs)),
+                mont.into_raw(&mont.mul(&rm, &rm)),
+                "sq({x})"
             );
         }
     }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1745,6 +1745,124 @@ mod tests {
         }
     }
 
+    // Multi-word modulus (len 8) held sub-CAP (CAP 16): the ed25519 field
+    // (p = 2^255-19) / group-order shape krabitls deploys for Nct verify.
+    // The prior sub-CAP guard used a len-1 modulus; this exercises a multi-
+    // word modulus with full-width operands, where a capacity leak would
+    // diverge from the CAP==len carrier. Both carriers are HeaplessBigInt so
+    // any CAP-dependent arithmetic (not value-dependent) shows up as a diff.
+    #[test]
+    fn heapless_subcap_multiword_modulus_parity() {
+        use fixed_bigint::HeaplessBigInt;
+        use modmath_cios::CiosRowOps as _;
+        const P: [u32; 8] = [
+            0xFFFF_FFED,
+            0xFFFF_FFFF,
+            0xFFFF_FFFF,
+            0xFFFF_FFFF,
+            0xFFFF_FFFF,
+            0xFFFF_FFFF,
+            0xFFFF_FFFF,
+            0x7FFF_FFFF,
+        ];
+        const A: [u32; 8] = [
+            0x1234_5678,
+            0x9abc_def0,
+            0x0f1e_2d3c,
+            0x4b5a_6978,
+            0x1122_3344,
+            0x5566_7788,
+            0x99aa_bbcc,
+            0x1357_9bdf,
+        ];
+        const B: [u32; 8] = [
+            0xdead_beef,
+            0xcafe_babe,
+            0xfeed_face,
+            0x0bad_c0de,
+            0x8899_aabb,
+            0xccdd_eeff,
+            0x0011_2233,
+            0x2468_ace0,
+        ];
+        type Full = HeaplessBigInt<u32, 8>; // CAP == len
+        type Sub = HeaplessBigInt<u32, 16>; // CAP > len (deployment carrier)
+        let mfull = Full::from_limbs(P, 8);
+        let mut p16 = [0u32; 16];
+        p16[..8].copy_from_slice(&P);
+        let msub = Sub::from_limbs(p16, 8);
+        let full = |a: [u32; 8]| Full::from_limbs(a, 8);
+        let sub = |a: [u32; 8]| {
+            let mut w = [0u32; 16];
+            w[..8].copy_from_slice(&a);
+            Sub::from_limbs(w, 8)
+        };
+        let eq = |a: &Full, b: &Sub| (0..8).all(|i| a.word(i) == b.word(i));
+        let eqo = |a: &Option<Full>, b: &Option<Sub>| match (a, b) {
+            (Some(x), Some(y)) => eq(x, y),
+            (None, None) => true,
+            _ => false,
+        };
+        assert!(
+            eq(
+                &crate::basic::add(full(A), full(B), mfull),
+                &crate::basic::add(sub(A), sub(B), msub)
+            ),
+            "add"
+        );
+        assert!(
+            eq(
+                &crate::basic::sub(full(A), full(B), mfull),
+                &crate::basic::sub(sub(A), sub(B), msub)
+            ),
+            "sub"
+        );
+        assert!(
+            eq(
+                &crate::basic::mul(full(A), full(B), mfull),
+                &crate::basic::mul(sub(A), sub(B), msub)
+            ),
+            "mul"
+        );
+        assert!(
+            eq(
+                &crate::basic::exp(full(A), full(B), mfull),
+                &crate::basic::exp(sub(A), sub(B), msub)
+            ),
+            "exp"
+        );
+        assert!(
+            eqo(
+                &crate::inv::basic_mod_inv(full(A), mfull),
+                &crate::inv::basic_mod_inv(sub(A), msub)
+            ),
+            "basic_inv"
+        );
+        assert!(
+            eqo(
+                &crate::inv::strict_mod_inv(full(A), &mfull),
+                &crate::inv::strict_mod_inv(sub(A), &msub)
+            ),
+            "strict_inv"
+        );
+        let ff: Field<Full> = Field::new(mfull).unwrap();
+        let fs: Field<Sub> = Field::new(msub).unwrap();
+        assert!(
+            eq(
+                &ff.into_raw(&ff.mul(&ff.reduce(&full(A)), &ff.reduce(&full(B)))),
+                &fs.into_raw(&fs.mul(&fs.reduce(&sub(A)), &fs.reduce(&sub(B)))),
+            ),
+            "montgomery mul"
+        );
+        assert!(
+            eq(
+                &ff.into_raw(&ff.exp(&ff.reduce(&full(A)), &full(B))),
+                &fs.into_raw(&fs.exp(&fs.reduce(&sub(A)), &sub(B))),
+            ),
+            "montgomery exp"
+        );
+    }
+
     // CT safegcd inverse where the modulus FILLS the carrier (top bit set):
     // the full-CAP RSA deployment shape (2048-bit N in a 2048-bit carrier),
     // scaled to a 128-bit carrier. Guards the se_shr1 top-bit mask — it must

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -371,7 +371,11 @@ where
     /// `mont == x * R mod modulus`.
     pub fn residue_from_mont(&self, mont: T) -> Residue<'_, T, P> {
         Residue {
-            mont,
+            // Establish ring width even on this escape hatch: a narrow `mont`
+            // (e.g. `T::zero()`) would otherwise be a narrow residue a
+            // width-sensitive op could misread, breaking the surface's no-narrow
+            // -residue guarantee.
+            mont: mont.widen_to_precision_of(&self.modulus),
             _brand: PhantomData,
             _p: PhantomData,
         }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1668,12 +1668,12 @@ mod tests {
         assert!(eq_ab);
         assert!(!eq_ac);
     }
+    // Full Field round-trip on HeaplessBigInt at CAP == len (modulus fills the
+    // carrier). Catches the type_bit_width proxy (precompute R width) and the
+    // CarryingMul value-width split — the full-CAP config ed25519 / 2048-bit RSA
+    // use. Passes as of modmath's bits_precision fix + fixed-bigint alpha.17.
     #[test]
     fn heapless_field_roundtrip() {
-        // The coverage that was missing: a full Field round-trip on a carrier
-        // whose size_of != value width AND whose field is narrower than CAP
-        // (len 2 in an 8-word carrier). Catches both the type_bit_width proxy
-        // (precompute R width) and the CarryingMul CAP-split (wide-REDC hi/lo).
         use fixed_bigint::HeaplessBigInt;
         type H = HeaplessBigInt<u32, 2, const_num_traits::Nct>;
         let modulus = H::from_limbs([7u32, 1], 2); // 2^32 + 7, odd, fills CAP=2
@@ -1683,9 +1683,39 @@ mod tests {
             let r = f.reduce(&w(raw));
             assert_eq!(f.into_raw(&r), w(raw), "round trip {raw}");
         }
-        // 3 * 5 = 15 < modulus, so the raw product is exactly 15.
         let a = f.reduce(&w(3));
         let b = f.reduce(&w(5));
-        assert_eq!(f.into_raw(&f.mul(&a, &b)), w(15));
+        assert_eq!(f.into_raw(&f.mul(&a, &b)), w(15)); // 3*5=15 < modulus
+    }
+
+    // Shift-left coverage: the SUB-CAP config (len < CAP) that leaked all the way
+    // to ed25519/rsa. A modulus narrower than the carrier makes the field width
+    // (`bits_precision` = len*word) smaller than storage, so the wide-REDC
+    // precompute (`compute_n_prime_newton` etc.) needs value-width wrapping
+    // arithmetic. It currently fails because HeaplessBigInt's wrapping_add/sub/mul
+    // GROW the result length instead of wrapping at value width, so the Newton
+    // loop computes n_prime at the wrong (growing) width. Repro:
+    // `reduce(4).into_raw()` yields 14, must be 4; `mont(4)^2` yields 13, want 16.
+    //
+    // Ignored until fixed-bigint ships value-width (non-growing) wrapping ops;
+    // this is the acceptance for that fix. Un-`ignore` when it lands — then CI
+    // catches any regression here instead of two crates downstream.
+    #[test]
+    #[ignore = "acceptance for fixed-bigint value-width wrapping-op fix (sub-CAP HeaplessBigInt)"]
+    fn heapless_field_roundtrip_subcap() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 8, const_num_traits::Nct>; // modulus 35 -> len 1 < CAP 8
+        let f: Field<H> = Field::new(H::from(35u8)).unwrap();
+        // reduce/into_raw is the identity.
+        for raw in [0u8, 1, 4, 17, 34] {
+            assert_eq!(
+                f.into_raw(&f.reduce(&H::from(raw))),
+                H::from(raw),
+                "round trip {raw}"
+            );
+        }
+        // 4 * 4 = 16 mod 35.
+        let a = f.reduce(&H::from(4u8));
+        assert_eq!(f.into_raw(&f.mul(&a, &a)), H::from(16u8));
     }
 }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1713,4 +1713,35 @@ mod tests {
         let a = f.reduce(&H::from(4u8));
         assert_eq!(f.into_raw(&f.mul(&a, &a)), H::from(16u8));
     }
+
+    // CT safegcd inverse on a runtime-width carrier where the residue is
+    // narrower than the modulus (small blinding factor in a wide RSA field).
+    // The divstep count and shift mask must track the modulus width; a value-
+    // width count silently masks valid inverses to None. Scaled-down proxy for
+    // the 2048-bit RSA-blinding inverse; composite modulus, since Fermat can't
+    // invert mod p·q.
+    #[test]
+    fn heapless_inv_safegcd_ct_narrow_value_wide_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 8, Ct>; // modulus fills 2 words, operands 1
+        let f = FieldCt::new(65535u16.into()).unwrap(); // 3·5·17·257
+        for raw in [2u8, 4, 7, 8, 11] {
+            let r = f.reduce(&H::from(raw));
+            let inv = f.inv_safegcd_ct(&r);
+            assert_eq!(inv.is_some().unwrap_u8(), 1, "expected inverse for {raw}");
+            assert_eq!(
+                f.into_raw(&f.mul(&r, &inv.unwrap())),
+                H::from(1u8),
+                "{raw} * inv != 1 mod 65535"
+            );
+        }
+        for raw in [3u8, 5, 15, 17] {
+            let r = f.reduce(&H::from(raw));
+            assert_eq!(
+                f.inv_safegcd_ct(&r).is_some().unwrap_u8(),
+                0,
+                "expected None for non-coprime {raw} mod 65535"
+            );
+        }
+    }
 }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -217,7 +217,8 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + MontStorage,
+        + MontStorage
+        + const_num_traits::WithPrecision,
 {
     /// Construct a new `Field` from an already-proven-odd modulus.
     ///
@@ -373,7 +374,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + Parity
         + crate::NonCt
-        + MontStorage,
+        + MontStorage
+        + const_num_traits::WithPrecision,
 {
     /// Convert a raw value `< modulus` (or arbitrary value, which is then
     /// reduced) to Montgomery form. Returns a brand-tagged [`Residue`].
@@ -614,7 +616,8 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + MontStorage,
+        + MontStorage
+        + const_num_traits::WithPrecision,
 {
     /// Construct a `Field<T, Ct>` from a **secret** modulus without a
     /// value-dependent branch on the parity check.

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1688,20 +1688,15 @@ mod tests {
         assert_eq!(f.into_raw(&f.mul(&a, &b)), w(15)); // 3*5=15 < modulus
     }
 
-    // Shift-left coverage: the SUB-CAP config (len < CAP) that leaked all the way
-    // to ed25519/rsa. A modulus narrower than the carrier makes the field width
-    // (`bits_precision` = len*word) smaller than storage, so the wide-REDC
-    // precompute (`compute_n_prime_newton` etc.) needs value-width wrapping
-    // arithmetic. It currently fails because HeaplessBigInt's wrapping_add/sub/mul
-    // GROW the result length instead of wrapping at value width, so the Newton
-    // loop computes n_prime at the wrong (growing) width. Repro:
-    // `reduce(4).into_raw()` yields 14, must be 4; `mont(4)^2` yields 13, want 16.
-    //
-    // Ignored until fixed-bigint ships value-width (non-growing) wrapping ops;
-    // this is the acceptance for that fix. Un-`ignore` when it lands — then CI
-    // catches any regression here instead of two crates downstream.
+    // Shift-left guard: the SUB-CAP config (len < CAP) that leaked all the way to
+    // ed25519/rsa. A modulus narrower than the carrier makes the field width
+    // (`bits_precision` = len*word) smaller than storage, so the whole wide-REDC
+    // precompute runs at value width on unused-capacity operands. Passes because
+    // HeaplessBigInt@len behaves bit-for-bit like FixedUInt<len> (fixed-bigint
+    // alpha.20) — this test exercises that with NO modmath accommodation. If a
+    // future carrier change reintroduces capacity-dependent arithmetic, it fails
+    // here, in modmath's CI, not two crates downstream.
     #[test]
-    #[ignore = "acceptance for fixed-bigint value-width wrapping-op fix (sub-CAP HeaplessBigInt)"]
     fn heapless_field_roundtrip_subcap() {
         use fixed_bigint::HeaplessBigInt;
         type H = HeaplessBigInt<u8, 8, const_num_traits::Nct>; // modulus 35 -> len 1 < CAP 8

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -344,10 +344,9 @@ where
     /// The additive identity (0 in Montgomery form is 0).
     pub fn zero(&self) -> Residue<'_, T, P> {
         Residue {
-            // Seed at the ring width (`one()` is already `r_mod_n`, ring-width):
-            // a minimal-width `T::zero()` would be a narrow residue, which a
-            // width-sensitive op (e.g. CIOS mul) could misread on a runtime-width
-            // carrier — the seed hazard this surface exists to preclude.
+            // Ring width, not minimal `T::zero()`: a narrow residue would misfire
+            // a width-sensitive op (CIOS mul) on a runtime-width carrier. (`one()`
+            // is already `r_mod_n`.)
             mont: T::zero_with_precision_of(&self.modulus),
             _brand: PhantomData,
             _p: PhantomData,
@@ -1142,10 +1141,8 @@ where
         self.0.exp(base, e)
     }
     fn inv<'f>(&'f self, a: &Residue<'f, T, Nct>) -> Option<Residue<'f, T, Nct>> {
-        // Extended Euclid, not Fermat: `inv` is a general modular inverse, so it
-        // must be correct for composite moduli too (Fermat's `a^(m-2)` is only
-        // valid for prime `m`). The inherent `Field::inv_fermat` keeps the
-        // prime-only fast path for callers that know the modulus is prime.
+        // EEA, not Fermat: `inv` is a general (composite-correct) inverse; the
+        // prime-only Fermat fast path stays the inherent `Field::inv_fermat`.
         self.0.inv_eea(a)
     }
     fn one(&self) -> Residue<'_, T, Nct> {
@@ -1211,11 +1208,10 @@ where
         self.0.exp(base, e)
     }
     fn inv<'f>(&'f self, a: &Residue<'f, T, Ct>) -> Option<Residue<'f, T, Ct>> {
-        // safegcd, not Fermat: `inv` is a general modular inverse (correct for
-        // composite moduli), and safegcd is the CT general inverse. Collapses the
-        // CtOption existence bit (operand non-invertible) per the trait's CT
-        // contract; the inverse value stays constant-time. Callers who must not
-        // branch on existence use the inherent `Field::inv_safegcd_ct`.
+        // safegcd, not Fermat: the CT general (composite-correct) inverse.
+        // Collapses the CtOption existence bit per the trait's CT contract
+        // (value stays CT); callers needing the masked bit use the inherent
+        // `Field::inv_safegcd_ct`.
         self.0.inv_safegcd_ct(a).into_option()
     }
     fn one(&self) -> Residue<'_, T, Ct> {

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1056,7 +1056,19 @@ pub trait FieldOps {
     /// The exponent is a **magnitude** (consumed as bits by square-and-multiply),
     /// so it stays a raw `Backend`, not a residue.
     fn exp<'f>(&'f self, base: &Self::Residue<'f>, e: &Self::Backend) -> Self::Residue<'f>;
-    fn inv_fermat<'f>(&'f self, a: &Self::Residue<'f>) -> Option<Self::Residue<'f>>;
+    /// Modular inverse, strategy-neutral: Montgomery backends compute it by
+    /// Fermat (`a^(m−2)`), schoolbook by extended Euclid — the trait names the
+    /// operation, not either algorithm.
+    ///
+    /// **CT contract.** The returned *value* is computed under the backend's
+    /// personality (constant-time on a `Ct` backend). The `Option` itself is
+    /// **not** constant-time: `None` is observable and means the operand is
+    /// non-invertible, i.e. `≡ 0` (or shares a factor with a composite modulus)
+    /// — a negligible-probability event callers already handle by resampling
+    /// (e.g. an ECDSA nonce). A caller that must not branch even on that bit
+    /// uses the inherent [`Field::inv_fermat`] on a `Ct` field, which returns a
+    /// masked [`subtle::CtOption`] and never collapses the existence flag.
+    fn inv<'f>(&'f self, a: &Self::Residue<'f>) -> Option<Self::Residue<'f>>;
     fn one(&self) -> Self::Residue<'_>;
     fn zero(&self) -> Self::Residue<'_>;
     /// Converts the *residue* out of the field (not `self`), mirroring
@@ -1122,7 +1134,7 @@ where
     fn exp<'f>(&'f self, base: &Residue<'f, T, Nct>, e: &T) -> Residue<'f, T, Nct> {
         self.0.exp(base, e)
     }
-    fn inv_fermat<'f>(&'f self, a: &Residue<'f, T, Nct>) -> Option<Residue<'f, T, Nct>> {
+    fn inv<'f>(&'f self, a: &Residue<'f, T, Nct>) -> Option<Residue<'f, T, Nct>> {
         self.0.inv_fermat(a)
     }
     fn one(&self) -> Residue<'_, T, Nct> {
@@ -1184,8 +1196,10 @@ where
     fn exp<'f>(&'f self, base: &Residue<'f, T, Ct>, e: &T) -> Residue<'f, T, Ct> {
         self.0.exp(base, e)
     }
-    fn inv_fermat<'f>(&'f self, a: &Residue<'f, T, Ct>) -> Option<Residue<'f, T, Ct>> {
-        // Ct field returns CtOption; verify inputs are public, so normalize.
+    fn inv<'f>(&'f self, a: &Residue<'f, T, Ct>) -> Option<Residue<'f, T, Ct>> {
+        // Collapses the CtOption existence bit (operand ≡ 0) per the trait's CT
+        // contract; the inverse value itself stays constant-time. Callers who
+        // must not branch on existence use the inherent `Field::inv_fermat`.
         self.0.inv_fermat(a).into_option()
     }
     fn one(&self) -> Residue<'_, T, Ct> {
@@ -1324,7 +1338,8 @@ where
     fn exp<'f>(&'f self, base: &SchoolbookResidue<'f, T>, e: &T) -> SchoolbookResidue<'f, T> {
         self.wrap(crate::exp::basic_mod_exp_pr(base.val, *e, self.modulus))
     }
-    fn inv_fermat<'f>(&'f self, a: &SchoolbookResidue<'f, T>) -> Option<SchoolbookResidue<'f, T>> {
+    fn inv<'f>(&'f self, a: &SchoolbookResidue<'f, T>) -> Option<SchoolbookResidue<'f, T>> {
+        // Extended Euclid, not Fermat — the strategy-neutral `inv` names the op.
         crate::inv::basic_mod_inv(a.val, self.modulus)
             .map(|v| self.wrap(v.widen_to_precision_of(&self.modulus)))
     }
@@ -2250,7 +2265,7 @@ mod tests {
         assert_eq!(sb.into_raw(&sb.add(&a, &b)), U::from(8u8));
         assert_eq!(sb.into_raw(&sb.sub(&b, &a)), U::from(2u8));
         assert_eq!(sb.into_raw(&sb.exp(&a, &U::from(3u8))), U::from(1u8)); // 27 % 13
-        let inv = sb.inv_fermat(&a).expect("3 invertible mod 13");
+        let inv = sb.inv(&a).expect("3 invertible mod 13");
         assert_eq!(sb.into_raw(&sb.mul(&a, &inv)), U::from(1u8));
         // schoolbook and Montgomery agree, both through FieldOps
         let mont = FieldView(Field::<U>::new(U::from(13u8)).unwrap());
@@ -2284,7 +2299,7 @@ mod tests {
                 f.into_raw(&f.exp(&a, &F::Backend::from(3u8))),
                 F::Backend::from(1u8)
             ); // 27 % 13
-            let inv = f.inv_fermat(&a).expect("3 invertible mod 13");
+            let inv = f.inv(&a).expect("3 invertible mod 13");
             assert_eq!(f.into_raw(&f.mul(&a, &inv)), F::Backend::from(1u8));
             assert_eq!(f.modulus(), &F::Backend::from(13u8));
         }

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1034,6 +1034,162 @@ mod tests {
         U16Ct::from(n)
     }
 
+    // Nct `Field`/`Residue` API matrix: reduce/into_raw round-trip, add/sub/mul,
+    // exp, and Fermat inverse (prime modulus), cross-checked against a u64
+    // oracle. Runs the crypto-facing high-level surface across every backend,
+    // which the hand-rolled FixedUInt-alias tests never did.
+    macro_rules! field_test_module {
+        ($stem:ident, $type_path:path, $(type $td:ty = $te:ty;)?) => {
+            paste::paste! {
+                mod [<$stem _field_tests>] {
+                    #[allow(unused_imports)]
+                    use $type_path;
+                    $( type $td = $te; )?
+                    use crate::Field;
+
+                    const M: u64 = 251; // prime, fits u8
+
+                    fn field() -> Field<U256> {
+                        Field::new(U256::from(251u8)).unwrap()
+                    }
+
+                    #[test]
+                    fn reduce_roundtrip() {
+                        let f = field();
+                        for raw in [0u8, 1, 2, 100, 250] {
+                            assert_eq!(
+                                f.into_raw(&f.reduce(&U256::from(raw))),
+                                U256::from(raw),
+                                "roundtrip {raw}"
+                            );
+                        }
+                    }
+
+                    #[test]
+                    fn add_sub_mul() {
+                        let f = field();
+                        for a in [3u8, 100, 250] {
+                            for b in [7u8, 200, 249] {
+                                let ra = f.reduce(&U256::from(a));
+                                let rb = f.reduce(&U256::from(b));
+                                let add = ((a as u64 + b as u64) % M) as u8;
+                                let sub = ((a as u64 + M - b as u64) % M) as u8;
+                                let mul = ((a as u64 * b as u64) % M) as u8;
+                                assert_eq!(f.into_raw(&f.add(&ra, &rb)), U256::from(add), "add {a}+{b}");
+                                assert_eq!(f.into_raw(&f.sub(&ra, &rb)), U256::from(sub), "sub {a}-{b}");
+                                assert_eq!(f.into_raw(&f.mul(&ra, &rb)), U256::from(mul), "mul {a}*{b}");
+                            }
+                        }
+                    }
+
+                    #[test]
+                    fn exp_matches_oracle() {
+                        let f = field();
+                        for base in [2u8, 7, 200] {
+                            for e in [0u8, 1, 5, 17] {
+                                let want = crate::exp::basic_mod_exp(base as u64, e as u64, M) as u8;
+                                let got = f.into_raw(&f.exp(&f.reduce(&U256::from(base)), &U256::from(e)));
+                                assert_eq!(got, U256::from(want), "exp {base}^{e}");
+                            }
+                        }
+                    }
+
+                    #[test]
+                    fn inv_fermat_roundtrip() {
+                        let f = field();
+                        for a in [1u8, 2, 100, 250] {
+                            let ra = f.reduce(&U256::from(a));
+                            let inv = f.inv_fermat(&ra).expect("prime modulus invertible");
+                            assert_eq!(f.into_raw(&f.mul(&ra, &inv)), U256::from(1u8), "inv {a}");
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    field_test_module!(
+        fixed_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::FixedUInt<u8, 4>;
+    );
+
+    field_test_module!(
+        heapless_bigint,
+        fixed_bigint::HeaplessBigInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
+    );
+
+    // bnum / crypto-bigint expose a ready `U256`; the type-path import *is* the
+    // alias, so no `type U256 =`.
+    field_test_module!(bnum_patched, bnum_patched::types::U256,);
+
+    field_test_module!(crypto_bigint_patched, crypto_bigint_patched::U256,);
+
+    // num-bigint (`FixedWidthBigUint`) is intentionally absent: the Montgomery
+    // `Field`/CIOS path is `Copy`-bound (row ops copy limbs), and it is a
+    // heap-allocated non-`Copy` carrier. It rides the schoolbook + free-function
+    // Montgomery matrices instead.
+
+    // Ct `FieldCt` matrix: the constant-time surface (reduce/mul + the
+    // Bernstein-Yang `inv_safegcd_ct` RSA-blinding path), across Ct-personality
+    // carriers. Previously only hand-rolled on FixedUInt/U128 + reactive heapless.
+    macro_rules! field_ct_test_module {
+        ($stem:ident, $type_path:path, $(type $td:ty = $te:ty;)?) => {
+            paste::paste! {
+                mod [<$stem _field_ct_tests>] {
+                    #[allow(unused_imports)]
+                    use $type_path;
+                    $( type $td = $te; )?
+                    use crate::FieldCt;
+
+                    const M: u64 = 251; // prime, fits u8
+
+                    #[test]
+                    fn ct_reduce_mul() {
+                        let f = FieldCt::<U256>::new(U256::from(251u8)).unwrap();
+                        for raw in [0u8, 1, 100, 250] {
+                            assert_eq!(f.into_raw(&f.reduce(&U256::from(raw))), U256::from(raw));
+                        }
+                        for (a, b) in [(7u8, 5u8), (200, 199), (250, 2)] {
+                            let ra = f.reduce(&U256::from(a));
+                            let rb = f.reduce(&U256::from(b));
+                            let mul = ((a as u64 * b as u64) % M) as u8;
+                            assert_eq!(f.into_raw(&f.mul(&ra, &rb)), U256::from(mul), "mul {a}*{b}");
+                        }
+                    }
+
+                    #[test]
+                    fn ct_inv_safegcd_roundtrip() {
+                        let f = FieldCt::<U256>::new(U256::from(251u8)).unwrap();
+                        for a in [1u8, 2, 100, 250] {
+                            let ra = f.reduce(&U256::from(a));
+                            let inv = f.inv_safegcd_ct(&ra);
+                            assert_eq!(inv.is_some().unwrap_u8(), 1, "inv exists {a}");
+                            assert_eq!(
+                                f.into_raw(&f.mul(&ra, &inv.unwrap())),
+                                U256::from(1u8),
+                                "v*inv==1 for {a}"
+                            );
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    field_ct_test_module!(
+        fixed_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::FixedUInt<u8, 4, const_num_traits::Ct>;
+    );
+
+    field_ct_test_module!(
+        heapless_bigint,
+        fixed_bigint::HeaplessBigInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u8, 4, const_num_traits::Ct>;
+    );
+
     #[test]
     fn round_trip_small() {
         let f: Field<U16> = Field::new(u16(13)).unwrap();

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1026,6 +1026,205 @@ where
 // Tests
 // ---------------------------------------------------------------------------
 
+// ── [24]/[D] Phase 0: personality-generic `FieldOps` surface ────────────────
+//
+// `Field<T, P>` splits its arithmetic across two per-personality inherent impls,
+// so code that runs one algorithm over *either* personality has no generic
+// method surface. `FieldOps` provides it. It is impl'd on a `FieldView` wrapper,
+// never directly on `Field` — a direct `impl FieldOps for Field<T, Nct>` makes
+// the forwarding `self.mul(..)` re-dispatch to the trait method (inherent
+// priority does not win when the trait is impl'd on the same type), infinitely
+// recursing. The wrapper's `self.0.mul(..)` targets `Field` (no `FieldOps` on
+// it), so it resolves to the inherent method. Every consumer's hand-rolled
+// verify shim already uses exactly this wrapper shape; this hoists it.
+
+/// Personality-generic view of a Montgomery [`Field`]'s operation surface.
+/// `inv_fermat` normalizes the Ct field's `CtOption` to `Option` (verify inputs
+/// are public, so the branch leaks nothing). The residue carries ring-width as a
+/// type invariant, so a reducer written against this surface cannot inject a
+/// narrow value into a ring computation.
+pub trait FieldOps {
+    type Backend;
+    type Residue<'f>: Clone + PartialEq
+    where
+        Self: 'f;
+
+    fn reduce<'f>(&'f self, raw: &Self::Backend) -> Self::Residue<'f>;
+    fn mul<'f>(&'f self, a: &Self::Residue<'f>, b: &Self::Residue<'f>) -> Self::Residue<'f>;
+    fn add<'f>(&'f self, a: &Self::Residue<'f>, b: &Self::Residue<'f>) -> Self::Residue<'f>;
+    fn sub<'f>(&'f self, a: &Self::Residue<'f>, b: &Self::Residue<'f>) -> Self::Residue<'f>;
+    /// The exponent is a **magnitude** (consumed as bits by square-and-multiply),
+    /// so it stays a raw `Backend`, not a residue.
+    fn exp<'f>(&'f self, base: &Self::Residue<'f>, e: &Self::Backend) -> Self::Residue<'f>;
+    fn inv_fermat<'f>(&'f self, a: &Self::Residue<'f>) -> Option<Self::Residue<'f>>;
+    fn one(&self) -> Self::Residue<'_>;
+    fn zero(&self) -> Self::Residue<'_>;
+    /// Converts the *residue* out of the field (not `self`), mirroring
+    /// [`Field::into_raw`]; the `&self` receiver is the field.
+    #[allow(clippy::wrong_self_convention)]
+    fn into_raw(&self, a: &Self::Residue<'_>) -> Self::Backend;
+    fn modulus(&self) -> &Self::Backend;
+}
+
+/// The `Backend -> Field` selector: given a modulus, build the personality-keyed
+/// field for it. Consumers bound on `T: FieldFor` write verify code once.
+pub trait FieldFor: Sized {
+    type Field: FieldOps<Backend = Self>;
+    fn field(modulus: Self) -> Option<Self::Field>;
+}
+
+/// Wrapper owning a [`Field`], so `FieldOps` is impl'd on *it* (not on `Field`
+/// directly) — the indirection that dodges the trait-shadows-inherent recursion.
+#[derive(Clone, Debug)]
+pub struct FieldView<T, P: Personality>(pub Field<T, P>);
+
+impl<T> FieldOps for FieldView<T, Nct>
+where
+    T: MontStorage
+        + WideMul
+        + CiosMontMul
+        + const_num_traits::HasPersonality<P = Nct>
+        + const_num_traits::One
+        + const_num_traits::Zero
+        + Copy
+        + PartialEq
+        + PartialOrd
+        + crate::parity::Parity
+        + const_num_traits::WithPrecision
+        + core::ops::ShrAssign<usize>
+        + core::ops::Div<Output = T>
+        + core::ops::Sub<Output = T>
+        + const_num_traits::CheckedAdd<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>,
+{
+    type Backend = T;
+    type Residue<'f>
+        = Residue<'f, T, Nct>
+    where
+        Self: 'f;
+
+    fn reduce<'f>(&'f self, raw: &T) -> Residue<'f, T, Nct> {
+        self.0.reduce(raw)
+    }
+    fn mul<'f>(&'f self, a: &Residue<'f, T, Nct>, b: &Residue<'f, T, Nct>) -> Residue<'f, T, Nct> {
+        self.0.mul(a, b)
+    }
+    fn add<'f>(&'f self, a: &Residue<'f, T, Nct>, b: &Residue<'f, T, Nct>) -> Residue<'f, T, Nct> {
+        self.0.add(a, b)
+    }
+    fn sub<'f>(&'f self, a: &Residue<'f, T, Nct>, b: &Residue<'f, T, Nct>) -> Residue<'f, T, Nct> {
+        self.0.sub(a, b)
+    }
+    fn exp<'f>(&'f self, base: &Residue<'f, T, Nct>, e: &T) -> Residue<'f, T, Nct> {
+        self.0.exp(base, e)
+    }
+    fn inv_fermat<'f>(&'f self, a: &Residue<'f, T, Nct>) -> Option<Residue<'f, T, Nct>> {
+        self.0.inv_fermat(a)
+    }
+    fn one(&self) -> Residue<'_, T, Nct> {
+        self.0.one()
+    }
+    fn zero(&self) -> Residue<'_, T, Nct> {
+        self.0.zero()
+    }
+    fn into_raw(&self, a: &Residue<'_, T, Nct>) -> T {
+        self.0.into_raw(a)
+    }
+    fn modulus(&self) -> &T {
+        self.0.modulus()
+    }
+}
+
+impl<T> FieldOps for FieldView<T, Ct>
+where
+    T: MontStorage
+        + WideMul
+        + CiosMontMulCt
+        + const_num_traits::HasPersonality<P = Ct>
+        + const_num_traits::One
+        + const_num_traits::Zero
+        + Copy
+        + PartialEq
+        + PartialOrd
+        + const_num_traits::WithPrecision
+        + const_num_traits::CtIsZero
+        + const_num_traits::BitsPrecision
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeEq
+        + subtle::ConstantTimeLess
+        + core::ops::ShrAssign<usize>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::BitAnd<Output = T>
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>,
+{
+    type Backend = T;
+    type Residue<'f>
+        = Residue<'f, T, Ct>
+    where
+        Self: 'f;
+
+    fn reduce<'f>(&'f self, raw: &T) -> Residue<'f, T, Ct> {
+        self.0.reduce(raw)
+    }
+    fn mul<'f>(&'f self, a: &Residue<'f, T, Ct>, b: &Residue<'f, T, Ct>) -> Residue<'f, T, Ct> {
+        self.0.mul(a, b)
+    }
+    fn add<'f>(&'f self, a: &Residue<'f, T, Ct>, b: &Residue<'f, T, Ct>) -> Residue<'f, T, Ct> {
+        self.0.add(a, b)
+    }
+    fn sub<'f>(&'f self, a: &Residue<'f, T, Ct>, b: &Residue<'f, T, Ct>) -> Residue<'f, T, Ct> {
+        self.0.sub(a, b)
+    }
+    fn exp<'f>(&'f self, base: &Residue<'f, T, Ct>, e: &T) -> Residue<'f, T, Ct> {
+        self.0.exp(base, e)
+    }
+    fn inv_fermat<'f>(&'f self, a: &Residue<'f, T, Ct>) -> Option<Residue<'f, T, Ct>> {
+        // Ct field returns CtOption; verify inputs are public, so normalize.
+        self.0.inv_fermat(a).into_option()
+    }
+    fn one(&self) -> Residue<'_, T, Ct> {
+        self.0.one()
+    }
+    fn zero(&self) -> Residue<'_, T, Ct> {
+        self.0.zero()
+    }
+    fn into_raw(&self, a: &Residue<'_, T, Ct>) -> T {
+        self.0.into_raw(a)
+    }
+    fn modulus(&self) -> &T {
+        self.0.modulus()
+    }
+}
+
+impl<T> FieldFor for T
+where
+    T: const_num_traits::HasPersonality
+        + Copy
+        + PartialEq
+        + PartialOrd
+        + crate::parity::Parity
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::BitsPrecision
+        + const_num_traits::One
+        + const_num_traits::Zero
+        + const_num_traits::WithPrecision
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingMul<Output = T>
+        + const_num_traits::WrappingSub<Output = T>,
+    FieldView<T, <T as const_num_traits::HasPersonality>::P>: FieldOps<Backend = T>,
+{
+    type Field = FieldView<T, <T as const_num_traits::HasPersonality>::P>;
+    fn field(modulus: T) -> Option<Self::Field> {
+        Field::<T, <T as const_num_traits::HasPersonality>::P>::new(modulus).map(FieldView)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1920,6 +2119,39 @@ mod tests {
                 "expected None for non-coprime {raw} mod 65535"
             );
         }
+    }
+
+    // Phase 0 [24]: one generic body over `FieldOps` runs on both personalities,
+    // built directly and via the `FieldFor` selector. This is the surface that
+    // replaces the consumers' hand-rolled per-personality verify shims.
+    #[test]
+    fn fieldops_generic_over_personality() {
+        fn check<F>(f: &F)
+        where
+            F: FieldOps,
+            F::Backend: From<u8> + PartialEq + core::fmt::Debug,
+        {
+            let a = f.reduce(&F::Backend::from(3u8));
+            let b = f.reduce(&F::Backend::from(5u8));
+            assert_eq!(f.into_raw(&f.mul(&a, &b)), F::Backend::from(2u8)); // 15 % 13
+            assert_eq!(f.into_raw(&f.add(&a, &b)), F::Backend::from(8u8)); // 8
+            assert_eq!(f.into_raw(&f.sub(&b, &a)), F::Backend::from(2u8)); // 2
+            assert_eq!(
+                f.into_raw(&f.exp(&a, &F::Backend::from(3u8))),
+                F::Backend::from(1u8)
+            ); // 27 % 13
+            let inv = f.inv_fermat(&a).expect("3 invertible mod 13");
+            assert_eq!(f.into_raw(&f.mul(&a, &inv)), F::Backend::from(1u8));
+            assert_eq!(f.modulus(), &F::Backend::from(13u8));
+        }
+        type NctF = FixedUInt<u8, 4>;
+        type CtF = FixedUInt<u8, 4, Ct>;
+        // direct construction
+        check(&FieldView(Field::<NctF>::new(NctF::from(13u8)).unwrap()));
+        check(&FieldView(Field::<CtF, Ct>::new(CtF::from(13u8)).unwrap()));
+        // via the FieldFor selector
+        check(&<NctF as FieldFor>::field(NctF::from(13u8)).unwrap());
+        check(&<CtF as FieldFor>::field(CtF::from(13u8)).unwrap());
     }
 
     // Multi-word modulus (len 8) held sub-CAP (CAP 16): the ed25519 field

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -28,6 +28,24 @@
 //! shared by both algorithms (precompute, `new`, `zero`, `one`, the
 //! residue brand) live in the common `impl<T, P: Personality>` block.
 //!
+//! ## Width under each personality (runtime-width carriers)
+//!
+//! The two finalize strategies treat operand *width* differently on a
+//! runtime-width carrier (`HeaplessBigInt`), where stored length is a public
+//! shape parameter rather than value-derived:
+//!
+//! - **Ct (conditional-select finalize):** `conditional_select(x, x − m, ge)`
+//!   materializes both branches at the field width and selects between them, so
+//!   the result is always carried at the modulus width — the finalize
+//!   self-normalizes.
+//! - **Nct (compare-branch finalize):** `if x ≥ m { x − m } else { x }` returns
+//!   whichever branch at that branch's width; it does **not** widen a narrow
+//!   input. Correctness therefore depends on operands already sitting at the
+//!   modulus width, which the precompute/reduce path establishes via
+//!   [`WithPrecision`](const_num_traits::WithPrecision) seeding (see
+//!   `montgomery::basic_mont`). A residue entering narrower would fire its
+//!   carry/borrow at the wrong bit — the width-seed hazard that seeding closes.
+//!
 //! ## Branding
 //!
 //! Each `Field<T, P>` instance is implicitly tagged by its borrow lifetime

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -58,7 +58,6 @@ use crate::montgomery::basic_mont::{
 };
 use crate::montgomery::{
     CiosMontMul, CiosMontMulCt, compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n,
-    type_bit_width,
 };
 use crate::parity::Parity;
 use crate::wide_mul::WideMul;
@@ -236,10 +235,13 @@ where
     /// [`new`]: Self::new
     pub fn new_odd(modulus: Odd<T>) -> Self
     where
-        T: PartialEq + PartialOrd + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>,
+        T: PartialEq
+            + PartialOrd
+            + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+            + const_num_traits::BitsPrecision,
     {
         let modulus = modulus.get();
-        let w = type_bit_width::<T>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -273,10 +275,12 @@ where
     /// [`new_odd`]: Self::new_odd
     pub fn new_odd_ct(modulus: Odd<T>) -> Self
     where
-        T: subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess
+            + const_num_traits::BitsPrecision,
     {
         let modulus = modulus.get();
-        let w = type_bit_width::<T>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = crate::montgomery::compute_r_mod_n_ct(modulus, w);
         let r2_mod_n = crate::montgomery::compute_r2_mod_n_ct(r_mod_n, modulus, w);
@@ -303,7 +307,8 @@ where
         T: PartialEq
             + PartialOrd
             + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-            + Parity,
+            + Parity
+            + const_num_traits::BitsPrecision,
     {
         Odd::new(modulus).map(Self::new_odd)
     }
@@ -641,7 +646,10 @@ where
     /// [`CtParity`]: const_num_traits::CtParity
     pub fn try_new_odd_ct(modulus: T) -> subtle::CtOption<Self>
     where
-        T: const_num_traits::CtParity + subtle::ConditionallySelectable + subtle::ConstantTimeLess,
+        T: const_num_traits::CtParity
+            + subtle::ConditionallySelectable
+            + subtle::ConstantTimeLess
+            + const_num_traits::BitsPrecision,
     {
         // Mask the parity check (no branch on the secret modulus). The
         // precompute below uses the CT path ([`Self::new_odd_ct`]) so
@@ -759,9 +767,10 @@ where
             + const_num_traits::CtIsZero
             + subtle::ConditionallySelectable
             + core::ops::Shr<usize, Output = T>
-            + core::ops::BitAnd<Output = T>,
+            + core::ops::BitAnd<Output = T>
+            + const_num_traits::BitsPrecision,
     {
-        let w = type_bit_width::<T>();
+        let w = (*exp).bits_precision() as usize;
         let one = T::one();
         let mut result = self.r_mod_n;
 
@@ -811,9 +820,12 @@ where
     /// instead, which is a fixed-iteration Montgomery ladder.
     pub fn exp_public_exp(&self, base: &Residue<'_, T, Ct>, exp: &T) -> Residue<'_, T, Ct>
     where
-        T: CiosMontMulCt + core::ops::Shr<usize, Output = T> + core::ops::BitAnd<Output = T>,
+        T: CiosMontMulCt
+            + core::ops::Shr<usize, Output = T>
+            + core::ops::BitAnd<Output = T>
+            + const_num_traits::BitsPrecision,
     {
-        let w = type_bit_width::<T>();
+        let w = (*exp).bits_precision() as usize;
         let one = T::one();
         let zero = T::zero();
 
@@ -913,7 +925,8 @@ where
             + const_num_traits::CtIsZero
             + subtle::ConditionallySelectable
             + core::ops::Shr<usize, Output = T>
-            + core::ops::BitAnd<Output = T>,
+            + core::ops::BitAnd<Output = T>
+            + const_num_traits::BitsPrecision,
     {
         let a_is_nonzero = !a.mont.ct_is_zero();
         let two = T::one().wrapping_add(T::one());

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -327,14 +327,17 @@ mod bnum_inv_tests {
     //         basic: off, // Copy is not implemented, heap
     //     );
 
-    //     inv_test_module!(
-    //         num_bigint_patched,
-    //         num_bigint_patched::BigUint,
-    //         type U256 = num_bigint_patched::BigUint;
-    //         strict: on,
-    //         constrained: on,
-    //         basic: off, // Copy is not implemented, heap
-    //     );
+    // num-bigint `FixedWidthBigUint` deferred here: strict/constrained
+    // mod_inv need `T: Sub<&T>`, not yet impl'd on the fork (has
+    // `Sub<&FW> for &FW` + `Add<&FW> for FW`, needs `Sub<&FW> for FW`).
+    // inv_test_module!(
+    //     num_bigint_patched,
+    //     num_bigint_patched::FixedWidthBigUint,
+    //     type U256 = num_bigint_patched::FixedWidthBigUint;
+    //     strict: on,
+    //     constrained: on,
+    //     basic: off,
+    // );
 
     //     inv_test_module!(
     //         ibig,

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -113,14 +113,18 @@ where
         + core::cmp::PartialOrd
         + const_num_traits::CheckedAdd<Output = T>
         + core::ops::Sub<Output = T>
-        + const_num_traits::CheckedMul<Output = T>,
+        + const_num_traits::CheckedMul<Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T> + core::ops::Div<&'a T, Output = T>,
 {
-    let mut t = Signed::new(T::zero(), false);
-    let mut new_t = Signed::new(T::one(), false);
+    // Seed the signed coefficients at the modulus width (as strict_mod_inv):
+    // on a runtime-width carrier `T::zero()`/`one()` are minimal-width and the
+    // signed magnitude arithmetic corrupts the inverse otherwise.
+    let mut t = Signed::new(T::zero_with_precision_of(modulus), false);
+    let mut new_t = Signed::new(T::one_with_precision_of(modulus), false);
     let mut r = modulus.clone();
-    let mut new_r = a;
+    let mut new_r = a.widen_to_precision_of(modulus);
 
     while new_r != T::zero() {
         let quotient = &r / &new_r;
@@ -168,12 +172,16 @@ where
         + const_num_traits::CheckedAdd<Output = T>
         + core::ops::Sub<Output = T>
         + const_num_traits::CheckedMul<Output = T>
+        + const_num_traits::WithPrecision
         + core::cmp::PartialOrd,
 {
-    let mut t = Signed::new(T::zero(), false);
-    let mut new_t = Signed::new(T::one(), false);
+    // Seed the signed coefficients at the modulus width (as strict_mod_inv):
+    // on a runtime-width carrier `T::zero()`/`one()` are minimal-width and the
+    // signed magnitude arithmetic corrupts the inverse otherwise.
+    let mut t = Signed::new(T::zero_with_precision_of(&modulus), false);
+    let mut new_t = Signed::new(T::one_with_precision_of(&modulus), false);
     let mut r = Signed::new(modulus, false);
-    let mut new_r = Signed::new(a, false);
+    let mut new_r = Signed::new(a.widen_to_precision_of(&modulus), false);
 
     while new_r != Signed::new(T::zero(), false) {
         let quotient = r / new_r;
@@ -388,24 +396,30 @@ mod bnum_inv_tests {
         basic: on,
     );
 
-    // Regression for the strict_mod_inv width-0 seed bug: on a runtime-width
-    // carrier (len < CAP) strict_mod_inv corrupted the inverse for a large
-    // fraction of residues. Cross-check every residue against the u32 oracle.
+    // Regression for the width-0 seed bug in the EEA inverses: on a runtime-width
+    // carrier (len < CAP) `zero()`/`one()`-seeded coefficients corrupted the
+    // inverse for a large fraction of residues. All three flavors now seed at the
+    // modulus width; cross-check every residue against the u32 oracle.
     #[test]
-    fn strict_mod_inv_runtime_width_full_range() {
+    fn mod_inv_all_flavors_runtime_width_full_range() {
         use fixed_bigint::HeaplessBigInt;
         type H = HeaplessBigInt<u8, 4>;
         for m in [13u8, 17, 251] {
+            let hm = H::from(m);
             for a in 1..m {
-                let got = super::strict_mod_inv(H::from(a), &H::from(m));
-                let want = super::strict_mod_inv(a as u32, &(m as u32));
-                match (got, want) {
-                    (Some(g), Some(w)) => {
-                        assert_eq!(g, H::from(w as u8), "strict inv({a}) mod {m}")
-                    }
-                    (None, None) => {}
-                    (g, w) => panic!("strict inv({a}) mod {m}: heapless={g:?} u32={w:?}"),
-                }
+                let ha = H::from(a);
+                let want = super::basic_mod_inv(a as u32, m as u32).map(|w| H::from(w as u8));
+                assert_eq!(super::basic_mod_inv(ha, hm), want, "basic inv({a}) mod {m}");
+                assert_eq!(
+                    super::constrained_mod_inv(ha, &hm),
+                    want,
+                    "constrained inv({a}) mod {m}"
+                );
+                assert_eq!(
+                    super::strict_mod_inv(ha, &hm),
+                    want,
+                    "strict inv({a}) mod {m}"
+                );
             }
         }
     }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -375,8 +375,8 @@ mod bnum_inv_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        strict: off, // raw r-sequence uses plain Mul (shape-panics on HeaplessBigInt); only basic is fully on the checked Signed path
-        constrained: off, // raw r-sequence uses plain Mul (shape-panics on HeaplessBigInt); only basic is fully on the checked Signed path
+        strict: on,
+        constrained: on,
         basic: on,
     );
 }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -327,19 +327,20 @@ mod bnum_inv_tests {
     //         basic: off, // Copy is not implemented, heap
     //     );
 
-    // num-bigint `FixedWidthBigUint` inv deferred: the fork's Add/Sub/Mul
-    // truncate the result to `self.n_limbs`, so the EEA's width-free clone
-    // idiom `T::zero() + &x` (and `T::zero() + modulus`) yields 0 instead of x
-    // (`zero` is n_limbs=0). Every other carrier preserves `zero + x == x`.
-    // Re-enable once the fork widens results to `max(self.n_limbs, rhs.n_limbs)`.
-    // inv_test_module!(
-    //     num_bigint_patched,
-    //     num_bigint_patched::FixedWidthBigUint,
-    //     type U256 = num_bigint_patched::FixedWidthBigUint;
-    //     strict: on,
-    //     constrained: on,
-    //     basic: off,
-    // );
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct. constrained is its
+    // natural flavor (it *is* Clone). strict is off here: strict_mod_inv clones
+    // a signed coefficient via `Signed::new(T::zero()) + &x`, whose width-0
+    // signed-zero seed mishandles magnitude/sign on an exact-width carrier
+    // (wrong inverses for ~half of inputs); constrained's real `.clone()` is
+    // correct. `basic: off` — not Copy.
+    inv_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+        strict: off,
+        constrained: on,
+        basic: off,
+    );
 
     //     inv_test_module!(
     //         ibig,

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -333,17 +333,13 @@ mod bnum_inv_tests {
     //         basic: off, // Copy is not implemented, heap
     //     );
 
-    // num-bigint `FixedWidthBigUint`: heap carrier, Nct. constrained is its
-    // natural flavor (it *is* Clone). strict is off here: strict_mod_inv clones
-    // a signed coefficient via `Signed::new(T::zero()) + &x`, whose width-0
-    // signed-zero seed mishandles magnitude/sign on an exact-width carrier
-    // (wrong inverses for ~half of inputs); constrained's real `.clone()` is
-    // correct. `basic: off` — not Copy.
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct, constrained/strict
+    // only (not `Copy`, so `basic: off`).
     inv_test_module!(
         num_bigint_patched,
         num_bigint_patched::FixedWidthBigUint,
         type U256 = num_bigint_patched::FixedWidthBigUint;
-        strict: off,
+        strict: on,
         constrained: on,
         basic: off,
     );
@@ -391,4 +387,26 @@ mod bnum_inv_tests {
         constrained: on,
         basic: on,
     );
+
+    // Regression for the strict_mod_inv width-0 seed bug: on a runtime-width
+    // carrier (len < CAP) strict_mod_inv corrupted the inverse for a large
+    // fraction of residues. Cross-check every residue against the u32 oracle.
+    #[test]
+    fn strict_mod_inv_runtime_width_full_range() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 4>;
+        for m in [13u8, 17, 251] {
+            for a in 1..m {
+                let got = super::strict_mod_inv(H::from(a), &H::from(m));
+                let want = super::strict_mod_inv(a as u32, &(m as u32));
+                match (got, want) {
+                    (Some(g), Some(w)) => {
+                        assert_eq!(g, H::from(w as u8), "strict inv({a}) mod {m}")
+                    }
+                    (None, None) => {}
+                    (g, w) => panic!("strict inv({a}) mod {m}: heapless={g:?} u32={w:?}"),
+                }
+            }
+        }
+    }
 }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -58,7 +58,9 @@ where
     let mut new_t = Signed::new(T::one_with_precision_of(modulus), false);
     // makes a clone of modulus
     let mut r = T::zero_with_precision_of(modulus) + modulus;
-    let mut new_r = a;
+    // Widen `a` to the modulus width too (as constrained/basic do): a narrow
+    // `new_r` overflows `checked_mul(quotient2)` once `width(a) < width(modulus)`.
+    let mut new_r = a.widen_to_precision_of(modulus);
 
     while new_r != T::zero() {
         let quotient = &r / &new_r;
@@ -421,6 +423,35 @@ mod bnum_inv_tests {
                     "strict inv({a}) mod {m}"
                 );
             }
+        }
+    }
+
+    // Regression: value narrower than a multi-limb modulus. `strict_mod_inv`
+    // seeded `new_r = a` at `a`'s (narrow) width while the coefficients were at
+    // modulus width, so `new_r.checked_mul(quotient)` overflowed and panicked
+    // once width(a) < width(modulus). The full-range test above can't see it —
+    // its moduli are single-limb, so a and m share a width.
+    #[test]
+    fn strict_mod_inv_narrow_value_multiword_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 4>;
+        // 521 is prime and spans two u8 limbs; each `a` is a single limb.
+        let m = 521u32;
+        let hm = H::from(m); // 2 limbs
+        for a in [2u8, 3, 7, 100, 255] {
+            let ha = H::from(a); // 1 limb — narrower than the modulus
+            let want = super::basic_mod_inv(a as u32, m).map(|w| H::from(w as u16));
+            assert_eq!(super::basic_mod_inv(ha, hm), want, "basic inv({a}) mod {m}");
+            assert_eq!(
+                super::constrained_mod_inv(ha, &hm),
+                want,
+                "constrained inv({a}) mod {m}"
+            );
+            assert_eq!(
+                super::strict_mod_inv(ha, &hm),
+                want,
+                "strict inv({a}) mod {m}"
+            );
         }
     }
 

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -42,16 +42,22 @@ where
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
         + core::ops::Sub<Output = T>
+        + const_num_traits::WithPrecision
         + core::cmp::PartialOrd,
     for<'a> T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Add<&'a T, Output = T>
         + core::cmp::PartialOrd,
     for<'a> &'a T: core::ops::Div<&'a T, Output = T> + core::ops::Sub<T, Output = T>,
 {
-    let mut t = Signed::new(T::zero(), false);
-    let mut new_t = Signed::new(T::one(), false);
+    // Seed the signed coefficients at the modulus width: on a runtime-width
+    // carrier `T::zero()` is width 0, and the signed magnitude arithmetic
+    // (canonicalization, magnitude subtraction) misbehaves when a width-0
+    // magnitude meets field-width values. `zero_with_precision_of` establishes
+    // the ring width; identity on fixed-width carriers.
+    let mut t = Signed::new(T::zero_with_precision_of(modulus), false);
+    let mut new_t = Signed::new(T::one_with_precision_of(modulus), false);
     // makes a clone of modulus
-    let mut r = T::zero() + modulus;
+    let mut r = T::zero_with_precision_of(modulus) + modulus;
     let mut new_r = a;
 
     while new_r != T::zero() {
@@ -59,15 +65,15 @@ where
         // strict avoids a `Clone` bound: duplicate `quotient` via the same
         // reference-add trick used for `r`/`t`, so each coefficient update can
         // consume an owned copy through the checked multiply.
-        let quotient2 = T::zero() + &quotient;
+        let quotient2 = T::zero_with_precision_of(modulus) + &quotient;
 
         // clone
-        let tmp_t = Signed::new(T::zero(), false) + &new_t;
+        let tmp_t = Signed::new(T::zero_with_precision_of(modulus), false) + &new_t;
         new_t = t - new_t * quotient;
         t = tmp_t;
 
         // clone
-        let tmp_r = T::zero() + &new_r;
+        let tmp_r = T::zero_with_precision_of(modulus) + &new_r;
         new_r = r - new_r.checked_mul(quotient2).expect(signed::OVERFLOW_MSG);
         r = tmp_r;
     }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -375,8 +375,8 @@ mod bnum_inv_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        strict: off, // fork: value Mul panics on overflow; EEA Signed intermediates exceed the modulus
-        constrained: off, // fork: value Mul panics on overflow; EEA Signed intermediates exceed the modulus
-        basic: off, // fork: value Mul panics on overflow; EEA Signed intermediates exceed the modulus
+        strict: off, // fork+design: EEA products fit numerically (<= modulus) but HeaplessBigInt's overflow check is shape-based (len+len>CAP) and it never trims, so shape outgrows CAP; modmath's Signed<T> uses plain core::ops::Mul, whose overflow behavior is unspecified
+        constrained: off, // fork+design: EEA products fit numerically (<= modulus) but HeaplessBigInt's overflow check is shape-based (len+len>CAP) and it never trims, so shape outgrows CAP; modmath's Signed<T> uses plain core::ops::Mul, whose overflow behavior is unspecified
+        basic: off, // fork+design: EEA products fit numerically (<= modulus) but HeaplessBigInt's overflow check is shape-based (len+len>CAP) and it never trims, so shape outgrows CAP; modmath's Signed<T> uses plain core::ops::Mul, whose overflow behavior is unspecified
     );
 }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -375,8 +375,8 @@ mod bnum_inv_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        strict: off, // fork+design: EEA products fit numerically (<= modulus) but HeaplessBigInt's overflow check is shape-based (len+len>CAP) and it never trims, so shape outgrows CAP; modmath's Signed<T> uses plain core::ops::Mul, whose overflow behavior is unspecified
-        constrained: off, // fork+design: EEA products fit numerically (<= modulus) but HeaplessBigInt's overflow check is shape-based (len+len>CAP) and it never trims, so shape outgrows CAP; modmath's Signed<T> uses plain core::ops::Mul, whose overflow behavior is unspecified
-        basic: off, // fork+design: EEA products fit numerically (<= modulus) but HeaplessBigInt's overflow check is shape-based (len+len>CAP) and it never trims, so shape outgrows CAP; modmath's Signed<T> uses plain core::ops::Mul, whose overflow behavior is unspecified
+        strict: off, // raw r-sequence uses plain Mul (shape-panics on HeaplessBigInt); only basic is fully on the checked Signed path
+        constrained: off, // raw r-sequence uses plain Mul (shape-panics on HeaplessBigInt); only basic is fully on the checked Signed path
+        basic: on,
     );
 }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -426,11 +426,8 @@ mod bnum_inv_tests {
         }
     }
 
-    // Regression: value narrower than a multi-limb modulus. `strict_mod_inv`
-    // seeded `new_r = a` at `a`'s (narrow) width while the coefficients were at
-    // modulus width, so `new_r.checked_mul(quotient)` overflowed and panicked
-    // once width(a) < width(modulus). The full-range test above can't see it —
-    // its moduli are single-limb, so a and m share a width.
+    // A one-limb value against a multi-limb modulus — the width(a) < width(m)
+    // path the single-limb moduli in the full-range test above can't exercise.
     #[test]
     fn strict_mod_inv_narrow_value_multiword_modulus() {
         use fixed_bigint::HeaplessBigInt;

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -327,9 +327,11 @@ mod bnum_inv_tests {
     //         basic: off, // Copy is not implemented, heap
     //     );
 
-    // num-bigint `FixedWidthBigUint` deferred here: strict/constrained
-    // mod_inv need `T: Sub<&T>`, not yet impl'd on the fork (has
-    // `Sub<&FW> for &FW` + `Add<&FW> for FW`, needs `Sub<&FW> for FW`).
+    // num-bigint `FixedWidthBigUint` inv deferred: the fork's Add/Sub/Mul
+    // truncate the result to `self.n_limbs`, so the EEA's width-free clone
+    // idiom `T::zero() + &x` (and `T::zero() + modulus`) yields 0 instead of x
+    // (`zero` is n_limbs=0). Every other carrier preserves `zero + x == x`.
+    // Re-enable once the fork widens results to `max(self.n_limbs, rhs.n_limbs)`.
     // inv_test_module!(
     //     num_bigint_patched,
     //     num_bigint_patched::FixedWidthBigUint,

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -370,4 +370,13 @@ mod bnum_inv_tests {
         constrained: on,
         basic: on,
     );
+
+    inv_test_module!(
+        heapless_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
+        strict: off, // fork: value Mul panics on overflow; EEA Signed intermediates exceed the modulus
+        constrained: off, // fork: value Mul panics on overflow; EEA Signed intermediates exceed the modulus
+        basic: off, // fork: value Mul panics on overflow; EEA Signed intermediates exceed the modulus
+    );
 }

--- a/modmath/src/inv.rs
+++ b/modmath/src/inv.rs
@@ -409,4 +409,49 @@ mod bnum_inv_tests {
             }
         }
     }
+
+    // Multi-limb guard for num-bigint's FixedWidthBigUint (const-7 minimized its
+    // width handling): cross-check inv + schoolbook mul against a u128 oracle at
+    // a >1-limb odd modulus. The single-limb macro tests can't see a multi-limb
+    // width regression; this can.
+    #[test]
+    fn num_bigint_multilimb_matches_u128_oracle() {
+        use num_bigint_patched::{BigUint, FixedWidthBigUint as FW};
+        const N: usize = 4; // >= 128 bits even for u32 digits; holds m + EEA headroom
+        let m_u128: u128 = 1_180_591_620_717_411_303_451; // ~2^70, odd, multi-limb
+        let fw = |v: u128| FW::new(BigUint::from(v), N);
+        let m = fw(m_u128);
+        for a in [2u128, 3, 5, 65_537, 999_999_937, m_u128 - 1] {
+            for (label, gotv, wantv) in [
+                (
+                    "strict",
+                    super::strict_mod_inv(fw(a), &m),
+                    super::strict_mod_inv(a, &m_u128),
+                ),
+                (
+                    "constrained",
+                    super::constrained_mod_inv(fw(a), &m),
+                    super::constrained_mod_inv(a, &m_u128),
+                ),
+            ] {
+                match (gotv, wantv) {
+                    (Some(g), Some(w)) => assert_eq!(g, fw(w), "{label} inv({a})"),
+                    (None, None) => {}
+                    (g, w) => {
+                        panic!("{label} inv({a}): FW.is_some={} u128={w:?}", g.is_some())
+                    }
+                }
+            }
+        }
+        // Multi-limb schoolbook mul against the u128 oracle.
+        for (a, b) in [
+            (3u128, 5u128),
+            (123_456_789, 987_654_321),
+            (m_u128 - 1, m_u128 - 2),
+        ] {
+            let got = crate::mul::constrained_mod_mul(fw(a), &fw(b), &m);
+            let want = crate::mul::constrained_mod_mul(a, &b, &m_u128);
+            assert_eq!(got, fw(want), "mul({a},{b})");
+        }
+    }
 }

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -227,7 +227,7 @@ where
 {
     // Field-width zero, not `T::zero()`: on a runtime-width carrier the
     // latter is narrow and would re-narrow d/e when selected.
-    let zero = T::zero_with_precision(m.bits_precision());
+    let zero = T::zero_with_precision_of(m);
     let x_is_zero = x.ct_is_zero();
     let neg = m.clone().wrapping_sub(x.clone());
     T::conditional_select(&neg, &zero, x_is_zero)
@@ -315,8 +315,7 @@ where
     // the ±1 sentinels, and the mod-reductions align on a runtime-width
     // carrier — a narrow `value`/`one`/`zero` would place the mask and the
     // sentinels at the wrong bit and the divsteps would not converge.
-    let w_bits = modulus.bits_precision();
-    let max = T::zero_with_precision(w_bits).wrapping_sub(T::one());
+    let max = T::zero_with_precision_of(modulus).wrapping_sub(T::one());
     let top_bit_mask = max.clone().wrapping_sub(max.clone() >> 1);
     let m_half = modulus.clone() >> 1;
 
@@ -325,11 +324,11 @@ where
         hi: 0,
     };
     let mut g = SignedExt {
-        lo: value.clone().widen_to_precision(w_bits),
+        lo: value.clone().widen_to_precision_of(modulus),
         hi: 0,
     };
-    let mut d = T::zero_with_precision(w_bits);
-    let mut e = T::one_with_precision(w_bits);
+    let mut d = T::zero_with_precision_of(modulus);
+    let mut e = T::one_with_precision_of(modulus);
     let mut delta: i64 = 1;
 
     for _ in 0..total_steps {

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -65,7 +65,7 @@
 //! suitable for cases where the latency budget allows it (RSA blinding
 //! at 2048 bits is dominated by the main exponentiation anyway).
 
-use const_num_traits::{CtIsZero, CtParity, One, WrappingAdd, WrappingSub, Zero};
+use const_num_traits::{CtIsZero, CtParity, One, WithPrecision, WrappingAdd, WrappingSub, Zero};
 use modmath_cios::CiosRowOps;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeLess, CtOption};
 
@@ -223,11 +223,11 @@ where
 #[inline]
 fn neg_mod_ct<T>(x: &T, m: &T) -> T
 where
-    T: Clone + ConditionallySelectable + WrappingSub<Output = T> + CtIsZero,
+    T: Clone + ConditionallySelectable + WrappingSub<Output = T> + CtIsZero + Zero + WithPrecision,
 {
-    // Field-width zero (`m - m`), not `T::zero()`: on a runtime-width
-    // carrier the latter is narrow and would re-narrow d/e when selected.
-    let zero = m.clone().wrapping_sub(m.clone());
+    // Field-width zero, not `T::zero()`: on a runtime-width carrier the
+    // latter is narrow and would re-narrow d/e when selected.
+    let zero = T::zero_with_precision(m.clone().bits_precision());
     let x_is_zero = x.ct_is_zero();
     let neg = m.clone().wrapping_sub(x.clone());
     T::conditional_select(&neg, &zero, x_is_zero)
@@ -291,6 +291,7 @@ where
         + One
         + WrappingAdd<Output = T>
         + WrappingSub<Output = T>
+        + WithPrecision
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitOr<Output = T>,
     T::Word: CtParity,
@@ -314,9 +315,8 @@ where
     // the ±1 sentinels, and the mod-reductions align on a runtime-width
     // carrier — a narrow `value`/`one`/`zero` would place the mask and the
     // sentinels at the wrong bit and the divsteps would not converge.
-    // `m - m` is a field-width zero synthesized from the modulus.
-    let field_zero = modulus.clone().wrapping_sub(modulus.clone());
-    let max = field_zero.clone().wrapping_sub(T::one());
+    let w_bits = modulus.clone().bits_precision();
+    let max = T::zero_with_precision(w_bits).wrapping_sub(T::one());
     let top_bit_mask = max.clone().wrapping_sub(max.clone() >> 1);
     let m_half = modulus.clone() >> 1;
 
@@ -325,11 +325,11 @@ where
         hi: 0,
     };
     let mut g = SignedExt {
-        lo: field_zero.clone().wrapping_add(value.clone()),
+        lo: value.clone().widen_to_precision(w_bits),
         hi: 0,
     };
-    let mut d = field_zero.clone();
-    let mut e = field_zero.clone().wrapping_add(T::one());
+    let mut d = T::zero_with_precision(w_bits);
+    let mut e = T::one_with_precision(w_bits);
     let mut delta: i64 = 1;
 
     for _ in 0..total_steps {

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -223,9 +223,11 @@ where
 #[inline]
 fn neg_mod_ct<T>(x: &T, m: &T) -> T
 where
-    T: Clone + Zero + ConditionallySelectable + WrappingSub<Output = T> + CtIsZero,
+    T: Clone + ConditionallySelectable + WrappingSub<Output = T> + CtIsZero,
 {
-    let zero = T::zero();
+    // Field-width zero (`m - m`), not `T::zero()`: on a runtime-width
+    // carrier the latter is narrow and would re-narrow d/e when selected.
+    let zero = m.clone().wrapping_sub(m.clone());
     let x_is_zero = x.ct_is_zero();
     let neg = m.clone().wrapping_sub(x.clone());
     T::conditional_select(&neg, &zero, x_is_zero)
@@ -293,7 +295,14 @@ where
         + core::ops::BitOr<Output = T>,
     T::Word: CtParity,
 {
-    let n_bits = value.word_count() * core::mem::size_of::<T::Word>() * 8;
+    // Divstep count is a function of the ring width, not the particular
+    // value: a runtime-width carrier can hand us a `value` narrower than the
+    // modulus (e.g. inverting a small residue in a wide field), and counting
+    // its words would run too few divsteps to converge. Bound by the wider
+    // of the two operands.
+    let n_bits = core::cmp::max(value.word_count(), modulus.word_count())
+        * core::mem::size_of::<T::Word>()
+        * 8;
     let total_steps = divsteps_total(n_bits);
     // Loop invariants for se_shr1 / half_mod_ct — hoisted so each
     // divstep doesn't redo a full-width shift. The mask is MAX − (MAX
@@ -301,8 +310,14 @@ where
     // defeats const-folding through multi-limb Shl impls, keeping
     // their index bounds-check panic path alive post-LTO (flagged by
     // the panic-free audit); a constant-amount shift folds clean.
-    let max = T::zero().wrapping_sub(T::one());
-    let top_bit_mask = max.wrapping_sub(max.clone() >> 1);
+    // All working values operate at the modulus width so the top-bit mask,
+    // the ±1 sentinels, and the mod-reductions align on a runtime-width
+    // carrier — a narrow `value`/`one`/`zero` would place the mask and the
+    // sentinels at the wrong bit and the divsteps would not converge.
+    // `m - m` is a field-width zero synthesized from the modulus.
+    let field_zero = modulus.clone().wrapping_sub(modulus.clone());
+    let max = field_zero.clone().wrapping_sub(T::one());
+    let top_bit_mask = max.clone().wrapping_sub(max.clone() >> 1);
     let m_half = modulus.clone() >> 1;
 
     let mut f = SignedExt {
@@ -310,11 +325,11 @@ where
         hi: 0,
     };
     let mut g = SignedExt {
-        lo: value.clone(),
+        lo: field_zero.clone().wrapping_add(value.clone()),
         hi: 0,
     };
-    let mut d = T::zero();
-    let mut e = T::one();
+    let mut d = field_zero.clone();
+    let mut e = field_zero.clone().wrapping_add(T::one());
     let mut delta: i64 = 1;
 
     for _ in 0..total_steps {
@@ -360,7 +375,9 @@ where
     // invertible case (gcd == 1), f is either +1 (lo == 1, hi == 0)
     // or -1 (lo all-ones, hi all-ones).
     let one = T::one();
-    let neg_one_lo = T::zero().wrapping_sub(T::one());
+    // -1 at the modulus width (all-ones), matching f.lo's width for the
+    // f == -1 sentinel check; a narrow `zero - one` would miscompare.
+    let neg_one_lo = max.clone();
 
     let f_is_one = f.lo.ct_eq(&one) & f.hi.ct_eq(&0u64);
     let f_is_neg_one = f.lo.ct_eq(&neg_one_lo) & f.hi.ct_eq(&u64::MAX);
@@ -386,6 +403,28 @@ where
 mod tests {
     use super::*;
     use crate::inv::basic_mod_inv;
+
+    #[test]
+    fn heapless_narrow_value_wide_modulus() {
+        // Runtime-width carrier: value occupies one word, modulus two.
+        // Divstep count and the shift mask must track the modulus width,
+        // not the value's, or the loop fails to converge and reports None.
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 8>;
+        for (v, m) in [(3u16, 511u16), (7, 65535), (2, 65521), (123, 40001)] {
+            let vh: H = v.into();
+            let mh: H = m.into();
+            let got = safegcd_inv_ct::<H>(&vh, &mh).into_option();
+            let want = safegcd_inv_ct::<u32>(&(v as u32), &(m as u32)).into_option();
+            match (got, want) {
+                (Some(g), Some(w)) => {
+                    let gw: u32 = (g.word(0) as u32) | ((g.word(1) as u32) << 8);
+                    assert_eq!(gw, w, "value={v} modulus={m}");
+                }
+                (a, b) => panic!("value={v} modulus={m}: heapless={a:?} u32={b:?}"),
+            }
+        }
+    }
 
     #[test]
     fn divsteps_total_matches_paper_bound() {

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -227,7 +227,7 @@ where
 {
     // Field-width zero, not `T::zero()`: on a runtime-width carrier the
     // latter is narrow and would re-narrow d/e when selected.
-    let zero = T::zero_with_precision(m.clone().bits_precision());
+    let zero = T::zero_with_precision(m.bits_precision());
     let x_is_zero = x.ct_is_zero();
     let neg = m.clone().wrapping_sub(x.clone());
     T::conditional_select(&neg, &zero, x_is_zero)
@@ -315,7 +315,7 @@ where
     // the ±1 sentinels, and the mod-reductions align on a runtime-width
     // carrier — a narrow `value`/`one`/`zero` would place the mask and the
     // sentinels at the wrong bit and the divsteps would not converge.
-    let w_bits = modulus.clone().bits_precision();
+    let w_bits = modulus.bits_precision();
     let max = T::zero_with_precision(w_bits).wrapping_sub(T::one());
     let top_bit_mask = max.clone().wrapping_sub(max.clone() >> 1);
     let m_half = modulus.clone() >> 1;

--- a/modmath/src/inv/safegcd.rs
+++ b/modmath/src/inv/safegcd.rs
@@ -296,14 +296,13 @@ where
         + core::ops::BitOr<Output = T>,
     T::Word: CtParity,
 {
-    // Divstep count is a function of the ring width, not the particular
-    // value: a runtime-width carrier can hand us a `value` narrower than the
-    // modulus (e.g. inverting a small residue in a wide field), and counting
-    // its words would run too few divsteps to converge. Bound by the wider
-    // of the two operands.
-    let n_bits = core::cmp::max(value.word_count(), modulus.word_count())
-        * core::mem::size_of::<T::Word>()
-        * 8;
+    // Divstep count is a function of the operating (ring) width, not the
+    // particular value: a runtime-width carrier can hand us a `value` narrower
+    // than the modulus (e.g. inverting a small residue in a wide field), and
+    // counting its width alone would run too few divsteps to converge. Bound by
+    // the wider of the two operands, read via the canonical width accessor
+    // `bits_precision()` (not `word_count()`).
+    let n_bits = core::cmp::max(value.bits_precision(), modulus.bits_precision()) as usize;
     let total_steps = divsteps_total(n_bits);
     // Loop invariants for se_shr1 / half_mod_ct — hoisted so each
     // divstep doesn't redo a full-width shift. The mask is MAX − (MAX
@@ -370,8 +369,18 @@ where
         e = half_mod_ct(&e, &m_half);
     }
 
-    // After total_steps divsteps, g == 0 and f == ±gcd. For the
-    // invertible case (gcd == 1), f is either +1 (lo == 1, hi == 0)
+    // After total_steps divsteps, g == 0 and f == ±gcd. A `None` below must
+    // therefore mean f == ±gcd with gcd > 1 (a genuine shared factor) — never
+    // that the divsteps failed to converge. If g != 0 here, the step count was
+    // too small for the operating width (a width desync), and the `None` would
+    // be a false "not coprime". Guard it in debug builds; stripped in release,
+    // so the shipped CT path is unaffected.
+    debug_assert!(
+        g.lo.ct_is_zero().unwrap_u8() == 1 && g.hi == 0,
+        "safegcd: divsteps did not converge (g != 0) — width desync, not a coprimality verdict"
+    );
+
+    // For the invertible case (gcd == 1), f is either +1 (lo == 1, hi == 0)
     // or -1 (lo all-ones, hi all-ones).
     let one = T::one();
     // -1 at the modulus width (all-ones), matching f.lo's width for the

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -58,7 +58,7 @@ pub mod strict;
 
 pub use field::{
     Field, FieldCt, FieldFor, FieldNct, FieldOps, FieldView, MontStorage, Residue, ResidueCt,
-    ResidueNct,
+    ResidueNct, SchoolbookField, SchoolbookResidue,
 };
 pub use nonct::NonCt;
 pub use parity::Parity;

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -69,12 +69,11 @@ pub use exp::const_mod_exp;
 // (algorithm selector for R>N `*_with_method` computations, used through
 // `modmath::{basic,constrained,strict}::montgomery::compute_params_with_method`)
 // plus the precompute helpers (`compute_n_prime_newton`, `compute_r_mod_n`,
-// `compute_r2_mod_n`) and `type_bit_width`. The flavor-keyed wide-REDC
+// `compute_r2_mod_n`). The flavor-keyed wide-REDC
 // wrappers live under `modmath::{basic,constrained,strict}::montgomery::wide::*`.
 #[rustfmt::skip]
 pub use montgomery::{
     NPrimeMethod,
-    type_bit_width,
     compute_n_prime_newton,
     compute_r_mod_n,
     compute_r_mod_n_ct,

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -56,7 +56,10 @@ pub mod basic;
 pub mod constrained;
 pub mod strict;
 
-pub use field::{Field, FieldCt, FieldNct, MontStorage, Residue, ResidueCt, ResidueNct};
+pub use field::{
+    Field, FieldCt, FieldFor, FieldNct, FieldOps, FieldView, MontStorage, Residue, ResidueCt,
+    ResidueNct,
+};
 pub use nonct::NonCt;
 pub use parity::Parity;
 pub use wide_mul::WideMul;

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -31,6 +31,27 @@
 //! flavor's `Copy` bound rules out heap-allocated backends; those use
 //! `constrained` or `strict`.
 //!
+//! ## Which surface to use (width safety)
+//!
+//! On a **runtime-width carrier** (a fixed-capacity, runtime-length bignum such
+//! as `HeaplessBigInt`), a value's stored width reflects its magnitude, not the
+//! ring it lives in — so a modular value must be established at the modulus
+//! ("ring") width or width-sensitive ops fire at the wrong bit and truncate.
+//! The [`FieldOps`] surface — Montgomery [`Field`]/[`FieldView`] and the
+//! schoolbook [`SchoolbookField`] strategy — carries the ring width as a **type
+//! invariant** of its [`Residue`], so a computation written against it cannot
+//! seed a narrow value. **Prefer it for anything on a runtime-width carrier, and
+//! for building your own reducer.**
+//!
+//! The raw-`T` schoolbook free functions ([`basic`]/[`constrained`]/[`strict`])
+//! are the low-level convenience layer: they reduce *their own* operands to the
+//! ring width internally, so a single `basic::mul(a, b, m)` is correct — but
+//! they operate on ring-membership-untyped `T`, so a **hand-rolled reducer** that
+//! seeds accumulators/coefficients from `T::zero()`/`one()` and grows them
+//! *outside* these calls re-opens the width-seed hazard. Such reducers belong on
+//! [`SchoolbookField`] (identities come from `field.zero()`/`one()`, which are
+//! ring-width by construction), not on raw `T`.
+//!
 //! [`Overflowing`]: https://docs.rs/num-traits/latest/num_traits/ops/overflowing
 //! [`subtle`]: https://crates.io/crates/subtle
 

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -491,7 +491,9 @@ where
     if modulus == T::one() {
         return T::zero();
     }
-    let mut result = val;
+    // Widen the start value to the modulus width so mod_double's
+    // overflow flag fires at bit W, not at the narrow value's width.
+    let mut result = modulus.wrapping_sub(modulus).overflowing_add(val).0;
     for _ in 0..w {
         result = mod_double(result, modulus);
     }
@@ -514,7 +516,9 @@ where
         + subtle::ConstantTimeEq
         + subtle::ConstantTimeLess,
 {
-    let mut result = val;
+    // Widen the start value to the modulus width so mod_double_ct's
+    // overflow flag fires at bit W, not at the narrow value's width.
+    let mut result = modulus.wrapping_sub(modulus).wrapping_add(val);
     for _ in 0..w {
         result = mod_double_ct(result, modulus);
     }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -268,24 +268,6 @@ where
     crate::mul::basic_mod_mul(a, r, modulus)
 }
 
-/// Convert to Montgomery form (Basic, pre-reduced): a -> (a * R) mod N
-/// Precondition: `a < modulus` and `r < modulus`. No `Rem` bound.
-pub fn basic_to_montgomery_pr<T>(a: T, modulus: T, r: T) -> T
-where
-    T: core::cmp::PartialOrd
-        + Copy
-        + const_num_traits::Zero
-        + const_num_traits::One
-        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Shr<usize, Output = T>
-        + crate::parity::Parity
-        + crate::NonCt
-        + const_num_traits::WithPrecision,
-{
-    crate::mul::basic_mod_mul_pr(a, r, modulus)
-}
-
 /// Convert from Montgomery form (Basic): (a * R) -> a mod N
 /// Uses Montgomery reduction algorithm with R > N semantics.
 ///
@@ -378,30 +360,6 @@ where
     // from_montgomery can also overflow at key sizes. For overflow-free
     // multiplication, route through wide-REDC / CIOS instead.
     let product = crate::mul::basic_mod_mul(a_mont, b_mont, modulus);
-    basic_from_montgomery(product, modulus, n_prime, r_bits)
-}
-
-/// Montgomery multiplication (Basic, pre-reduced)
-/// Precondition: `a_mont < modulus` and `b_mont < modulus`. No `Rem` bound.
-pub fn basic_montgomery_mul_pr<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
-where
-    T: Copy
-        + const_num_traits::Zero
-        + core::ops::Add<Output = T>
-        + const_num_traits::CheckedMul<Output = T>
-        + const_num_traits::One
-        + PartialOrd
-        + core::ops::Sub<Output = T>
-        + core::ops::Shr<usize, Output = T>
-        + core::ops::Shl<usize, Output = T>
-        + core::ops::BitAnd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
-        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::parity::Parity
-        + crate::NonCt
-        + const_num_traits::WithPrecision,
-{
-    let product = crate::mul::basic_mod_mul_pr(a_mont, b_mont, modulus);
     basic_from_montgomery(product, modulus, n_prime, r_bits)
 }
 
@@ -1064,7 +1022,7 @@ where
 ///
 /// Precondition (unchanged from the `Option`-returning sibling): `a < modulus`
 /// and `b < modulus`.
-pub fn basic_montgomery_mod_mul_pr_odd<T>(a: T, b: T, modulus: Odd<T>) -> T
+pub(crate) fn basic_montgomery_mod_mul_pr_odd<T>(a: T, b: T, modulus: Odd<T>) -> T
 where
     T: Copy
         + const_num_traits::Zero
@@ -1105,7 +1063,8 @@ where
 /// [`basic_montgomery_mod_mul_pr_odd`] that performs the parity proof at
 /// runtime — prefer the `_odd` form to keep the panic path out of the
 /// linked binary.
-pub fn basic_montgomery_mod_mul_pr<T>(a: T, b: T, modulus: T) -> Option<T>
+#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
+pub(crate) fn basic_montgomery_mod_mul_pr<T>(a: T, b: T, modulus: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::Zero
@@ -1177,7 +1136,7 @@ where
 
 /// Complete Montgomery modular exponentiation (Basic, pre-reduced,
 /// proven-odd modulus). **Infallible.** Precondition: `base < modulus`.
-pub fn basic_montgomery_mod_exp_pr_odd<T>(base: T, exponent: T, modulus: Odd<T>) -> T
+pub(crate) fn basic_montgomery_mod_exp_pr_odd<T>(base: T, exponent: T, modulus: Odd<T>) -> T
 where
     T: Copy
         + const_num_traits::Zero
@@ -1226,7 +1185,8 @@ where
 /// Precondition: `base < modulus`. No `Rem` bound. Returns None only if
 /// modulus is even or zero. Thin wrapper around
 /// [`basic_montgomery_mod_exp_pr_odd`].
-pub fn basic_montgomery_mod_exp_pr<T>(base: T, exponent: T, modulus: T) -> Option<T>
+#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
+pub(crate) fn basic_montgomery_mod_exp_pr<T>(base: T, exponent: T, modulus: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::Zero
@@ -1268,7 +1228,8 @@ where
 ///
 /// Complete Montgomery modular exponentiation (Basic, CT, pre-reduced,
 /// proven-odd modulus). **Infallible.** Precondition: `base < modulus`.
-pub fn basic_montgomery_mod_exp_pr_odd_ct<T>(base: T, exponent: T, modulus: Odd<T>) -> T
+#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
+pub(crate) fn basic_montgomery_mod_exp_pr_odd_ct<T>(base: T, exponent: T, modulus: Odd<T>) -> T
 where
     T: Copy
         + const_num_traits::Zero
@@ -1327,7 +1288,8 @@ where
 
 /// Returns None if modulus is even or zero. Thin wrapper around
 /// [`basic_montgomery_mod_exp_pr_odd_ct`].
-pub fn basic_montgomery_mod_exp_pr_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
+#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
+pub(crate) fn basic_montgomery_mod_exp_pr_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::Zero

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -320,9 +320,8 @@ where
         .checked_mul(modulus)
         .expect(crate::montgomery::OVERFLOW_MSG);
     let sum = a_mont + m_times_n;
-    // `+` panics on an Nct carrier's overflow but silently wraps on a Ct one;
-    // a dropped carry here corrupts the reduction just as a dropped `m*N` carry
-    // would, so catch the wrap (sum < a_mont) and panic per the same contract.
+    // `+` wraps on a Ct carrier (panics on Nct); a dropped carry corrupts the
+    // reduction, so catch the wrap (sum < a_mont) and panic per the same contract.
     assert!(sum >= a_mont, "{}", crate::montgomery::OVERFLOW_MSG);
     let t = sum >> r_bits;
 
@@ -1324,11 +1323,9 @@ mod tests {
     use const_num_traits::BitsPrecision;
     use const_num_traits::Ct;
 
-    // Regression: the narrow REDC's `a_mont + m*N` can carry past the carrier
-    // width even after `m*N` fits. N=17, R=32 (r_bits=5), n_prime=15: from_mont(1)
-    // needs a_mont + m*N = 1 + 255 = 256, overflowing u8. The dropped carry used
-    // to silently reduce to 0; it must panic (OVERFLOW_MSG) instead. A wider
-    // carrier holds the intermediate and reduces correctly to R⁻¹ mod N = 8.
+    // The narrow REDC's `a_mont + m*N` can carry past the carrier even after
+    // `m*N` fits: N=17, R=32 (r_bits=5), n'=15 → from_mont(1) needs 256, which
+    // overflows u8 (must panic); a u16 holds it and reduces to R⁻¹ = 8.
     #[test]
     fn from_montgomery_narrow_carrier_lost_carry_panics() {
         let overflowed = std::panic::catch_unwind(|| basic_from_montgomery(1u8, 17u8, 15u8, 5));

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -316,10 +316,15 @@ where
     // carrier-too-narrow product into a panic rather than a wrapped, wrong
     // reduction. Use wide_redc(a_mont, T::zero(), modulus, n_prime) for
     // overflow-free reduction.
-    let t = (a_mont
-        + m.checked_mul(modulus)
-            .expect(crate::montgomery::OVERFLOW_MSG))
-        >> r_bits;
+    let m_times_n = m
+        .checked_mul(modulus)
+        .expect(crate::montgomery::OVERFLOW_MSG);
+    let sum = a_mont + m_times_n;
+    // `+` panics on an Nct carrier's overflow but silently wraps on a Ct one;
+    // a dropped carry here corrupts the reduction just as a dropped `m*N` carry
+    // would, so catch the wrap (sum < a_mont) and panic per the same contract.
+    assert!(sum >= a_mont, "{}", crate::montgomery::OVERFLOW_MSG);
+    let t = sum >> r_bits;
 
     // Step 3: Final reduction
     if t >= modulus { t - modulus } else { t }
@@ -1318,6 +1323,21 @@ mod tests {
     use super::*;
     use const_num_traits::BitsPrecision;
     use const_num_traits::Ct;
+
+    // Regression: the narrow REDC's `a_mont + m*N` can carry past the carrier
+    // width even after `m*N` fits. N=17, R=32 (r_bits=5), n_prime=15: from_mont(1)
+    // needs a_mont + m*N = 1 + 255 = 256, overflowing u8. The dropped carry used
+    // to silently reduce to 0; it must panic (OVERFLOW_MSG) instead. A wider
+    // carrier holds the intermediate and reduces correctly to R⁻¹ mod N = 8.
+    #[test]
+    fn from_montgomery_narrow_carrier_lost_carry_panics() {
+        let overflowed = std::panic::catch_unwind(|| basic_from_montgomery(1u8, 17u8, 15u8, 5));
+        assert!(
+            overflowed.is_err(),
+            "u8 REDC overflow must panic, not silently corrupt to 0"
+        );
+        assert_eq!(basic_from_montgomery(1u16, 17u16, 15u16, 5), 8u16);
+    }
     use fixed_bigint::FixedUInt;
 
     // -- Old basic_mont tests (param computation, N' methods, etc.) ----------

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -5,6 +5,7 @@ use crate::inv::basic_mod_inv;
 use crate::parity::Parity;
 use crate::wide_mul::WideMul;
 use const_num_traits::Odd;
+use const_num_traits::WithPrecision;
 use subtle::Choice;
 
 /// Methods for computing N' in Montgomery parameter computation
@@ -258,7 +259,8 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>
         + crate::parity::Parity
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     crate::mul::basic_mod_mul(a, r, modulus)
 }
@@ -275,7 +277,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::parity::Parity
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     crate::mul::basic_mod_mul_pr(a, r, modulus)
 }
@@ -359,7 +362,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + crate::parity::Parity
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     // Montgomery multiplication algorithm:
     // Input: a_mont, b_mont (both in Montgomery form), modulus N, N', r_bits
@@ -391,7 +395,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + crate::parity::Parity
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
 {
     let product = crate::mul::basic_mod_mul_pr(a_mont, b_mont, modulus);
     basic_from_montgomery(product, modulus, n_prime, r_bits)
@@ -485,15 +490,16 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>
+        + WithPrecision,
 {
     // For modulus == 1, any value mod 1 == 0
     if modulus == T::one() {
         return T::zero();
     }
-    // Widen the start value to the modulus width so mod_double's
-    // overflow flag fires at bit W, not at the narrow value's width.
-    let mut result = modulus.wrapping_sub(modulus).overflowing_add(val).0;
+    // Seed the start value at the modulus width so mod_double's overflow
+    // flag fires at bit W, not the narrow value's width.
+    let mut result = val.widen_to_precision_of(&modulus);
     for _ in 0..w {
         result = mod_double(result, modulus);
     }
@@ -514,11 +520,12 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeEq
-        + subtle::ConstantTimeLess,
+        + subtle::ConstantTimeLess
+        + WithPrecision,
 {
-    // Widen the start value to the modulus width so mod_double_ct's
-    // overflow flag fires at bit W, not at the narrow value's width.
-    let mut result = modulus.wrapping_sub(modulus).wrapping_add(val);
+    // Seed the start value at the modulus width so mod_double_ct's overflow
+    // flag fires at bit W, not the narrow value's width.
+    let mut result = val.widen_to_precision_of(&modulus);
     for _ in 0..w {
         result = mod_double_ct(result, modulus);
     }
@@ -539,7 +546,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::WithPrecision,
 {
     mod_exp2(T::one(), modulus, w)
 }
@@ -555,7 +563,8 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+        + subtle::ConstantTimeLess
+        + const_num_traits::WithPrecision,
 {
     mod_exp2_ct(T::one(), modulus, w)
 }
@@ -571,7 +580,8 @@ where
         + const_num_traits::Zero
         + const_num_traits::One
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::WithPrecision,
 {
     mod_exp2(r_mod_n, modulus, w)
 }
@@ -586,7 +596,8 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+        + subtle::ConstantTimeLess
+        + const_num_traits::WithPrecision,
 {
     mod_exp2_ct(r_mod_n, modulus, w)
 }
@@ -1011,7 +1022,8 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + core::ops::Rem<Output = T>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     let m = modulus.get();
     basic_montgomery_mod_mul_pr_odd(reduce_mod(a, m), reduce_mod(b, m), modulus)
@@ -1033,7 +1045,8 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Rem<Output = T>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_mul_odd(a, b, m))
 }
@@ -1060,7 +1073,8 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     let modulus = modulus.get();
     let w = modulus.bits_precision() as usize;
@@ -1101,7 +1115,8 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_mul_pr_odd(a, b, m))
 }
@@ -1123,7 +1138,8 @@ where
         + Parity
         + core::ops::Rem<Output = T>
         + core::ops::ShrAssign<usize>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     let m = modulus.get();
     basic_montgomery_mod_exp_pr_odd(reduce_mod(base, m), exponent, modulus)
@@ -1150,7 +1166,8 @@ where
         + Parity
         + core::ops::Rem<Output = T>
         + core::ops::ShrAssign<usize>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_odd(base, exponent, m))
 }
@@ -1171,7 +1188,8 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::ShrAssign<usize>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     let modulus = modulus.get();
     let w = modulus.bits_precision() as usize;
@@ -1219,7 +1237,8 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::ShrAssign<usize>
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd(base, exponent, m))
 }
@@ -1263,7 +1282,8 @@ where
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     let modulus = modulus.get();
     let w = modulus.bits_precision() as usize;
@@ -1322,7 +1342,8 @@ where
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
-        + const_num_traits::BitsPrecision,
+        + const_num_traits::BitsPrecision
+        + const_num_traits::WithPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd_ct(base, exponent, m))
 }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -84,7 +84,8 @@ where
         + PartialEq
         + PartialOrd
         + core::ops::Sub<Output = T>
-        + core::ops::Div<Output = T>,
+        + core::ops::Div<Output = T>
+        + const_num_traits::WithPrecision,
 {
     // We need to solve: modulus * N' ≡ -1 (mod R)
     // This is equivalent to: modulus * N' ≡ R - 1 (mod R)
@@ -194,7 +195,8 @@ where
         + core::ops::Div<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>,
+        + core::ops::Add<Output = T>
+        + const_num_traits::WithPrecision,
 {
     // Step 1: Find R = 2^k where R > modulus
     let mut r = T::one();
@@ -242,7 +244,8 @@ where
         + core::ops::Div<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Rem<Output = T>
-        + core::ops::Add<Output = T>,
+        + core::ops::Add<Output = T>
+        + const_num_traits::WithPrecision,
 {
     basic_compute_montgomery_params_with_method(modulus, NPrimeMethod::default())
 }

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -401,11 +401,6 @@ where
 // Wide-REDC private helpers (R = 2^W, full type width)
 // ---------------------------------------------------------------------------
 
-/// Bit width of type T (e.g. 32 for u32, 128 for a 4×32-limb bigint).
-pub const fn type_bit_width<T>() -> usize {
-    core::mem::size_of::<T>() * 8
-}
-
 /// Modular doubling: (val + val) mod modulus, handling overflow.
 ///
 /// **Variable-time.** Branches on the `overflow || doubled >= modulus`
@@ -1011,7 +1006,8 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + core::ops::Rem<Output = T>,
+        + core::ops::Rem<Output = T>
+        + const_num_traits::BitsPrecision,
 {
     let m = modulus.get();
     basic_montgomery_mod_mul_pr_odd(reduce_mod(a, m), reduce_mod(b, m), modulus)
@@ -1032,7 +1028,8 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::Rem<Output = T>,
+        + core::ops::Rem<Output = T>
+        + const_num_traits::BitsPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_mul_odd(a, b, m))
 }
@@ -1058,10 +1055,11 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
-        + const_num_traits::WrappingSub<Output = T>,
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::BitsPrecision,
 {
     let modulus = modulus.get();
-    let w = type_bit_width::<T>();
+    let w = modulus.bits_precision() as usize;
     let n_prime = compute_n_prime_newton(modulus, w);
     let r_mod_n = compute_r_mod_n(modulus, w);
     let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -1098,7 +1096,8 @@ where
         + const_num_traits::WrappingMul<Output = T>
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
-        + Parity,
+        + Parity
+        + const_num_traits::BitsPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_mul_pr_odd(a, b, m))
 }
@@ -1119,7 +1118,8 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Rem<Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + const_num_traits::BitsPrecision,
 {
     let m = modulus.get();
     basic_montgomery_mod_exp_pr_odd(reduce_mod(base, m), exponent, modulus)
@@ -1145,7 +1145,8 @@ where
         + const_num_traits::WrappingSub<Output = T>
         + Parity
         + core::ops::Rem<Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + const_num_traits::BitsPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_odd(base, exponent, m))
 }
@@ -1165,10 +1166,11 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + const_num_traits::BitsPrecision,
 {
     let modulus = modulus.get();
-    let w = type_bit_width::<T>();
+    let w = modulus.bits_precision() as usize;
     let n_prime = compute_n_prime_newton(modulus, w);
     let r_mod_n = compute_r_mod_n(modulus, w);
     let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -1212,7 +1214,8 @@ where
         + const_num_traits::WrappingAdd<Output = T>
         + const_num_traits::WrappingSub<Output = T>
         + Parity
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + const_num_traits::BitsPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd(base, exponent, m))
 }
@@ -1255,10 +1258,11 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+        + subtle::ConstantTimeLess
+        + const_num_traits::BitsPrecision,
 {
     let modulus = modulus.get();
-    let w = type_bit_width::<T>();
+    let w = modulus.bits_precision() as usize;
     let n_prime = compute_n_prime_newton(modulus, w);
     let r_mod_n = compute_r_mod_n(modulus, w);
     let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -1271,10 +1275,12 @@ where
 
     let mut result = one_mont;
 
-    // Constant-time square-and-multiply, MSB to LSB, fixed iteration count = w.
-    // Always squares; always computes the multiply; conditionally selects.
+    // Constant-time square-and-multiply, MSB to LSB. Iteration count is the
+    // exponent width (public shape); equals w on a fixed carrier, tracks the
+    // exponent independently of the modulus R width on a runtime-len carrier.
+    let exp_bits = exponent.bits_precision() as usize;
     let one = T::one();
-    for i in (0..w).rev() {
+    for i in (0..exp_bits).rev() {
         // Always square
         result = wide_montgomery_mul_ct(result, result, modulus, n_prime);
 
@@ -1311,7 +1317,8 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::BitAnd<Output = T>
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+        + subtle::ConstantTimeLess
+        + const_num_traits::BitsPrecision,
 {
     Odd::new(modulus).map(|m| basic_montgomery_mod_exp_pr_odd_ct(base, exponent, m))
 }
@@ -1319,6 +1326,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use const_num_traits::BitsPrecision;
     use const_num_traits::Ct;
     use fixed_bigint::FixedUInt;
 
@@ -1615,14 +1623,6 @@ mod tests {
     // -- Wide REDC helper tests (moved from wide_mont.rs) --------------------
 
     #[test]
-    fn test_type_bit_width() {
-        assert_eq!(type_bit_width::<u8>(), 8);
-        assert_eq!(type_bit_width::<u16>(), 16);
-        assert_eq!(type_bit_width::<u32>(), 32);
-        assert_eq!(type_bit_width::<u64>(), 64);
-    }
-
-    #[test]
     fn test_mod_double() {
         // Normal case: 5+5=10, 10 < 13 -> 10
         assert_eq!(mod_double(5u8, 13), 10);
@@ -1686,7 +1686,7 @@ mod tests {
     #[test]
     fn test_wide_montgomery_roundtrip() {
         let modulus = 13u8;
-        let w = type_bit_width::<u8>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -1701,7 +1701,7 @@ mod tests {
     #[test]
     fn test_wide_montgomery_roundtrip_u32() {
         let modulus = 0xFFFF_FFF1u32; // large odd u32
-        let w = type_bit_width::<u32>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -1847,7 +1847,7 @@ mod tests {
         let modulus = !U128::from(0u64) - U128::from(58u64); // 2^128 - 59 (odd)
 
         // Round-trip test via wide helpers directly
-        let w = type_bit_width::<U128>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -2084,7 +2084,7 @@ mod tests {
     #[test]
     fn test_wide_mul_acc_dot_product_u32_mlkem_q() {
         let modulus = 3329u32;
-        let w = type_bit_width::<u32>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r2 = compute_r2_mod_n(compute_r_mod_n(modulus, w), modulus, w);
         let to_mont = |x: u32| {
@@ -2121,7 +2121,7 @@ mod tests {
         type U128Ct = FixedUInt<u32, 4, Ct>;
 
         let modulus = !U128::from(0u64) - U128::from(58u64);
-        let w = type_bit_width::<U128>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let modulus_ct: U128Ct = modulus.into();
         let n_prime_ct: U128Ct = n_prime.into();

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -268,6 +268,24 @@ where
     crate::mul::basic_mod_mul(a, r, modulus)
 }
 
+/// Convert to Montgomery form (Basic, pre-reduced): a -> (a * R) mod N
+/// Precondition: `a < modulus` and `r < modulus`. No `Rem` bound.
+pub fn basic_to_montgomery_pr<T>(a: T, modulus: T, r: T) -> T
+where
+    T: core::cmp::PartialOrd
+        + Copy
+        + const_num_traits::Zero
+        + const_num_traits::One
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + crate::parity::Parity
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
+{
+    crate::mul::basic_mod_mul_pr(a, r, modulus)
+}
+
 /// Convert from Montgomery form (Basic): (a * R) -> a mod N
 /// Uses Montgomery reduction algorithm with R > N semantics.
 ///
@@ -360,6 +378,30 @@ where
     // from_montgomery can also overflow at key sizes. For overflow-free
     // multiplication, route through wide-REDC / CIOS instead.
     let product = crate::mul::basic_mod_mul(a_mont, b_mont, modulus);
+    basic_from_montgomery(product, modulus, n_prime, r_bits)
+}
+
+/// Montgomery multiplication (Basic, pre-reduced)
+/// Precondition: `a_mont < modulus` and `b_mont < modulus`. No `Rem` bound.
+pub fn basic_montgomery_mul_pr<T>(a_mont: T, b_mont: T, modulus: T, n_prime: T, r_bits: usize) -> T
+where
+    T: Copy
+        + const_num_traits::Zero
+        + core::ops::Add<Output = T>
+        + const_num_traits::CheckedMul<Output = T>
+        + const_num_traits::One
+        + PartialOrd
+        + core::ops::Sub<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::Shl<usize, Output = T>
+        + core::ops::BitAnd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
+        + const_num_traits::ops::wrapping::WrappingSub<Output = T>
+        + crate::parity::Parity
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
+{
+    let product = crate::mul::basic_mod_mul_pr(a_mont, b_mont, modulus);
     basic_from_montgomery(product, modulus, n_prime, r_bits)
 }
 
@@ -1022,7 +1064,7 @@ where
 ///
 /// Precondition (unchanged from the `Option`-returning sibling): `a < modulus`
 /// and `b < modulus`.
-pub(crate) fn basic_montgomery_mod_mul_pr_odd<T>(a: T, b: T, modulus: Odd<T>) -> T
+pub fn basic_montgomery_mod_mul_pr_odd<T>(a: T, b: T, modulus: Odd<T>) -> T
 where
     T: Copy
         + const_num_traits::Zero
@@ -1063,8 +1105,7 @@ where
 /// [`basic_montgomery_mod_mul_pr_odd`] that performs the parity proof at
 /// runtime — prefer the `_odd` form to keep the panic path out of the
 /// linked binary.
-#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
-pub(crate) fn basic_montgomery_mod_mul_pr<T>(a: T, b: T, modulus: T) -> Option<T>
+pub fn basic_montgomery_mod_mul_pr<T>(a: T, b: T, modulus: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::Zero
@@ -1136,7 +1177,7 @@ where
 
 /// Complete Montgomery modular exponentiation (Basic, pre-reduced,
 /// proven-odd modulus). **Infallible.** Precondition: `base < modulus`.
-pub(crate) fn basic_montgomery_mod_exp_pr_odd<T>(base: T, exponent: T, modulus: Odd<T>) -> T
+pub fn basic_montgomery_mod_exp_pr_odd<T>(base: T, exponent: T, modulus: Odd<T>) -> T
 where
     T: Copy
         + const_num_traits::Zero
@@ -1185,8 +1226,7 @@ where
 /// Precondition: `base < modulus`. No `Rem` bound. Returns None only if
 /// modulus is even or zero. Thin wrapper around
 /// [`basic_montgomery_mod_exp_pr_odd`].
-#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
-pub(crate) fn basic_montgomery_mod_exp_pr<T>(base: T, exponent: T, modulus: T) -> Option<T>
+pub fn basic_montgomery_mod_exp_pr<T>(base: T, exponent: T, modulus: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::Zero
@@ -1228,8 +1268,7 @@ where
 ///
 /// Complete Montgomery modular exponentiation (Basic, CT, pre-reduced,
 /// proven-odd modulus). **Infallible.** Precondition: `base < modulus`.
-#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
-pub(crate) fn basic_montgomery_mod_exp_pr_odd_ct<T>(base: T, exponent: T, modulus: Odd<T>) -> T
+pub fn basic_montgomery_mod_exp_pr_odd_ct<T>(base: T, exponent: T, modulus: Odd<T>) -> T
 where
     T: Copy
         + const_num_traits::Zero
@@ -1288,8 +1327,7 @@ where
 
 /// Returns None if modulus is even or zero. Thin wrapper around
 /// [`basic_montgomery_mod_exp_pr_odd_ct`].
-#[cfg(test)] // retained as differential test oracle; absent from the shipped surface
-pub(crate) fn basic_montgomery_mod_exp_pr_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
+pub fn basic_montgomery_mod_exp_pr_ct<T>(base: T, exponent: T, modulus: T) -> Option<T>
 where
     T: Copy
         + const_num_traits::Zero

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -53,12 +53,7 @@ where
     // O(log R) alternatives for larger moduli.
     let mut n_prime = T::one();
     loop {
-        if modulus
-            .checked_mul(n_prime)
-            .expect(crate::montgomery::OVERFLOW_MSG)
-            % r
-            == target
-        {
+        if modulus.checked_mul(n_prime)? % r == target {
             return Some(n_prime);
         }
         n_prime = n_prime + T::one();
@@ -142,11 +137,7 @@ where
         //     x_new = x - x - 1/modulus  (but we work mod powers of 2)
 
         let target_mod = T::one() << k; // 2^k
-        let check_val = (modulus
-            .checked_mul(n_prime)
-            .expect(crate::montgomery::OVERFLOW_MSG)
-            + T::one())
-            % target_mod;
+        let check_val = (modulus.checked_mul(n_prime)? + T::one()) % target_mod;
 
         if check_val != T::zero() {
             // Need to adjust n_prime
@@ -160,10 +151,7 @@ where
     }
 
     // Final check and adjustment to ensure modulus * N' ≡ -1 (mod R)
-    let final_check = modulus
-        .checked_mul(n_prime)
-        .expect(crate::montgomery::OVERFLOW_MSG)
-        % r;
+    let final_check = modulus.checked_mul(n_prime)? % r;
     let target = r - T::one(); // -1 mod R
 
     if final_check != target {

--- a/modmath/src/montgomery/basic_mont.rs
+++ b/modmath/src/montgomery/basic_mont.rs
@@ -185,7 +185,6 @@ pub fn basic_compute_montgomery_params_with_method<T>(
 where
     T: Copy
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -234,7 +233,6 @@ pub fn basic_compute_montgomery_params<T>(modulus: T) -> Option<(T, T, T, usize)
 where
     T: Copy
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -319,9 +317,13 @@ where
     let m_times_n = m
         .checked_mul(modulus)
         .expect(crate::montgomery::OVERFLOW_MSG);
+    // Same lost-carry guard as the constrained/strict siblings, via this
+    // flavor's `Copy`/`Add` profile (no wrapping/overflowing add without a
+    // bound cascade): on an Nct carrier `+` panics on overflow before the
+    // assert; on a Ct carrier it wraps and `sum < a_mont` catches it. Either
+    // way a dropped carry (`checked_mul` above guards only `m*N`) panics
+    // rather than silently corrupting the reduction.
     let sum = a_mont + m_times_n;
-    // `+` wraps on a Ct carrier (panics on Nct); a dropped carry corrupts the
-    // reduction, so catch the wrap (sum < a_mont) and panic per the same contract.
     assert!(sum >= a_mont, "{}", crate::montgomery::OVERFLOW_MSG);
     let t = sum >> r_bits;
 

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -504,6 +504,21 @@ mod heapless_cios_montmul {
     }
 
     #[test]
+    fn ct_variant_runs() {
+        let m = H::from(13u8);
+        let w = m.word_count() * 32;
+        let n_prime = compute_n_prime_newton(m, w);
+        let r2 = compute_r2_mod_n(compute_r_mod_n(m, w), m, w);
+        let np0 = n_prime.word(0);
+        // 7*R and 5*R in domain, CT multiply, CT back-convert.
+        let a_m = cios_montgomery_mul_ct(&H::from(7u8), &r2, &m, np0);
+        let b_m = cios_montgomery_mul_ct(&H::from(5u8), &r2, &m, np0);
+        let p_m = cios_montgomery_mul_ct(&a_m, &b_m, &m, np0);
+        let one = H::from(1u8);
+        assert_eq!(cios_montgomery_mul_ct(&p_m, &one, &m, np0), H::from(9u8));
+    }
+
+    #[test]
     fn single_word_modulus() {
         let m = H::from(13u8);
         for (a, b, exp) in [(7u8, 5u8, 9u8), (12, 12, 1), (2, 11, 9), (0, 7, 0)] {

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -438,4 +438,41 @@ mod tests {
 
     /// Trait CiosMontMulCt is usable as a bound without constraining T::Word.
     fn _assert_ct_trait_bound<T: CiosMontMulCt>() {}
+
+    /// `CiosRowOps` on fixed-bigint's `HeaplessBigInt` (fixed capacity,
+    /// runtime length) — the runtime-width carrier the `cios_accumulator`
+    /// override exists for. It cannot run the full CIOS driver here (no
+    /// `BorrowingSub` yet, so the final conditional subtraction has no
+    /// impl), so this exercises the trait surface directly: the
+    /// accumulator is sized from the operand's runtime `len`, not a
+    /// compile-time width, and the row kernel computes the right partial
+    /// product.
+    #[test]
+    fn heapless_cios_row_ops() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u32, 4, const_num_traits::Nct>;
+
+        // Two used limbs inside a capacity-4 carrier.
+        let mult = H::from_limbs([7u32, 3, 0, 0], 2);
+
+        // The accumulator sizes to the operand's runtime len (2), which
+        // is the whole point of the `&self` accumulator override — a
+        // no-arg `Default` would give word_count 0 and break the driver.
+        let mut acc = <H as CiosRowOps>::cios_accumulator(&mult);
+        assert_eq!(<H as CiosRowOps>::word_count(&acc), 2);
+
+        // acc += 5 * [7, 3]  ->  [35, 15], no carry out.
+        let carry = <H as CiosRowOps>::mul_acc_row(5, &mult, &mut acc, 0);
+        assert_eq!(carry, 0);
+        assert_eq!(<H as CiosRowOps>::word(&acc, 0), 35);
+        assert_eq!(<H as CiosRowOps>::word(&acc, 1), 15);
+
+        // Carry-out path: MAX * MAX = (2^32-1)^2 -> low word 1, high word
+        // 2^32-2 carried out of the single limb.
+        let one_limb = H::from_limbs([u32::MAX, 0, 0, 0], 1);
+        let mut acc1 = <H as CiosRowOps>::cios_accumulator(&one_limb);
+        let carry1 = <H as CiosRowOps>::mul_acc_row(u32::MAX, &one_limb, &mut acc1, 0);
+        assert_eq!(<H as CiosRowOps>::word(&acc1, 0), 1);
+        assert_eq!(carry1, u32::MAX - 1);
+    }
 }

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -39,7 +39,7 @@ where
     debug_assert!(a < modulus, "CIOS input a must be in [0, modulus)");
     debug_assert!(b < modulus, "CIOS input b must be in [0, modulus)");
 
-    let n = a.word_count();
+    let n = modulus.word_count();
     let zero = <T::Word as Zero>::zero();
     let one = <T::Word as One>::one();
     let mut acc = modulus.cios_accumulator();
@@ -98,7 +98,7 @@ where
         + core::ops::Add<Output = T::Word>
         + subtle::ConditionallySelectable,
 {
-    let n = a.word_count();
+    let n = modulus.word_count();
     let zero = <T::Word as Zero>::zero();
     let one = <T::Word as One>::one();
     let mut acc = modulus.cios_accumulator();
@@ -474,5 +474,50 @@ mod tests {
         let carry1 = <H as CiosRowOps>::mul_acc_row(u32::MAX, &one_limb, &mut acc1, 0);
         assert_eq!(<H as CiosRowOps>::word(&acc1, 0), 1);
         assert_eq!(carry1, u32::MAX - 1);
+    }
+}
+
+// The CIOS driver's operating width is the modulus word count (public), not
+// the multiplier's — so a HeaplessBigInt operand narrower than the modulus
+// still reduces over the full modulus width. Regression against `n =
+// a.word_count()`, which under-iterated the reduction on a runtime-len carrier
+// (invisible on fixed carriers, where every operand is one width).
+#[cfg(test)]
+mod heapless_cios_montmul {
+    use super::*;
+    use crate::montgomery::{compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n};
+    use fixed_bigint::HeaplessBigInt;
+
+    type H = HeaplessBigInt<u32, 4, const_num_traits::Nct>;
+
+    // Full a·b mod N via CIOS: reduce → mul → reduce back out of the domain.
+    fn mont_mul(a: H, b: H, modulus: H) -> H {
+        let w = modulus.word_count() * 32;
+        let n_prime = compute_n_prime_newton(modulus, w);
+        let r2 = compute_r2_mod_n(compute_r_mod_n(modulus, w), modulus, w);
+        let np0 = n_prime.word(0);
+        let a_m = cios_montgomery_mul(&a, &r2, &modulus, np0);
+        let b_m = cios_montgomery_mul(&b, &r2, &modulus, np0);
+        let p_m = cios_montgomery_mul(&a_m, &b_m, &modulus, np0);
+        let one = H::from_limbs([1u32, 0, 0, 0], modulus.word_count() as u16);
+        cios_montgomery_mul(&p_m, &one, &modulus, np0)
+    }
+
+    #[test]
+    fn single_word_modulus() {
+        let m = H::from(13u8);
+        for (a, b, exp) in [(7u8, 5u8, 9u8), (12, 12, 1), (2, 11, 9), (0, 7, 0)] {
+            assert_eq!(mont_mul(H::from(a), H::from(b), m), H::from(exp));
+        }
+    }
+
+    #[test]
+    fn multiword_modulus_narrow_operand() {
+        // 2-word odd modulus 2^32 + 15; operands fit in one word (len 1 < 2).
+        let m = H::from_limbs([15u32, 1, 0, 0], 2);
+        // 70000 * 70000 = 4_900_000_000 ≡ 605_032_689 (mod 2^32 + 15).
+        let want = H::from_limbs([605_032_689u32, 0, 0, 0], 1);
+        let a = H::from_limbs([70000u32, 0, 0, 0], 1);
+        assert_eq!(mont_mul(a, a, m), want);
     }
 }

--- a/modmath/src/montgomery/cios.rs
+++ b/modmath/src/montgomery/cios.rs
@@ -190,7 +190,8 @@ where
 #[cfg(test)]
 mod smoke_tests {
     use super::*;
-    use crate::montgomery::{compute_n_prime_newton, type_bit_width};
+    use crate::montgomery::compute_n_prime_newton;
+    use const_num_traits::BitsPrecision;
 
     /// New CIOS via `CiosRowOps` must match the existing wide-REDC
     /// `wide_montgomery_mul` reference for every `(a, b)` modulo a small
@@ -201,7 +202,7 @@ mod smoke_tests {
             #[test]
             fn $name() {
                 let modulus: $t = 13;
-                let n_prime = compute_n_prime_newton(modulus, type_bit_width::<$t>());
+                let n_prime = compute_n_prime_newton(modulus, modulus.bits_precision() as usize);
                 for a in 0..modulus {
                     for b in 0..modulus {
                         let direct = crate::montgomery::basic_mont::wide_montgomery_mul(
@@ -225,9 +226,9 @@ mod smoke_tests {
 mod tests {
     use super::*;
     use crate::montgomery::basic_mont::{
-        compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n, type_bit_width,
-        wide_montgomery_mul, wide_redc,
+        compute_n_prime_newton, compute_r_mod_n, compute_r2_mod_n, wide_montgomery_mul, wide_redc,
     };
+    use const_num_traits::BitsPrecision;
     use const_num_traits::Ct;
     use fixed_bigint::FixedUInt;
 
@@ -241,7 +242,7 @@ mod tests {
         type U16 = FixedUInt<u8, 2>;
 
         let modulus = U16::from(13u16);
-        let w = type_bit_width::<U16>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -278,7 +279,7 @@ mod tests {
         type U128 = FixedUInt<u32, 4>;
 
         let modulus = !U128::from(0u64) - U128::from(58u64); // 2^128 - 59 (odd)
-        let w = type_bit_width::<U128>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -308,7 +309,7 @@ mod tests {
         type U128 = FixedUInt<u32, 4>;
 
         let modulus = !U128::from(0u64) - U128::from(58u64);
-        let w = type_bit_width::<U128>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -339,7 +340,7 @@ mod tests {
         type U128 = FixedUInt<u32, 4>;
 
         let modulus = !U128::from(0u64) - U128::from(58u64);
-        let w = type_bit_width::<U128>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -370,7 +371,7 @@ mod tests {
         type U16Ct = FixedUInt<u8, 2, Ct>;
 
         let modulus = U16::from(13u16);
-        let w = type_bit_width::<U16>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);
@@ -406,7 +407,7 @@ mod tests {
         type U128Ct = FixedUInt<u32, 4, Ct>;
 
         let modulus = !U128::from(0u64) - U128::from(58u64);
-        let w = type_bit_width::<U128>();
+        let w = modulus.bits_precision() as usize;
         let n_prime = compute_n_prime_newton(modulus, w);
         let r_mod_n = compute_r_mod_n(modulus, w);
         let r2_mod_n = compute_r2_mod_n(r_mod_n, modulus, w);

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -30,10 +30,7 @@ where
     // Simple trial search for N'
     let mut n_prime = T::one();
     loop {
-        let product = modulus
-            .clone()
-            .checked_mul(n_prime.clone())
-            .expect(crate::montgomery::OVERFLOW_MSG);
+        let product = modulus.clone().checked_mul(n_prime.clone())?;
         if product % r == target {
             return Some(n_prime);
         }
@@ -103,10 +100,7 @@ where
     // Lift from 2^1 to 2^r_bits using Newton's method
     for k in 2..=r_bits {
         let target_mod = T::one() << k; // 2^k
-        let temp_prod = modulus
-            .clone()
-            .checked_mul(n_prime.clone())
-            .expect(crate::montgomery::OVERFLOW_MSG);
+        let temp_prod = modulus.clone().checked_mul(n_prime.clone())?;
         let temp_sum = temp_prod.wrapping_add(T::one());
         let check_val = &temp_sum % &target_mod;
 
@@ -119,10 +113,7 @@ where
     }
 
     // Final check
-    let final_prod = modulus
-        .clone()
-        .checked_mul(n_prime.clone())
-        .expect(crate::montgomery::OVERFLOW_MSG);
+    let final_prod = modulus.clone().checked_mul(n_prime.clone())?;
     let final_check = final_prod % r;
     let target = r.clone().wrapping_sub(T::one()); // -1 mod R
 
@@ -368,6 +359,11 @@ where
 {
     let (r, _r_inv, n_prime, r_bits) =
         constrained_compute_montgomery_params_with_method(modulus, method)?;
+    // The R>N reduction's intermediates (`a_low*N'`, `m*N`, and `a_mont+m*N`,
+    // all < R²) must fit the carrier. If R² overflows it, this modulus can't be
+    // reduced on this path — return None rather than let `from_montgomery` panic.
+    // (`Field`/CIOS/wide-REDC handle sized moduli overflow-free.)
+    r.clone().checked_mul(r.clone())?;
     let a_mont = constrained_to_montgomery(a, modulus, &r);
     let b_mont = constrained_to_montgomery(b.clone(), modulus, &r);
     let result_mont = constrained_montgomery_mul(&a_mont, &b_mont, modulus, &n_prime, r_bits);
@@ -450,6 +446,9 @@ where
     // Compute Montgomery parameters using specified method
     let (r, _r_inv, n_prime, r_bits) =
         constrained_compute_montgomery_params_with_method(modulus, method)?;
+    // R² must fit the carrier (see mod_mul): the reduction intermediates are all
+    // < R², so if R² overflows, return None rather than panic in from_montgomery.
+    r.clone().checked_mul(r.clone())?;
 
     // Reduce base and convert to Montgomery form
     base.rem_assign(modulus);

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -289,10 +289,8 @@ where
         .checked_mul(modulus.clone())
         .expect(crate::montgomery::OVERFLOW_MSG);
     let temp_sum = a_mont.clone().wrapping_add(m_times_n);
-    // `wrapping_add` silently drops the carry; a lost carry corrupts the
-    // reduction (the `checked_mul` above guards only `m*N`). Catch the wrap
-    // (sum < a_mont) and panic per the narrow-path contract — use wide-REDC
-    // for overflow-free reduction.
+    // `wrapping_add` drops the carry (the `checked_mul` above guards only `m*N`);
+    // catch the wrap (sum < a_mont) and panic per the narrow-path contract.
     assert!(temp_sum >= a_mont, "{}", crate::montgomery::OVERFLOW_MSG);
     let t = temp_sum >> r_bits;
 

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -288,7 +288,12 @@ where
     let m_times_n = m
         .checked_mul(modulus.clone())
         .expect(crate::montgomery::OVERFLOW_MSG);
-    let temp_sum = a_mont.wrapping_add(m_times_n);
+    let temp_sum = a_mont.clone().wrapping_add(m_times_n);
+    // `wrapping_add` silently drops the carry; a lost carry corrupts the
+    // reduction (the `checked_mul` above guards only `m*N`). Catch the wrap
+    // (sum < a_mont) and panic per the narrow-path contract — use wide-REDC
+    // for overflow-free reduction.
+    assert!(temp_sum >= a_mont, "{}", crate::montgomery::OVERFLOW_MSG);
     let t = temp_sum >> r_bits;
 
     // Step 3: Final reduction

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -230,7 +230,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: crate::parity::Parity,
@@ -313,7 +314,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + const_num_traits::CheckedMul<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T> + core::ops::Mul<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T> + core::ops::BitAnd<Output = T>,
     for<'a> &'a T: crate::parity::Parity,
@@ -349,7 +351,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
@@ -391,7 +394,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + core::ops::Shr<usize, Output = T>
         + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
@@ -430,7 +434,8 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
         + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -495,7 +500,8 @@ where
         + core::ops::Shr<usize, Output = T>
         + core::ops::ShrAssign<usize>
         + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -59,7 +59,8 @@ where
         + PartialEq
         + PartialOrd
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<T, Output = T> + core::ops::Div<&'a T, Output = T>,
 {
@@ -153,7 +154,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shl<usize, Output = T>
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>,
@@ -209,7 +211,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Sub<Output = T>
         + core::ops::Shl<usize, Output = T>
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Add<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>,

--- a/modmath/src/montgomery/constrained_mont.rs
+++ b/modmath/src/montgomery/constrained_mont.rs
@@ -144,7 +144,6 @@ pub fn constrained_compute_montgomery_params_with_method<T>(
 where
     T: Clone
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -201,7 +200,6 @@ pub fn constrained_compute_montgomery_params<T>(modulus: &T) -> Option<(T, T, T,
 where
     T: Clone
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -345,7 +343,6 @@ pub fn constrained_montgomery_mod_mul_with_method<T>(
 where
     T: Clone
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -388,7 +385,6 @@ pub fn constrained_montgomery_mod_mul<T>(a: T, b: &T, modulus: &T) -> Option<T>
 where
     T: Clone
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -427,7 +423,6 @@ pub fn constrained_montgomery_mod_exp_with_method<T>(
 where
     T: Clone
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>
@@ -493,7 +488,6 @@ pub fn constrained_montgomery_mod_exp<T>(base: T, exponent: &T, modulus: &T) -> 
 where
     T: Clone
         + const_num_traits::Zero
-        + core::ops::Mul<Output = T>
         + const_num_traits::One
         + const_num_traits::CheckedAdd<Output = T>
         + const_num_traits::CheckedMul<Output = T>

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -876,8 +876,8 @@ mod backend_montgomery_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        strict: off, // fork: WrappingMul + CarryingMul missing (WideMul + wide-REDC)
-        constrained: off, // fork: WrappingMul + CarryingMul missing (WideMul + wide-REDC)
-        basic: off, // fork: WrappingMul + CarryingMul missing (WideMul + wide-REDC)
+        strict: off, // fork: from_montgomery needs BitAnd (&T & &T mask)
+        constrained: off, // fork: from_montgomery needs BitAnd (&T & &T mask)
+        basic: off, // fork: from_montgomery needs BitAnd (&T & &T mask)
     );
 }

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -831,10 +831,13 @@ mod backend_montgomery_tests {
     //     );
 
     // num-bigint `FixedWidthBigUint`: heap carrier, Nct. `basic: off` — not
-    // `Copy`. `strict: off` — the strict Montgomery free-functions move out of
-    // `&modulus`/reuse operands assuming `Copy`, so they don't compile for a
-    // non-`Copy` carrier (a library limitation, not a fork gap). `constrained`
-    // is clean and runs the full param-compute / mont-mul / mont-exp surface.
+    // `Copy`. `strict: off` — the *test macro's* strict rows assume `Copy`
+    // (they reuse `a`/`base` after moving into the mont fn, and the
+    // param-compute assertions do `% *modulus`), so they don't compile for a
+    // non-`Copy` carrier. The strict library free-functions are `Clone`-bounded
+    // and fine; this is a test-harness limitation, not a library one, and
+    // `constrained` already runs the full param-compute / mont-mul / mont-exp
+    // surface on the heap carrier.
     montgomery_test_module!(
         num_bigint_patched,
         num_bigint_patched::FixedWidthBigUint,

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -876,13 +876,17 @@ mod backend_montgomery_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        // Off pending a fixed-bigint correctness bug, not a modmath gap: the
-        // R>N REDC now compiles and runs on HeaplessBigInt (checked mul, no
-        // shape-panic), but strict_montgomery_mod_mul(7,5,13) returns 1 where
-        // the identical-width FixedUInt<u8,4> returns the correct 9. Round-trip
-        // to/from_montgomery passes, so a len-sensitive carrier op miscomputes
-        // in the multiply chain. (The param-computation test also verifies via
-        // plain `*` on the carrier, which HeaplessBigInt shape-panics on.)
+        // Off, but the R>N path itself is correct on HeaplessBigInt: strict
+        // and constrained montgomery_mod_mul(7,5,13) both give 9 (verified).
+        // Two things still block a green row, both modmath/test-side:
+        //   1. basic_montgomery_mod_mul routes through wide-REDC (R = 2^W),
+        //      and `type_bit_width::<T>() = size_of::<T>() * 8` reads 48 for
+        //      HeaplessBigInt (the `len: u16` field inflates size_of past the
+        //      32-bit value width), so it builds a bogus R and reduces wrong.
+        //      A runtime-length carrier needs a value-bit-width source other
+        //      than size_of before wide-REDC can support it.
+        //   2. test_montgomery_parameter_computation verifies via plain `*`/`%`
+        //      on the carrier, which HeaplessBigInt shape-panics on.
         strict: off,
         constrained: off,
         basic: off,

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Holds the [`NPrimeMethod`] enum (shared by every flavor's
 //! `*_with_method` siblings), the wide-REDC param helpers
-//! ([`compute_n_prime_newton`], [`compute_r_mod_n`], [`compute_r2_mod_n`],
-//! [`type_bit_width`]), and the [`cios`] submodule with the
+//! ([`compute_n_prime_newton`], [`compute_r_mod_n`], [`compute_r2_mod_n`]),
+//! and the [`cios`] submodule with the
 //! interleaved-multiply-and-reduce primitives and their CT siblings.
 //!
 //! The R>N path's per-flavor implementations live in private
@@ -34,14 +34,13 @@ pub(crate) const OVERFLOW_MSG: &str =
 // Flavor-neutral items live at this flat path: the NPrimeMethod enum
 // (shared by every flavor's `*_with_method` siblings), the wide-REDC
 // param helpers (`compute_n_prime_newton` etc., generic over any T:
-// WrappingMul + ...), and `type_bit_width`. Flavor-keyed R>N items are
+// WrappingMul + ...). Flavor-keyed R>N items are
 // surfaced through `modmath::{basic,constrained,strict}::montgomery::*`
 // and reach into `basic_mont` / `constrained_mont` / `strict_mont` via
 // the submodule paths instead of this flat re-export.
 #[rustfmt::skip]
 pub use basic_mont::{
     NPrimeMethod,
-    type_bit_width,
     compute_n_prime_newton,
     compute_r_mod_n,
     compute_r_mod_n_ct,
@@ -876,17 +875,13 @@ mod backend_montgomery_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        // Off, but the R>N path itself is correct on HeaplessBigInt: strict
-        // and constrained montgomery_mod_mul(7,5,13) both give 9 (verified).
-        // Two things still block a green row, both modmath/test-side:
-        //   1. basic_montgomery_mod_mul routes through wide-REDC (R = 2^W),
-        //      and `type_bit_width::<T>() = size_of::<T>() * 8` reads 48 for
-        //      HeaplessBigInt (the `len: u16` field inflates size_of past the
-        //      32-bit value width), so it builds a bogus R and reduces wrong.
-        //      A runtime-length carrier needs a value-bit-width source other
-        //      than size_of before wide-REDC can support it.
-        //   2. test_montgomery_parameter_computation verifies via plain `*`/`%`
-        //      on the carrier, which HeaplessBigInt shape-panics on.
+        // Off. The width bug is fixed (the precompute reads
+        // `modulus.bits_precision()`, not `size_of*8`), and HeaplessBigInt's CT
+        // montgomery is the CIOS path, covered by `cios::heapless_cios_montmul`
+        // (single- and multi-word). This schoolbook row stays off for two
+        // reasons unrelated to that fix: `test_montgomery_parameter_computation`
+        // verifies via plain `*`/`%` on the carrier (shape-panics), and the
+        // Nct wide-REDC multiply is not width-uniform on a runtime-len carrier.
         strict: off,
         constrained: off,
         basic: off,

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -871,4 +871,13 @@ mod backend_montgomery_tests {
         constrained: on,
         basic: on,
     );
+
+    montgomery_test_module!(
+        heapless_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
+        strict: off, // fork: WrappingMul + CarryingMul missing (WideMul + wide-REDC)
+        constrained: off, // fork: WrappingMul + CarryingMul missing (WideMul + wide-REDC)
+        basic: off, // fork: WrappingMul + CarryingMul missing (WideMul + wide-REDC)
+    );
 }

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -876,8 +876,8 @@ mod backend_montgomery_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
-        strict: off, // fork: from_montgomery needs BitAnd (&T & &T mask)
-        constrained: off, // fork: from_montgomery needs BitAnd (&T & &T mask)
-        basic: off, // fork: from_montgomery needs BitAnd (&T & &T mask)
+        strict: off,
+        constrained: off,
+        basic: off,
     );
 }

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -876,6 +876,13 @@ mod backend_montgomery_tests {
         heapless_bigint,
         fixed_bigint::FixedUInt,
         type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
+        // Off pending a fixed-bigint correctness bug, not a modmath gap: the
+        // R>N REDC now compiles and runs on HeaplessBigInt (checked mul, no
+        // shape-panic), but strict_montgomery_mod_mul(7,5,13) returns 1 where
+        // the identical-width FixedUInt<u8,4> returns the correct 9. Round-trip
+        // to/from_montgomery passes, so a len-sensitive carrier op miscomputes
+        // in the multiply chain. (The param-computation test also verifies via
+        // plain `*` on the carrier, which HeaplessBigInt shape-panics on.)
         strict: off,
         constrained: off,
         basic: off,

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -830,14 +830,19 @@ mod backend_montgomery_tests {
     //         basic: off, // Copy is not implemented, heap allocation
     //     );
 
-    //     montgomery_test_module!(
-    //         num_bigint_patched,
-    //         num_bigint_patched::BigUint,
-    //         type U256 = num_bigint_patched::BigUint;
-    //         strict: off, // Complex trait bounds for Montgomery operations not fully compatible
-    //         constrained: on, // Fixed trait bounds - now works with patched libraries
-    //         basic: off, // Copy is not implemented, heap allocation
-    //     );
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct. `basic: off` — not
+    // `Copy`. `strict: off` — the strict Montgomery free-functions move out of
+    // `&modulus`/reuse operands assuming `Copy`, so they don't compile for a
+    // non-`Copy` carrier (a library limitation, not a fork gap). `constrained`
+    // is clean and runs the full param-compute / mont-mul / mont-exp surface.
+    montgomery_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+        strict: off,
+        constrained: on,
+        basic: off,
+    );
 
     //     montgomery_test_module!(
     //         ibig,

--- a/modmath/src/montgomery/mod.rs
+++ b/modmath/src/montgomery/mod.rs
@@ -478,6 +478,21 @@ mod tests {
         );
     }
 
+    // A carrier too narrow for the R>N reduction (R² overflows it) must make the
+    // constrained/strict Option pipelines return None, not panic. N=100003 → R=2^17,
+    // R²=2^34 overflows u32; a small modulus whose R² fits still computes.
+    #[test]
+    fn mod_mul_exp_return_none_when_carrier_too_narrow() {
+        let big = 100_003u32; // odd; R² overflows u32
+        assert_eq!(constrained_montgomery_mod_mul(2u32, &3u32, &big), None);
+        assert_eq!(strict_montgomery_mod_mul(2u32, &3u32, &big), None);
+        assert_eq!(constrained_montgomery_mod_exp(2u32, &5u32, &big), None);
+        assert_eq!(strict_montgomery_mod_exp(2u32, &5u32, &big), None);
+        // R² fits (R=16 for N=13): still computes. 7*5=35 ≡ 9 (mod 13).
+        assert_eq!(constrained_montgomery_mod_mul(7u32, &5u32, &13u32), Some(9));
+        assert_eq!(strict_montgomery_mod_mul(7u32, &5u32, &13u32), Some(9));
+    }
+
     #[test]
     fn test_conversion_functions_with_edge_cases() {
         // Test the conversion functions with additional edge cases

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -347,7 +347,12 @@ where
     let m_times_n = m
         .checked_mul(modulus.clone())
         .expect(crate::montgomery::OVERFLOW_MSG);
-    let (sum, _overflow) = a_mont.overflowing_add(m_times_n);
+    let (sum, overflow) = a_mont.overflowing_add(m_times_n);
+    // A dropped carry here corrupts the reduction (the `checked_mul` above
+    // guards only `m*N`); the flag is already in hand — panic per the
+    // narrow-path contract instead of discarding it. Use wide-REDC for the
+    // overflow-free path.
+    assert!(!overflow, "{}", crate::montgomery::OVERFLOW_MSG);
     let t = sum >> r_bits; // Divide by R = 2^r_bits using bit shift
 
     // Step 3: Final reduction

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -275,7 +275,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::RemAssign<&'a T>
         + core::ops::Sub<&'a T, Output = T>,
@@ -361,7 +362,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: crate::parity::Parity,
@@ -392,7 +394,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -456,7 +459,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Sub<Output = T>
         + crate::NonCt
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
@@ -497,7 +501,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Sub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>
@@ -576,7 +581,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Sub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>
         + core::ops::Rem<&'a T, Output = T>
         + core::ops::Mul<&'a T, Output = T>

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -348,10 +348,8 @@ where
         .checked_mul(modulus.clone())
         .expect(crate::montgomery::OVERFLOW_MSG);
     let (sum, overflow) = a_mont.overflowing_add(m_times_n);
-    // A dropped carry here corrupts the reduction (the `checked_mul` above
-    // guards only `m*N`); the flag is already in hand — panic per the
-    // narrow-path contract instead of discarding it. Use wide-REDC for the
-    // overflow-free path.
+    // A dropped carry corrupts the reduction (the `checked_mul` above guards
+    // only `m*N`); the flag is in hand — panic per the narrow-path contract.
     assert!(!overflow, "{}", crate::montgomery::OVERFLOW_MSG);
     let t = sum >> r_bits; // Divide by R = 2^r_bits using bit shift
 

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -29,10 +29,7 @@ where
     let mut n_prime = T::one();
     loop {
         // Check if (modulus * n_prime) % r == target
-        let product = modulus
-            .clone()
-            .checked_mul(n_prime.clone())
-            .expect(crate::montgomery::OVERFLOW_MSG);
+        let product = modulus.clone().checked_mul(n_prime.clone())?;
         let remainder = &product % r;
         if remainder == target {
             return Some(n_prime);
@@ -121,10 +118,7 @@ where
         // This is the core of Hensel lifting: extending solutions modulo increasing powers
 
         let target_mod = T::one() << k; // 2^k
-        let temp_prod = modulus
-            .clone()
-            .checked_mul(n_prime.clone())
-            .expect(crate::montgomery::OVERFLOW_MSG);
+        let temp_prod = modulus.clone().checked_mul(n_prime.clone())?;
         let (temp_sum, _overflow) = temp_prod.overflowing_add(T::one());
         let check_val = &temp_sum % &target_mod;
 
@@ -145,10 +139,7 @@ where
 
     // Verification: ensure the computed N' satisfies modulus * N' ≡ -1 (mod R)
     // This check validates the mathematical correctness of our Hensel lifting
-    let final_prod = modulus
-        .clone()
-        .checked_mul(n_prime.clone())
-        .expect(crate::montgomery::OVERFLOW_MSG);
+    let final_prod = modulus.clone().checked_mul(n_prime.clone())?;
     let final_check = &final_prod % r;
     let target = r - &T::one(); // -1 mod R
 
@@ -418,6 +409,11 @@ where
     // Step 1: Compute Montgomery parameters using specified method
     let (r, _r_inv, n_prime, r_bits) =
         strict_compute_montgomery_params_with_method(modulus, method)?;
+    // The R>N reduction's intermediates (`a_low*N'`, `m*N`, and `a_mont+m*N`,
+    // all < R²) must fit the carrier. If R² overflows it, this modulus can't be
+    // reduced on this path — return None rather than let `from_montgomery` panic.
+    // (`Field`/CIOS/wide-REDC handle sized moduli overflow-free.)
+    r.clone().checked_mul(r.clone())?;
 
     // Step 2: Convert inputs to Montgomery form
     let a_mont = strict_to_montgomery(a, modulus, &r);
@@ -526,6 +522,9 @@ where
     // Step 1: Compute Montgomery parameters using specified method
     let (r, _r_inv, n_prime, r_bits) =
         strict_compute_montgomery_params_with_method(modulus, method)?;
+    // R² must fit the carrier (see mod_mul): the reduction intermediates are all
+    // < R², so if R² overflows, return None rather than panic in from_montgomery.
+    r.clone().checked_mul(r.clone())?;
 
     // Step 2: Reduce base and convert to Montgomery form
     base.rem_assign(modulus); // Reduce base first to ensure base < modulus

--- a/modmath/src/montgomery/strict_mont.rs
+++ b/modmath/src/montgomery/strict_mont.rs
@@ -63,7 +63,8 @@ where
         + const_num_traits::CheckedMul<Output = T>
         + PartialEq
         + PartialOrd
-        + core::ops::Sub<Output = T>,
+        + core::ops::Sub<Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Sub<&'a T, Output = T> + core::ops::Add<&'a T, Output = T>,
     for<'a> &'a T: core::ops::Sub<&'a T, Output = T>
         + core::ops::Div<&'a T, Output = T>
@@ -177,7 +178,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Sub<Output = T>
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Add<&'a T, Output = T>,
@@ -213,7 +215,8 @@ where
         + core::ops::Shl<usize, Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + core::ops::Sub<Output = T>
-        + for<'a> core::ops::Rem<&'a T, Output = T>,
+        + for<'a> core::ops::Rem<&'a T, Output = T>
+        + const_num_traits::WithPrecision,
     for<'a> T: core::ops::Mul<&'a T, Output = T>
         + core::ops::Sub<&'a T, Output = T>
         + core::ops::Add<&'a T, Output = T>,

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -225,7 +225,7 @@ where
     let mut b = b.clone();
     // Seed the doubling operand and accumulator at the modulus width so
     // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
-    let w = m.clone().bits_precision();
+    let w = m.bits_precision();
     let mut a = a.widen_to_precision(w);
     let mut result = T::zero_with_precision(w);
 
@@ -321,7 +321,7 @@ where
     let mut b = b.clone();
     // Seed the doubling operand and accumulator at the modulus width so
     // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
-    let w = m.clone().bits_precision();
+    let w = m.bits_precision();
     let mut a = a.widen_to_precision(w);
     let mut result = T::zero_with_precision(w);
 

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -114,7 +114,7 @@ where
 /// Note: this only removes the division side-channel from the signature.
 /// The double-and-add loop still leaks `bit_length(b)`; for constant-time
 /// multiplication, use the Montgomery wide-REDC path.
-pub fn basic_mod_mul_pr<T>(mut a: T, mut b: T, m: T) -> T
+pub fn basic_mod_mul_pr<T>(a: T, mut b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
@@ -127,7 +127,12 @@ where
         + crate::NonCt,
 {
     let m1 = m;
-    let mut result = T::zero();
+    // Widen the doubling operand and accumulator to the modulus width so
+    // `a + a` / `result + a` overflow at bit W, not at the narrow operand's
+    // width. `m - m` is a field-width zero synthesized from the modulus.
+    let field_zero = m.wrapping_sub(m);
+    let mut a = field_zero.wrapping_add(a);
+    let mut result = field_zero;
 
     while b > T::zero() {
         if b.is_odd() {
@@ -200,7 +205,7 @@ where
 /// # Modular Multiplication (Constrained, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound. See
 /// [`basic_mod_mul_pr`] for the CT caveat.
-pub fn constrained_mod_mul_pr<T>(mut a: T, b: &T, m: &T) -> T
+pub fn constrained_mod_mul_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: Clone
         + const_num_traits::Zero
@@ -213,7 +218,12 @@ where
     for<'a> &'a T: crate::parity::Parity,
 {
     let mut b = b.clone();
-    let mut result = T::zero();
+    // Widen the doubling operand and accumulator to the modulus width so
+    // `a + a` / `result + a` overflow at bit W, not at the narrow operand's
+    // width. `m - m` is a field-width zero synthesized from the modulus.
+    let field_zero = m.clone().wrapping_sub(m.clone());
+    let mut a = field_zero.clone().wrapping_add(a);
+    let mut result = field_zero;
 
     while b > T::zero() {
         if (&b).is_odd() {
@@ -289,7 +299,7 @@ where
 /// # Modular Multiplication (Strict, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound. See
 /// [`basic_mod_mul_pr`] for the CT caveat.
-pub fn strict_mod_mul_pr<T>(mut a: T, b: &T, m: &T) -> T
+pub fn strict_mod_mul_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: Clone
         + const_num_traits::Zero
@@ -302,7 +312,12 @@ where
     for<'a> &'a T: crate::parity::Parity,
 {
     let mut b = b.clone();
-    let mut result = T::zero();
+    // Widen the doubling operand and accumulator to the modulus width so
+    // `a + a` / `result + a` overflow at bit W, not at the narrow operand's
+    // width. `m - m` is a field-width zero synthesized from the modulus.
+    let field_zero = m.clone().overflowing_sub(m.clone()).0;
+    let mut a = field_zero.clone().overflowing_add(a).0;
+    let mut result = field_zero;
 
     while b > T::zero() {
         if (&b).is_odd() {
@@ -723,6 +738,26 @@ mod bnum_mul_tests {
         constrained: on,
         basic: on,
     );
+
+    // Operands occupy one byte, modulus spans two: the peasant loop doubles
+    // `a` and must overflow at the modulus width, not the operand's. Regression
+    // guard for the len(a) < len(m) case the single-word modules can't reach.
+    #[test]
+    fn heapless_narrow_operand_wide_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 4>;
+        let m: H = 1000u16.into();
+        let want: H = 104u16.into(); // 234 * 56 = 13104 ≡ 104 (mod 1000)
+        assert_eq!(super::basic_mod_mul(H::from(234u8), H::from(56u8), m), want);
+        assert_eq!(
+            super::constrained_mod_mul(H::from(234u8), &H::from(56u8), &m),
+            want
+        );
+        assert_eq!(
+            super::strict_mod_mul(H::from(234u8), &H::from(56u8), &m),
+            want
+        );
+    }
 }
 
 #[cfg(test)]

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -1,4 +1,5 @@
 use crate::parity::Parity;
+use const_num_traits::WithPrecision;
 #[cfg(feature = "nightly")]
 use const_num_traits::{One, OverflowingAdd, OverflowingSub, Zero};
 
@@ -63,7 +64,8 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
         + core::ops::Rem<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     basic_mod_mul_pr(a % m, b % m, m)
 }
@@ -102,7 +104,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     basic_mod_mul_pr(a.rem_nonzero(m), b.rem_nonzero(m), m_raw)
@@ -124,15 +127,14 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m1 = m;
-    // Widen the doubling operand and accumulator to the modulus width so
-    // `a + a` / `result + a` overflow at bit W, not at the narrow operand's
-    // width. `m - m` is a field-width zero synthesized from the modulus.
-    let field_zero = m.wrapping_sub(m);
-    let mut a = field_zero.wrapping_add(a);
-    let mut result = field_zero;
+    // Seed the doubling operand and accumulator at the modulus width so
+    // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
+    let mut a = a.widen_to_precision_of(&m);
+    let mut result = T::zero_with_precision_of(&m);
 
     while b > T::zero() {
         if b.is_odd() {
@@ -172,7 +174,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: crate::parity::Parity,
@@ -194,7 +197,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> &'a T: crate::parity::Parity,
 {
     let m_raw = T::nonzero_get(m);
@@ -214,16 +218,16 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> &'a T: crate::parity::Parity,
 {
     let mut b = b.clone();
-    // Widen the doubling operand and accumulator to the modulus width so
-    // `a + a` / `result + a` overflow at bit W, not at the narrow operand's
-    // width. `m - m` is a field-width zero synthesized from the modulus.
-    let field_zero = m.clone().wrapping_sub(m.clone());
-    let mut a = field_zero.clone().wrapping_add(a);
-    let mut result = field_zero;
+    // Seed the doubling operand and accumulator at the modulus width so
+    // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
+    let w = m.clone().bits_precision();
+    let mut a = a.widen_to_precision(w);
+    let mut result = T::zero_with_precision(w);
 
     while b > T::zero() {
         if (&b).is_odd() {
@@ -266,7 +270,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> &'a T: crate::parity::Parity,
 {
     let m_raw = T::nonzero_get(m);
@@ -286,7 +291,8 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> T: core::ops::RemAssign<&'a T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
     for<'a> &'a T: crate::parity::Parity,
@@ -308,16 +314,16 @@ where
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + core::ops::Shr<usize, Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> &'a T: crate::parity::Parity,
 {
     let mut b = b.clone();
-    // Widen the doubling operand and accumulator to the modulus width so
-    // `a + a` / `result + a` overflow at bit W, not at the narrow operand's
-    // width. `m - m` is a field-width zero synthesized from the modulus.
-    let field_zero = m.clone().overflowing_sub(m.clone()).0;
-    let mut a = field_zero.clone().overflowing_add(a).0;
-    let mut result = field_zero;
+    // Seed the doubling operand and accumulator at the modulus width so
+    // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
+    let w = m.clone().bits_precision();
+    let mut a = a.widen_to_precision(w);
+    let mut result = T::zero_with_precision(w);
 
     while b > T::zero() {
         if (&b).is_odd() {

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -714,6 +714,15 @@ mod bnum_mul_tests {
         constrained: on,
         basic: on,
     );
+
+    mul_test_module!(
+        heapless_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u32, 4>;
+        strict: on,
+        constrained: on,
+        basic: on,
+    );
 }
 
 #[cfg(test)]

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -225,9 +225,8 @@ where
     let mut b = b.clone();
     // Seed the doubling operand and accumulator at the modulus width so
     // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
-    let w = m.bits_precision();
-    let mut a = a.widen_to_precision(w);
-    let mut result = T::zero_with_precision(w);
+    let mut a = a.widen_to_precision_of(m);
+    let mut result = T::zero_with_precision_of(m);
 
     while b > T::zero() {
         if (&b).is_odd() {
@@ -321,9 +320,8 @@ where
     let mut b = b.clone();
     // Seed the doubling operand and accumulator at the modulus width so
     // `a + a` / `result + a` overflow at bit W, not the narrow operand's.
-    let w = m.bits_precision();
-    let mut a = a.widen_to_precision(w);
-    let mut result = T::zero_with_precision(w);
+    let mut a = a.widen_to_precision_of(m);
+    let mut result = T::zero_with_precision_of(m);
 
     while b > T::zero() {
         if (&b).is_odd() {

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -117,7 +117,7 @@ where
 /// Note: this only removes the division side-channel from the signature.
 /// The double-and-add loop still leaks `bit_length(b)`; for constant-time
 /// multiplication, use the Montgomery wide-REDC path.
-pub fn basic_mod_mul_pr<T>(a: T, mut b: T, m: T) -> T
+pub(crate) fn basic_mod_mul_pr<T>(a: T, mut b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
@@ -209,7 +209,7 @@ where
 /// # Modular Multiplication (Constrained, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound. See
 /// [`basic_mod_mul_pr`] for the CT caveat.
-pub fn constrained_mod_mul_pr<T>(a: T, b: &T, m: &T) -> T
+pub(crate) fn constrained_mod_mul_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: Clone
         + const_num_traits::Zero
@@ -304,7 +304,7 @@ where
 /// # Modular Multiplication (Strict, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound. See
 /// [`basic_mod_mul_pr`] for the CT caveat.
-pub fn strict_mod_mul_pr<T>(a: T, b: &T, m: &T) -> T
+pub(crate) fn strict_mod_mul_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: Clone
         + const_num_traits::Zero

--- a/modmath/src/mul.rs
+++ b/modmath/src/mul.rs
@@ -695,14 +695,16 @@ mod bnum_mul_tests {
     //         basic: off, // Copy cannot be implemented, heap allocation
     //     );
 
-    //     mul_test_module!(
-    //         num_bigint_patched,
-    //         num_bigint_patched::BigUint,
-    //         type U256 = num_bigint_patched::BigUint;
-    //         strict: on,
-    //         constrained: on,
-    //         basic: off, // Copy cannot be implemented, heap allocation
-    //     );
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct, constrained/strict
+    // only (not `Copy`, so `basic: off`).
+    mul_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+        strict: on,
+        constrained: on,
+        basic: off,
+    );
 
     //     mul_test_module!(
     //         ibig,

--- a/modmath/src/strict/mod.rs
+++ b/modmath/src/strict/mod.rs
@@ -12,15 +12,11 @@
 //! [`modmath::constrained`](crate::constrained) (`Clone`-bound, mixed
 //! value/reference) for less strict surfaces.
 //!
-//! ## Pre-reduced variants
-//!
-//! [`pre_reduced`] re-exports `add` / `sub` / `mul` / `exp` siblings that
-//! assume inputs are already in `[0, m)` and skip the `% m` reduction
-//! step. Works for backends without `core::ops::Rem` and is the right
-//! entry point inside loops where reduction is handled separately.
-//! Note: `inv` has no pre-reduced sibling — modular inverse via the
-//! extended Euclidean algorithm inside `inv` performs its own
-//! magnitude-dependent loop, with no useful "pre-reduced" shortcut.
+//! A pre-reduced value (already in `[0, m)`) is a residue in a fixed ring;
+//! establish it once through [`SchoolbookField`](crate::SchoolbookField) /
+//! [`FieldOps`](crate::FieldOps) rather than threading raw `T` past the `% m`
+//! boundary — that surface carries the ring width as a type invariant and
+//! cannot seed a narrow value.
 
 #[doc(inline)]
 pub use crate::add::strict_mod_add as add;
@@ -34,19 +30,6 @@ pub use crate::mul::strict_mod_mul as mul;
 pub use crate::sub::strict_mod_sub as sub;
 
 pub mod montgomery;
-
-/// Pre-reduced variants. Caller guarantees inputs are in `[0, m)`;
-/// no `Rem`-family bound.
-pub mod pre_reduced {
-    #[doc(inline)]
-    pub use crate::add::strict_mod_add_pr as add;
-    #[doc(inline)]
-    pub use crate::exp::strict_mod_exp_pr as exp;
-    #[doc(inline)]
-    pub use crate::mul::strict_mod_mul_pr as mul;
-    #[doc(inline)]
-    pub use crate::sub::strict_mod_sub_pr as sub;
-}
 
 /// Non-zero-modulus variants. See [`basic::nonzero`](crate::basic::nonzero).
 pub mod nonzero {

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -125,7 +125,7 @@ where
         + WithPrecision,
 {
     // Widen a to the modulus width so an underflowing a - b wraps at bit W.
-    let a = a.widen_to_precision(m.bits_precision());
+    let a = a.widen_to_precision_of(m);
     let diff = a.clone().wrapping_sub(b.clone());
     if diff > a {
         // If we wrapped around (underflow)
@@ -184,7 +184,7 @@ where
 {
     // Widen a to the modulus width so the wrapped diff on underflow is
     // 2^W - (b-a), which m + diff then reduces correctly.
-    let a = a.widen_to_precision(m.bits_precision());
+    let a = a.widen_to_precision_of(m);
     let (diff, overflow) = a.overflowing_sub(b.clone());
     if overflow {
         m.clone().overflowing_add(diff).0

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -419,6 +419,15 @@ mod bnum_sub_tests {
         constrained: on,
         basic: on,
     );
+
+    sub_test_module!(
+        heapless_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u32, 4>;
+        strict: on,
+        constrained: on,
+        basic: on,
+    );
 }
 
 #[cfg(test)]

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -1,3 +1,4 @@
+use const_num_traits::WithPrecision;
 #[cfg(feature = "nightly")]
 use const_num_traits::{OverflowingAdd, OverflowingSub};
 
@@ -33,7 +34,8 @@ where
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + core::ops::Rem<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     basic_mod_sub_pr(a % m, b % m, m)
 }
@@ -47,7 +49,8 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     basic_mod_sub_pr(a.rem_nonzero(m), b.rem_nonzero(m), m_raw)
@@ -61,11 +64,11 @@ where
         + Copy
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
-    // Widen a to the modulus width so an underflowing a - b wraps at bit W,
-    // matching m's width when the correction adds m. `m - m` is field-width zero.
-    let a = m.wrapping_sub(m).wrapping_add(a);
+    // Widen a to the modulus width so an underflowing a - b wraps at bit W.
+    let a = a.widen_to_precision_of(&m);
     let diff = a.wrapping_sub(b);
     if diff > a {
         // If we wrapped around (underflow)
@@ -84,7 +87,8 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
     let a_mod = &a % m;
@@ -101,7 +105,8 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = b.clone().rem_nonzero(m);
@@ -116,11 +121,11 @@ where
         + Clone
         + const_num_traits::ops::wrapping::WrappingAdd<Output = T>
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
-    // Widen a to the modulus width so an underflowing a - b wraps at bit W,
-    // matching m's width when the correction adds m. `m - m` is field-width zero.
-    let a = m.clone().wrapping_sub(m.clone()).wrapping_add(a);
+    // Widen a to the modulus width so an underflowing a - b wraps at bit W.
+    let a = a.widen_to_precision(m.clone().bits_precision());
     let diff = a.clone().wrapping_sub(b.clone());
     if diff > a {
         // If we wrapped around (underflow)
@@ -139,7 +144,8 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
     for<'b> T: core::ops::RemAssign<&'b T>,
     for<'a> &'a T: core::ops::Rem<&'a T, Output = T>,
 {
@@ -157,7 +163,8 @@ where
         + const_num_traits::DivNonZero<Output = T>
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     let m_raw = T::nonzero_get(m);
     let b_mod = b.clone().rem_nonzero(m);
@@ -172,11 +179,12 @@ where
         + Clone
         + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
-        + crate::NonCt,
+        + crate::NonCt
+        + WithPrecision,
 {
     // Widen a to the modulus width so the wrapped diff on underflow is
-    // 2^W - (b-a), which m + diff then reduces correctly. `m - m` is field-width zero.
-    let a = m.clone().overflowing_sub(m.clone()).0.overflowing_add(a).0;
+    // 2^W - (b-a), which m + diff then reduces correctly.
+    let a = a.widen_to_precision(m.clone().bits_precision());
     let (diff, overflow) = a.overflowing_sub(b.clone());
     if overflow {
         m.clone().overflowing_add(diff).0

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -125,7 +125,7 @@ where
         + WithPrecision,
 {
     // Widen a to the modulus width so an underflowing a - b wraps at bit W.
-    let a = a.widen_to_precision(m.clone().bits_precision());
+    let a = a.widen_to_precision(m.bits_precision());
     let diff = a.clone().wrapping_sub(b.clone());
     if diff > a {
         // If we wrapped around (underflow)
@@ -184,7 +184,7 @@ where
 {
     // Widen a to the modulus width so the wrapped diff on underflow is
     // 2^W - (b-a), which m + diff then reduces correctly.
-    let a = a.widen_to_precision(m.clone().bits_precision());
+    let a = a.widen_to_precision(m.bits_precision());
     let (diff, overflow) = a.overflowing_sub(b.clone());
     if overflow {
         m.clone().overflowing_add(diff).0

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -58,7 +58,7 @@ where
 
 /// # Modular Subtraction (Basic, pre-reduced)
 /// Precondition: `a < m` and `b < m`. No `Rem` bound.
-pub fn basic_mod_sub_pr<T>(a: T, b: T, m: T) -> T
+pub(crate) fn basic_mod_sub_pr<T>(a: T, b: T, m: T) -> T
 where
     T: core::cmp::PartialOrd
         + Copy
@@ -115,7 +115,7 @@ where
 
 /// # Modular Subtraction (Constrained, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
-pub fn constrained_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
+pub(crate) fn constrained_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone
@@ -173,7 +173,7 @@ where
 
 /// # Modular Subtraction (Strict, pre-reduced)
 /// Precondition: `a < *m` and `*b < *m`. No `Rem` family bound.
-pub fn strict_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
+pub(crate) fn strict_mod_sub_pr<T>(a: T, b: &T, m: &T) -> T
 where
     T: core::cmp::PartialOrd
         + Clone

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -398,14 +398,16 @@ mod bnum_sub_tests {
     //         basic: off, // Copy cannot be implemented, heap allocation
     //     );
 
-    //     sub_test_module!(
-    //         num_bigint_patched,
-    //         num_bigint_patched::BigUint,
-    //         type U256 = num_bigint_patched::BigUint;
-    //         strict: on,
-    //         constrained: on,
-    //         basic: off, // Copy cannot be implemented, heap allocation
-    //     );
+    // num-bigint `FixedWidthBigUint`: heap carrier, Nct, constrained/strict
+    // only (not `Copy`, so `basic: off`).
+    sub_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+        strict: on,
+        constrained: on,
+        basic: off,
+    );
 
     //     sub_test_module!(
     //         ibig,

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -63,6 +63,9 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + crate::NonCt,
 {
+    // Widen a to the modulus width so an underflowing a - b wraps at bit W,
+    // matching m's width when the correction adds m. `m - m` is field-width zero.
+    let a = m.wrapping_sub(m).wrapping_add(a);
     let diff = a.wrapping_sub(b);
     if diff > a {
         // If we wrapped around (underflow)
@@ -115,6 +118,9 @@ where
         + const_num_traits::ops::wrapping::WrappingSub<Output = T>
         + crate::NonCt,
 {
+    // Widen a to the modulus width so an underflowing a - b wraps at bit W,
+    // matching m's width when the correction adds m. `m - m` is field-width zero.
+    let a = m.clone().wrapping_sub(m.clone()).wrapping_add(a);
     let diff = a.clone().wrapping_sub(b.clone());
     if diff > a {
         // If we wrapped around (underflow)
@@ -168,6 +174,9 @@ where
         + const_num_traits::ops::overflowing::OverflowingSub<Output = T>
         + crate::NonCt,
 {
+    // Widen a to the modulus width so the wrapped diff on underflow is
+    // 2^W - (b-a), which m + diff then reduces correctly. `m - m` is field-width zero.
+    let a = m.clone().overflowing_sub(m.clone()).0.overflowing_add(a).0;
     let (diff, overflow) = a.overflowing_sub(b.clone());
     if overflow {
         m.clone().overflowing_add(diff).0
@@ -428,6 +437,23 @@ mod bnum_sub_tests {
         constrained: on,
         basic: on,
     );
+
+    // Operands occupy one byte, modulus spans two: an underflowing a - b must
+    // wrap at the modulus width so the +m correction lands. Regression guard
+    // for the len(a) < len(m) case the single-word modules can't reach.
+    #[test]
+    fn heapless_narrow_operand_wide_modulus() {
+        use fixed_bigint::HeaplessBigInt;
+        type H = HeaplessBigInt<u8, 4>;
+        let m: H = 1000u16.into();
+        let want: H = 998u16.into(); // (5 - 7) mod 1000
+        assert_eq!(super::basic_mod_sub(H::from(5u8), H::from(7u8), m), want);
+        assert_eq!(
+            super::constrained_mod_sub(H::from(5u8), &H::from(7u8), &m),
+            want
+        );
+        assert_eq!(super::strict_mod_sub(H::from(5u8), &H::from(7u8), &m), want);
+    }
 }
 
 #[cfg(test)]

--- a/modmath/src/test_carrier.rs
+++ b/modmath/src/test_carrier.rs
@@ -77,6 +77,19 @@ impl const_num_traits::ops::wrapping::WrappingSub for NcU64 {
     }
 }
 
+impl const_num_traits::BitsPrecision for NcU64 {
+    fn bits_precision(self) -> u32 {
+        64
+    }
+}
+
+// Fixed-width newtype: width is the type, so widening is the identity.
+impl const_num_traits::WithPrecision for NcU64 {
+    fn widen_to_precision(self, _bits_precision: u32) -> Self {
+        self
+    }
+}
+
 impl const_num_traits::ops::overflowing::OverflowingAdd for NcU64 {
     type Output = NcU64;
     fn overflowing_add(self, v: Self) -> (Self, bool) {

--- a/modmath/src/test_carrier.rs
+++ b/modmath/src/test_carrier.rs
@@ -78,7 +78,7 @@ impl const_num_traits::ops::wrapping::WrappingSub for NcU64 {
 }
 
 impl const_num_traits::BitsPrecision for NcU64 {
-    fn bits_precision(self) -> u32 {
+    fn bits_precision(&self) -> u32 {
         64
     }
 }


### PR DESCRIPTION
**Draft — for ecosystem validation, not merge.** Pin the tag
`v0.6.0-alpha.cios.1` to validate CIOS/HeaplessBigInt downstream (krabitls).

## What this is

CIOS Montgomery multiply brought onto the width-and-CT model
(`fixed-bigint/notes/WIDTH_AND_CT_MODEL.md`): **the operating width is the
modulus's public `word_count()`, never the multiplier's `len` and never a
`size_of`/capacity proxy.**

The kernel looped `n = a.word_count()`. The reduction must run once per word of
the operating width, which is the *modulus's* length. When the multiplier is
narrower than the modulus — only possible on a runtime-len carrier — that
under-iterated the reduction and returned a wrong result. Invisible on fixed
carriers (every operand is one width); wrong on `HeaplessBigInt`. Fixed to
`n = modulus.word_count()`: a no-op for fixed carriers, correct for
`HeaplessBigInt` on multi-word moduli.

## Why it matters

This is the concrete thing that makes `HeaplessBigInt` a **first-class CT CIOS
carrier** — one carrier type, one runtime-`word_count` kernel, every width in a
family, in one binary, constant-time (public `len`). `const W_WORDS` on
`FixedUInt<CAP>` stays the *static-verifiability overlay* for compile-time-known
widths; it does not replace this path.

## Validated here

- Full CIOS montmul round-trip on `HeaplessBigInt<u32,4>`, single- and
  multi-word moduli, **narrow operands included** (regression test).
- Branchless CT finalize (`cios_montgomery_mul_ct`) runs on `HeaplessBigInt`
  (subtle traits already impl'd on the carrier).
- No regression on fixed carriers (the change is a no-op there).

## Not yet done (follow-ups, not in this tag)

- `ctgrind` + negative fixture + asm-grep over `HeaplessBigInt` `_ct` — the
  ship-blocking CT gate. Correctness is proven; CT *verification* is next.
- Delete `type_bit_width` (wide-REDC's `size_of*8` proxy); build the optional
  `const W_WORDS` overlay for fixed carriers.

## Dep chain (git alpha tags, validation phase — nothing published)

- `fixed-bigint` **v0.6.0-alpha.13** (CiosRowOps, BorrowingSub,
  ConditionallySelectable, width-split CarryingMul on HeaplessBigInt)
- `const-num-traits` **v0.2.1-alpha.1** (via `[patch.crates-io]` git tag)

Stacks on `fix/signed-checked-ops` (the 0.6 correctness base).

## Summary by Sourcery

Make Montgomery CIOS use the modulus word count as its operating width and validate HeaplessBigInt as a runtime-length carrier across the bigint backend test matrix.

New Features:
- Add HeaplessBigInt-based Montgomery CIOS tests, including multiword modulus with narrower operands and constant-time variant coverage.
- Extend add, sub, mul, exp, and montgomery backend test modules to include fixed-bigint HeaplessBigInt as a tested bigint implementation.

Bug Fixes:
- Fix CIOS Montgomery multiplication to iterate reduction over the modulus word count instead of the multiplier length, correcting results for runtime-length carriers like HeaplessBigInt.

Enhancements:
- Add targeted tests for CiosRowOps on HeaplessBigInt to confirm accumulator sizing from runtime length and correct row multiplication behavior.

Build:
- Update modmath dev-dependency on fixed-bigint to a 0.6.0 alpha git tag with heapless-runtime-len support.
- Patch const-num-traits to a 0.2.1 alpha git tag to align with the experimental fixed-bigint backend.