### PR TITLE
release: modmath 0.6.1

### DIFF
--- a/modmath/Cargo.toml
+++ b/modmath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modmath"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = """
 Modular math implemented with traits.


### PR DESCRIPTION
Cut **modmath 0.6.1** to crates.io — additive minor over 0.6.0.

## What's new
- **`SchoolbookFieldRef<T>`** — a non-`Copy` (heap/`Clone`) `FieldOps` verify field. Lets a heap carrier (e.g. num-bigint) drive the verify surface (`reduce/add/sub/mul/exp/inv`) by delegating to the `constrained_*` free functions, without the `Copy`/Montgomery/CIOS path. Additive — no breaking changes; existing `Copy` `SchoolbookField`, Montgomery `Field`, and `Field<Ct>` are untouched.

## Why now
Validated downstream against the `v0.6.1-alpha.1` git tag. This is the ecosystem verify-carrier keystone; publishing 0.6.1 lets consumers (rsa/ed25519/krabiecdsa) depend on it from crates.io instead of a git pin.

## Release notes
- `Cargo.toml`: `version` 0.6.0 → 0.6.1 (only change; the code landed in #44/#45).
- `cargo publish --dry-run` clean — packages + verifies as `modmath v0.6.1`.
- Deps unchanged (const-num-traits 0.2.1, fixed-bigint 0.6.0, modmath-cios 0.1, all crates.io). The git-forked bnum/crypto-bigint/num-bigint are **dev-dependencies** and don't affect the published crate.

Merge, then publish `cargo publish -p modmath` and tag `v0.6.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the modmath package version to 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->