### PR TITLE
feat: SchoolbookFieldRef — non-Copy (heap/Clone) verify field

### DIFF
--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1403,7 +1403,6 @@ where
     T: Clone
         + const_num_traits::Zero
         + const_num_traits::One
-        + PartialEq
         + PartialOrd
         + crate::NonCt
         + const_num_traits::WithPrecision

--- a/modmath/src/field.rs
+++ b/modmath/src/field.rs
@@ -1370,6 +1370,128 @@ where
     }
 }
 
+/// Schoolbook modular arithmetic as a `FieldOps` strategy for **non-`Copy`**
+/// carriers — the heap/`Clone` verify path. Delegates to the `constrained_*`
+/// reference-based free functions (the same arithmetic the `Copy`
+/// [`SchoolbookField`] runs by value), so a `Clone` heap carrier drives verify
+/// without the `Copy`/Montgomery/CIOS surface. Nct/variable-time only (no
+/// `subtle`), so it cannot resolve for a constant-time path.
+#[derive(Clone, Debug)]
+pub struct SchoolbookFieldRef<T> {
+    modulus: T,
+}
+
+impl<T> SchoolbookFieldRef<T> {
+    /// Build a schoolbook field over `modulus`. Rejects `modulus < 2`.
+    pub fn new(modulus: T) -> Option<Self>
+    where
+        T: const_num_traits::One + PartialOrd,
+    {
+        (modulus > T::one()).then_some(SchoolbookFieldRef { modulus })
+    }
+
+    fn wrap<'f>(&self, val: T) -> SchoolbookResidue<'f, T> {
+        SchoolbookResidue {
+            val,
+            _brand: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> FieldOps for SchoolbookFieldRef<T>
+where
+    T: Clone
+        + const_num_traits::Zero
+        + const_num_traits::One
+        + PartialEq
+        + PartialOrd
+        + crate::NonCt
+        + const_num_traits::WithPrecision
+        + const_num_traits::WrappingAdd<Output = T>
+        + const_num_traits::WrappingSub<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingAdd<Output = T>
+        + const_num_traits::ops::overflowing::OverflowingMul<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Shr<usize, Output = T>
+        + core::ops::ShrAssign<usize>,
+    for<'a> T: core::ops::RemAssign<&'a T>
+        + core::ops::Add<&'a T, Output = T>
+        + core::ops::Sub<&'a T, Output = T>,
+    for<'a> &'a T: core::ops::Rem<&'a T, Output = T>
+        + core::ops::Sub<T, Output = T>
+        + core::ops::Div<&'a T, Output = T>
+        + crate::parity::Parity,
+{
+    type Backend = T;
+    type Residue<'f>
+        = SchoolbookResidue<'f, T>
+    where
+        Self: 'f;
+
+    fn reduce<'f>(&'f self, raw: &T) -> SchoolbookResidue<'f, T> {
+        // Enter the ring: reduce (by-ref), then widen to ring width.
+        self.wrap((raw % &self.modulus).widen_to_precision_of(&self.modulus))
+    }
+    fn mul<'f>(
+        &'f self,
+        a: &SchoolbookResidue<'f, T>,
+        b: &SchoolbookResidue<'f, T>,
+    ) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::mul::constrained_mod_mul(
+            a.val.clone(),
+            &b.val,
+            &self.modulus,
+        ))
+    }
+    fn add<'f>(
+        &'f self,
+        a: &SchoolbookResidue<'f, T>,
+        b: &SchoolbookResidue<'f, T>,
+    ) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::add::constrained_mod_add(
+            a.val.clone(),
+            &b.val,
+            &self.modulus,
+        ))
+    }
+    fn sub<'f>(
+        &'f self,
+        a: &SchoolbookResidue<'f, T>,
+        b: &SchoolbookResidue<'f, T>,
+    ) -> SchoolbookResidue<'f, T> {
+        self.wrap(crate::sub::constrained_mod_sub(
+            a.val.clone(),
+            &b.val,
+            &self.modulus,
+        ))
+    }
+    fn exp<'f>(&'f self, base: &SchoolbookResidue<'f, T>, e: &T) -> SchoolbookResidue<'f, T> {
+        // Re-establish ring width (as `SchoolbookField::exp`): exponent 0 skips
+        // the loop and yields a minimal-width `one`.
+        self.wrap(
+            crate::exp::constrained_mod_exp(base.val.clone(), e, &self.modulus)
+                .widen_to_precision_of(&self.modulus),
+        )
+    }
+    fn inv<'f>(&'f self, a: &SchoolbookResidue<'f, T>) -> Option<SchoolbookResidue<'f, T>> {
+        // Extended Euclid (strategy-neutral `inv`), not Fermat.
+        crate::inv::constrained_mod_inv(a.val.clone(), &self.modulus)
+            .map(|v| self.wrap(v.widen_to_precision_of(&self.modulus)))
+    }
+    fn one(&self) -> SchoolbookResidue<'_, T> {
+        self.wrap(T::one_with_precision_of(&self.modulus))
+    }
+    fn zero(&self) -> SchoolbookResidue<'_, T> {
+        self.wrap(T::zero_with_precision_of(&self.modulus))
+    }
+    fn into_raw(&self, a: &SchoolbookResidue<'_, T>) -> T {
+        a.val.clone()
+    }
+    fn modulus(&self) -> &T {
+        &self.modulus
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1489,8 +1611,104 @@ mod tests {
 
     // num-bigint (`FixedWidthBigUint`) is intentionally absent: the Montgomery
     // `Field`/CIOS path is `Copy`-bound (row ops copy limbs), and it is a
-    // heap-allocated non-`Copy` carrier. It rides the schoolbook + free-function
-    // Montgomery matrices instead.
+    // heap-allocated non-`Copy` carrier. It rides the `SchoolbookFieldRef` matrix
+    // below instead.
+
+    // SchoolbookFieldRef matrix: the non-`Copy` verify field. Same
+    // reduce/add/sub/mul/exp/inv surface as the Montgomery matrix, checked
+    // against a u64 oracle — but over `Clone` (incl. heap) carriers, so the
+    // num-bigint `FixedWidthBigUint` heap carrier the Montgomery matrix excludes
+    // runs here.
+    macro_rules! schoolbook_ref_test_module {
+        ($stem:ident, $type_path:path, $(type $td:ty = $te:ty;)?) => {
+            paste::paste! {
+                mod [<$stem _schoolbook_ref_tests>] {
+                    #[allow(unused_imports)]
+                    use $type_path;
+                    $( type $td = $te; )?
+                    use crate::{FieldOps, SchoolbookFieldRef};
+
+                    const M: u64 = 251; // prime, fits u8
+
+                    fn field() -> SchoolbookFieldRef<U256> {
+                        SchoolbookFieldRef::new(U256::from(251u8)).unwrap()
+                    }
+
+                    #[test]
+                    fn reduce_roundtrip() {
+                        let f = field();
+                        for raw in [0u8, 1, 2, 100, 250] {
+                            assert_eq!(
+                                f.into_raw(&f.reduce(&U256::from(raw))),
+                                U256::from(raw),
+                                "roundtrip {raw}"
+                            );
+                        }
+                    }
+
+                    #[test]
+                    fn add_sub_mul() {
+                        let f = field();
+                        for a in [3u8, 100, 250] {
+                            for b in [7u8, 200, 249] {
+                                let ra = f.reduce(&U256::from(a));
+                                let rb = f.reduce(&U256::from(b));
+                                let add = ((a as u64 + b as u64) % M) as u8;
+                                let sub = ((a as u64 + M - b as u64) % M) as u8;
+                                let mul = ((a as u64 * b as u64) % M) as u8;
+                                assert_eq!(f.into_raw(&f.add(&ra, &rb)), U256::from(add), "add {a}+{b}");
+                                assert_eq!(f.into_raw(&f.sub(&ra, &rb)), U256::from(sub), "sub {a}-{b}");
+                                assert_eq!(f.into_raw(&f.mul(&ra, &rb)), U256::from(mul), "mul {a}*{b}");
+                            }
+                        }
+                    }
+
+                    #[test]
+                    fn exp_matches_oracle() {
+                        let f = field();
+                        for base in [2u8, 7, 200] {
+                            for e in [0u8, 1, 5, 17] {
+                                let want = crate::exp::basic_mod_exp(base as u64, e as u64, M) as u8;
+                                let got = f.into_raw(&f.exp(&f.reduce(&U256::from(base)), &U256::from(e)));
+                                assert_eq!(got, U256::from(want), "exp {base}^{e}");
+                            }
+                        }
+                    }
+
+                    #[test]
+                    fn inv_roundtrip_and_zero() {
+                        let f = field();
+                        // Prime modulus: every nonzero residue is invertible.
+                        for a in [1u8, 2, 100, 250] {
+                            let ra = f.reduce(&U256::from(a));
+                            let inv = f.inv(&ra).expect("nonzero invertible mod prime");
+                            assert_eq!(f.into_raw(&f.mul(&ra, &inv)), U256::from(1u8), "inv {a}");
+                        }
+                        assert!(f.inv(&f.zero()).is_none(), "inv(0) is None");
+                    }
+                }
+            }
+        };
+    }
+
+    schoolbook_ref_test_module!(
+        fixed_bigint,
+        fixed_bigint::FixedUInt,
+        type U256 = fixed_bigint::FixedUInt<u8, 4>;
+    );
+    schoolbook_ref_test_module!(
+        heapless_bigint,
+        fixed_bigint::HeaplessBigInt,
+        type U256 = fixed_bigint::HeaplessBigInt<u8, 4>;
+    );
+    schoolbook_ref_test_module!(bnum_patched, bnum_patched::types::U256,);
+    schoolbook_ref_test_module!(crypto_bigint_patched, crypto_bigint_patched::U256,);
+    // Keystone row: the heap/`Clone` num-bigint carrier driving every FieldOps op.
+    schoolbook_ref_test_module!(
+        num_bigint_patched,
+        num_bigint_patched::FixedWidthBigUint,
+        type U256 = num_bigint_patched::FixedWidthBigUint;
+    );
 
     // Ct `FieldCt` matrix: the constant-time surface (reduce/mul + the
     // Bernstein-Yang `inv_safegcd_ct` RSA-blinding path), across Ct-personality

--- a/modmath/src/lib.rs
+++ b/modmath/src/lib.rs
@@ -79,7 +79,7 @@ pub mod strict;
 
 pub use field::{
     Field, FieldCt, FieldFor, FieldNct, FieldOps, FieldView, MontStorage, Residue, ResidueCt,
-    ResidueNct, SchoolbookField, SchoolbookResidue,
+    ResidueNct, SchoolbookField, SchoolbookFieldRef, SchoolbookResidue,
 };
 pub use nonct::NonCt;
 pub use parity::Parity;

--- a/modmath/src/sub.rs
+++ b/modmath/src/sub.rs
@@ -124,14 +124,19 @@ where
         + crate::NonCt
         + WithPrecision,
 {
-    // Widen a to the modulus width so an underflowing a - b wraps at bit W.
+    // Widen a to the modulus width so the residue lands at ring width.
     let a = a.widen_to_precision_of(m);
-    let diff = a.clone().wrapping_sub(b.clone());
-    if diff > a {
-        // If we wrapped around (underflow)
-        diff.wrapping_add(m.clone())
+    // Compare-then-subtract so the subtrahend never exceeds the minuend and no
+    // `wrapping_*` crosses the carrier width. A width-crossing `wrapping_sub` +
+    // `wrapping_add(m)` pair assumes two's-complement wrap, which a lenient heap
+    // carrier — e.g. num-bigint's `FixedWidthBigUint`, whose `wrapping_add` keeps
+    // the full value rather than masking — does not honor.
+    if a >= *b {
+        a.wrapping_sub(b.clone())
     } else {
-        diff
+        // a < b < m, so a + (m - b) stays in [0, m): no width-crossing wrap.
+        let m_minus_b = m.clone().wrapping_sub(b.clone());
+        a.wrapping_add(m_minus_b)
     }
 }
 
@@ -182,14 +187,18 @@ where
         + crate::NonCt
         + WithPrecision,
 {
-    // Widen a to the modulus width so the wrapped diff on underflow is
-    // 2^W - (b-a), which m + diff then reduces correctly.
+    // Widen a to the modulus width so the residue lands at ring width.
     let a = a.widen_to_precision_of(m);
-    let (diff, overflow) = a.overflowing_sub(b.clone());
-    if overflow {
-        m.clone().overflowing_add(diff).0
+    // Compare-then-subtract (see `constrained_mod_sub_pr`): the subtrahend never
+    // exceeds the minuend, so no `overflowing_*` crosses the carrier width — the
+    // lenient-heap-carrier hazard the old `overflowing_sub` + `overflowing_add(m)`
+    // pair had.
+    if a >= *b {
+        a.overflowing_sub(b.clone()).0
     } else {
-        diff
+        // a < b < m, so a + (m - b) stays in [0, m).
+        let m_minus_b = m.clone().overflowing_sub(b.clone()).0;
+        a.overflowing_add(m_minus_b).0
     }
 }
 
@@ -344,6 +353,20 @@ macro_rules! sub_test_module {
                     let a = U256::from(10u8);
                     crate::maybe_test!($constrained, assert_eq!(super::constrained_mod_sub(a, &b, &m), result));
                     let a = U256::from(10u8);
+                    crate::maybe_test!($basic, assert_eq!(super::basic_mod_sub(a, b, m), result));
+
+                    // Underflow (a < b): 5 - 10 mod 20 = 15. Exercises the
+                    // borrow-correction path on every backend — the case a lenient
+                    // heap carrier's wrapping arithmetic gets wrong if the mod-sub
+                    // relies on two's-complement width wrap.
+                    let a = U256::from(5u8);
+                    let b = U256::from(10u8);
+                    let m = U256::from(20u8);
+                    let result = U256::from(15u8);
+                    crate::maybe_test!($strict, assert_eq!(super::strict_mod_sub(a, &b, &m), result));
+                    let a = U256::from(5u8);
+                    crate::maybe_test!($constrained, assert_eq!(super::constrained_mod_sub(a, &b, &m), result));
+                    let a = U256::from(5u8);
                     crate::maybe_test!($basic, assert_eq!(super::basic_mod_sub(a, b, m), result));
                 }
             }


### PR DESCRIPTION
The verify-carrier audit's keystone: a `FieldOps` strategy that lets a heap/`Clone` carrier (num-bigint `FixedWidthBigUint`) drive verify without the `Copy` Montgomery/CIOS surface.

## What
- **Add `SchoolbookFieldRef<T>` + `impl FieldOps`** — delegates `reduce/add/sub/mul/exp/inv/into_raw` to the `constrained_*` by-ref free functions the heap carrier already runs in CI. Nct-only (no `subtle`), so it can't resolve for a CT path. Reuses the existing `SchoolbookResidue` (already `Clone`).
- **Modify nothing** on the existing surface — the `Copy` `SchoolbookField`, Montgomery `Field`, and `Field<Ct>` are byte-for-byte unchanged.
- **Macro-matrix coverage** (`schoolbook_ref_test_module!`) across all 5 backends **including patched num-bigint** — oracle-checked reduce/add/sub/mul/exp/inv.

## Latent bug this caught + fixed
The new num-bigint row failed on its first modular-subtraction **underflow** (`a < b`). `FixedWidthBigUint::wrapping_add` is lenient (keeps the full value) while `wrapping_sub` masks via `width_modulus`, so the old borrow-correction (`wrapping_sub` then `wrapping_add(m)`, assuming two's-complement width wrap) returned `value + 2^W`.

Fix: `constrained_mod_sub_pr` / `strict_mod_sub_pr` now **compare-then-subtract**, so no `wrapping_*`/`overflowing_*` ever crosses the carrier width — behavior-preserving for fixed-width carriers, **no bound changes**. Added an underflow case to the shared sub matrix test (it previously only tested `a > b`, which is why the bug hid) so every backend exercises the borrow path.

## Validation
524 default + 21 ct-fixtures + 525 zeroize, clippy/fmt clean, panic-free-audit clean.

## Summary by Sourcery

Introduce a schoolbook-based FieldOps strategy for non-Copy heap/Clone carriers and tighten modular subtraction logic to avoid width-wrapping bugs on lenient bigint backends.

New Features:
- Add SchoolbookFieldRef as a FieldOps implementation that enables verification over Clone, non-Copy carriers using existing schoolbook arithmetic.
- Expose SchoolbookFieldRef from the crate root alongside existing field types.

Bug Fixes:
- Correct constrained and strict modular subtraction to use compare-then-subtract so underflow does not rely on two's-complement width wrapping, fixing incorrect results on lenient heap-based carriers.

Tests:
- Add a SchoolbookFieldRef test matrix covering all bigint backends, including num-bigint FixedWidthBigUint, against a u64 oracle for reduce/add/sub/mul/exp/inv.
- Extend the shared modular subtraction test matrix with an underflow case to exercise the borrow-correction path on all backends.