### PR TITLE
test: bump num-bigint dev-carrier to v0.4.4-const-12

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -33,7 +33,7 @@ crypto-bigint_patched = { package = "crypto-bigint", git = "https://github.com/k
 # num-bigint = { package = "num-bigint", version = "0.4"}
 # Heap-backed carrier (`FixedWidthBigUint`): Nct, constrained/strict only (not
 # `Copy`). Uses its own `num-traits` (default `std`) — no default-features override.
-num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-10" }
+num-bigint_patched = { package = "num-bigint", git = "https://github.com/kaidokert/num-bigint.git", tag = "v0.4.4-const-12" }
 # ibig = "0.3"
 # ibig_patched = { package = "ibig", git = "https://github.com/kaidokert/ibig-rs.git" , tag = "v0.3.6_patch" }
 paste = "1"


### PR DESCRIPTION
Dev-dependency (differential test carrier) bump only — **no modmath code changes**.

## Why
const-12 fixes `FixedWidthBigUint::one()`/`zero()`, which declared `n_limbs: 0` (declared width 0) — inconsistent with `from(uN)`'s `.max(1)`. Width 0 made the carrier's declared-width `wrapping_add` mask any sum built from `T::one()`/`T::zero()` down to `0` (the R>N Montgomery trial-search `n_prime` loop hung; small-modulus reductions corrupted). Every constructor now declares `n_limbs >= 1`.

## Bonus: this proves leniency-independence
const-10 kept full values *leniently*; const-12 **masks** `wrapping_add` at the true declared width. The suite passing on const-12 demonstrates modmath's arithmetic no longer depends on the carrier's overflow leniency — the R>N Montgomery path is now exercised against a masking-wrapping heap carrier, not a permissive one.

## Verification
R>N num-bigint Montgomery 11/11 (no hang); full workspace 524 + 21 ct-fixtures + 525 zeroize; clippy/fmt clean.