### PR TITLE
Run F407 timing gate at 30 MHz

### DIFF
--- a/ct-verify/cyccnt-hardware/Cargo.toml
+++ b/ct-verify/cyccnt-hardware/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
+stm32f4xx-hal = { version = "0.22", features = ["stm32f407"] }
 ct-fixtures = { path = "../ct-fixtures", features = ["panic-handler"] }
 krabi-caliper = { version = "0.1", features = ["cortex-m-dwt", "paired", "rtt"] }
 

--- a/ct-verify/cyccnt-hardware/krabi-caliper.toml
+++ b/ct-verify/cyccnt-hardware/krabi-caliper.toml
@@ -5,7 +5,7 @@ board = "jtrace-reference-board"
 mcu = "STM32F407VG"
 transport = "rtt"
 probe = "${KRABI_PROBE}"
-clock-frequency-hz = 16000000
+clock-frequency-hz = 30000000
 executable = "probe-rs"
 args = [
   "run",

--- a/ct-verify/cyccnt-hardware/src/main.rs
+++ b/ct-verify/cyccnt-hardware/src/main.rs
@@ -6,6 +6,7 @@ use cortex_m_rt::entry;
 use krabi_caliper::cortex_m::DwtMeasurementPlatform;
 use krabi_caliper::report::Field;
 use krabi_caliper::suite::{PairedSuite, PairedSuiteConfig, PairedSuiteFields};
+use stm32f4xx_hal::{pac, prelude::*};
 
 const TRIALS: usize = 4;
 const BATCHES: usize = 1;
@@ -319,10 +320,14 @@ fn main() -> ! {
     let mut reporter = krabi_caliper::protocol::rtt::init_ct_compatible();
     ct_fixtures::link_anchor();
     let mut peripherals = cortex_m::Peripherals::take().unwrap();
+    // Stay within the F407's zero-wait-state flash range. This shortens wall
+    // time without introducing ART cache/prefetch jitter into cycle evidence.
+    let dp = pac::Peripherals::take().unwrap();
+    let _clocks = dp.RCC.constrain().cfgr.sysclk(30.MHz()).freeze();
     let mut platform = DwtMeasurementPlatform::enable(
         &mut peripherals.DCB,
         &mut peripherals.DWT,
-        Some(16_000_000),
+        Some(30_000_000),
     )
     .unwrap();
 
@@ -424,7 +429,7 @@ fn main() -> ! {
             target: "thumbv7em-none-eabihf",
             board: Some("stm32f407vg"),
             unit: krabi_caliper::Unit::CoreCycles,
-            frequency_hz: Some(16_000_000),
+            frequency_hz: Some(30_000_000),
             warmup_blocks: 1,
             batches: BATCHES,
             positive_max_spread: MAX_POSITIVE_SPREAD as u64,


### PR DESCRIPTION
## Summary

- configure the STM32F407 hardware timing fixture for a 30 MHz system clock
- qualify DWT evidence and campaign metadata at the actual 30 MHz frequency
- retain the existing CT sample counts, spread limit, and policy

## Why

Thirty megahertz stays within the F407 zero-wait-state flash regime while reducing hardware campaign wall time. Higher ART-assisted clocks introduced fetch jitter in the Ed25519 qualification; this keeps the deterministic measurement regime.

## Validation

- `cargo check --release` in `ct-verify/cyccnt-hardware`
- repository pre-commit suite

## Summary by Sourcery

Configure the STM32F407 cycle-counting hardware fixture to run at a 30 MHz system clock while preserving existing measurement parameters.

Enhancements:
- Update the DWT measurement platform and reporting metadata to use a 30 MHz core frequency instead of 16 MHz.
- Initialize the STM32F407 clock tree via stm32f4xx-hal to set sysclk to 30 MHz within the zero-wait-state flash range.

Build:
- Adjust krabi-caliper hardware configuration to reflect the new 30 MHz clock frequency.
- Add stm32f4xx-hal as a dependency for hardware clock configuration in the cyccnt-hardware crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated hardware timing configuration to operate at 30 MHz.
  * Improved clock setup for more accurate measurement timing on supported STM32F4 hardware.
  * Added support for the STM32F407 hardware platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->