### PR TITLE
docs: remove TODO.md, note the Field surface in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Implements:
 - Unsigned modular Montgomery exponentiation
 - Constant-time variants of the Montgomery and inverse paths, behind a
   `Ct` typestate
+- A width-safe `Field<T>` residue type (Nct + `Ct` typestate) wrapping the above
 
 The code isn't intended to be fast or efficient, just as generic as possible
 to work with multiple implementations.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Implements:
 - Unsigned modular Montgomery exponentiation
 - Constant-time variants of the Montgomery and inverse paths, behind a
   `Ct` typestate
-- A width-safe `Field<T>` residue type (Nct + `Ct` typestate) wrapping the above
+- A width-safe `Field<T>` context and its `Residue` type (Nct + `Ct`
+  typestate) wrapping the above
 
 The code isn't intended to be fast or efficient, just as generic as possible
 to work with multiple implementations.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 ### TODO list
 
-- Remove panic! - just make the functions return Option / Result
 - Add stack size tests on AVR / Cortex-M0

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-### TODO list
-
-- Add stack size tests on AVR / Cortex-M0


### PR DESCRIPTION
Small pre-release doc tidy.

- **Remove `TODO.md`** — a stale in-repo list of one-off items adds no value to a reader. Its one open item (AVR/Cortex-M0 stack-size tests) moved to #43; the panic-removal item shipped in 0.6.0.
- **README.md** — add one bullet for the `Field<T>` residue surface (Nct + `Ct`), the width-carrying entry point from 0.6.0; the list previously named only the free functions.

No code changes.